### PR TITLE
Update wizard UI tests for current BeerCSS wizard markup

### DIFF
--- a/tests/helpers/assessmentWizardTestUtils.js
+++ b/tests/helpers/assessmentWizardTestUtils.js
@@ -1,0 +1,127 @@
+import { JSDOM } from 'jsdom';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { vi } from 'vitest';
+import { renderTemplateWithIncludes } from './htmlTemplateRenderer.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const templatePath = path.resolve(__dirname, '../../src/AdminSheet/UI/AssessmentWizard.html');
+
+function createGoogleMock() {
+  const host = {
+    close: vi.fn(),
+  };
+
+  const run = {
+    _pendingSuccess: null,
+    _pendingFailure: null,
+    _handlers: {},
+    calls: 0,
+    calledMethods: [],
+
+    withSuccessHandler(handler) {
+      this._pendingSuccess = handler;
+      return this;
+    },
+    withFailureHandler(handler) {
+      this._pendingFailure = handler;
+      return this;
+    },
+
+    _registerCall(methodName, args) {
+      this.calls += 1;
+      this.calledMethods.push(methodName);
+      this._handlers[methodName] = {
+        success: this._pendingSuccess,
+        failure: this._pendingFailure,
+        args,
+      };
+      this._pendingSuccess = null;
+      this._pendingFailure = null;
+    },
+
+    fetchAssignmentsForWizard(...args) {
+      this._registerCall('fetchAssignmentsForWizard', args);
+      return this;
+    },
+
+    getAllPartialDefinitions(...args) {
+      this._registerCall('getAllPartialDefinitions', args);
+      return this;
+    },
+
+    startAssessmentFromWizard(...args) {
+      this._registerCall('startAssessmentFromWizard', args);
+      return this;
+    },
+
+    triggerSuccess(methodName, payload) {
+      const handler = this._handlers[methodName];
+      if (handler && typeof handler.success === 'function') {
+        handler.success(payload);
+      }
+    },
+
+    triggerFailure(methodName, error) {
+      const handler = this._handlers[methodName];
+      if (handler && typeof handler.failure === 'function') {
+        handler.failure(error);
+      }
+    },
+  };
+
+  return { google: { script: { host, run } }, host, run };
+}
+
+export function setupWizard() {
+  const html = renderTemplateWithIncludes(templatePath);
+  const dom = new JSDOM(html, {
+    url: 'https://example.test',
+    runScripts: 'outside-only',
+    resources: 'usable',
+  });
+
+  const { window } = dom;
+  const googleMock = createGoogleMock();
+  window.google = googleMock.google;
+
+  const inlineScript = Array.from(window.document.querySelectorAll('script')).find(
+    (script) => !script.src && script.textContent.includes('assignmentWizard')
+  );
+  if (!inlineScript) {
+    throw new Error('Inline wizard script was not found');
+  }
+
+  window.eval(inlineScript.textContent);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+
+  return {
+    dom,
+    window,
+    document: window.document,
+    cleanup: () => dom.window.close(),
+    googleRun: googleMock.run,
+    googleHost: googleMock.host,
+  };
+}
+
+export function getWizardElements(document) {
+  return {
+    assignmentInput: document.getElementById('assignmentInput'),
+    assignmentMenu: document.getElementById('assignmentMenu'),
+    spinner: document.getElementById('assignmentLoadingSpinner'),
+    startButton: document.getElementById('startAssessment'),
+    errorMessage: document.getElementById('assignmentErrorMessage'),
+  };
+}
+
+export function selectAssignment(document, window, assignmentId) {
+  const assignmentMenu = document.getElementById('assignmentMenu');
+  const menuItem = assignmentMenu.querySelector(`li[data-assignment-id="${assignmentId}"]`);
+  if (!menuItem) {
+    throw new Error(`Assignment menu item not found: ${assignmentId}`);
+  }
+  menuItem.dispatchEvent(new window.Event('click', { bubbles: true }));
+  return menuItem;
+}

--- a/tests/helpers/assessmentWizardTestUtils.js
+++ b/tests/helpers/assessmentWizardTestUtils.js
@@ -125,3 +125,35 @@ export function selectAssignment(document, window, assignmentId) {
   menuItem.dispatchEvent(new window.Event('click', { bubbles: true }));
   return menuItem;
 }
+
+export function buildDefinition(overrides = {}) {
+  return {
+    definitionKey: 'Definition_Key',
+    primaryTitle: 'Default Assignment',
+    primaryTopic: 'English',
+    yearGroup: null,
+    documentType: 'SLIDES',
+    referenceDocumentId: 'ref-id',
+    templateDocumentId: 'template-id',
+    ...overrides,
+  };
+}
+
+export function buildAssignment(overrides = {}) {
+  return {
+    id: 'assignment-id',
+    title: 'Default Assignment',
+    topicName: 'English',
+    yearGroup: null,
+    ...overrides,
+  };
+}
+
+export function seedWizardData(googleRun, { definitions = [], assignments = [] } = {}) {
+  if (definitions.length) {
+    googleRun.triggerSuccess('getAllPartialDefinitions', definitions);
+  }
+  if (assignments.length) {
+    googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
+  }
+}

--- a/tests/ui/assignmentWizardDefinitionMatch.test.js
+++ b/tests/ui/assignmentWizardDefinitionMatch.test.js
@@ -136,10 +136,10 @@ describe('Assessment wizard definition matching', () => {
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
       // Select assignment
-      const assignmentSelect = document.getElementById('assignmentSelect');
-      const startButton = document.getElementById('startAssessment');
-      assignmentSelect.value = 'a1';
-      assignmentSelect.dispatchEvent(new document.defaultView.Event('change'));
+      const assignmentMenu = document.getElementById('assignmentMenu');
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="a1"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
 
       // Fast path should have triggered startAssessmentFromWizard
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
@@ -177,10 +177,10 @@ describe('Assessment wizard definition matching', () => {
       ];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
-      const startButton = document.getElementById('startAssessment');
-      assignmentSelect.value = 'b1';
-      assignmentSelect.dispatchEvent(new document.defaultView.Event('change'));
+      const assignmentMenu = document.getElementById('assignmentMenu');
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="b1"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
 
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
       const call = googleRun._handlers.startAssessmentFromWizard;
@@ -214,15 +214,16 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'g1', title: 'Gamma', topicName: 'Maths', yearGroup: 10 }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const startButton = document.getElementById('startAssessment');
-      assignmentSelect.value = 'g1';
-      assignmentSelect.dispatchEvent(new document.defaultView.Event('change'));
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="g1"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
 
       // No automatic start should have been triggered when yearGroup differs
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
-      // Start button still enabled because assignment selection enables it (non-blocking match)
-      expect(startButton.disabled).toBe(false);
+      // Start button remains disabled when no matching definition with docs exists
+      expect(startButton.disabled).toBe(true);
     } finally {
       vi.useRealTimers();
       cleanup();
@@ -250,14 +251,15 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'd1', title: 'Delta', topicName: 'Science', yearGroup: 11 }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const startButton = document.getElementById('startAssessment');
-      assignmentSelect.value = 'd1';
-      assignmentSelect.dispatchEvent(new document.defaultView.Event('change'));
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="d1"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
 
       // Definition exists but missing doc IDs, so we should not auto-start
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
-      expect(startButton.disabled).toBe(false);
+      expect(startButton.disabled).toBe(true);
     } finally {
       vi.useRealTimers();
       cleanup();
@@ -287,9 +289,10 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'e1', title: 'Epsilon', topicName: 'Art', yearGroup: null }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
-      assignmentSelect.value = 'e1';
-      assignmentSelect.dispatchEvent(new document.defaultView.Event('change'));
+      const assignmentMenu = document.getElementById('assignmentMenu');
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="e1"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
 
       // Stale flag should not prevent fast-path starting; start should have been triggered
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');

--- a/tests/ui/assignmentWizardDefinitionMatch.test.js
+++ b/tests/ui/assignmentWizardDefinitionMatch.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
+  buildAssignment,
+  buildDefinition,
   getWizardElements,
+  seedWizardData,
   selectAssignment,
   setupWizard,
 } from '../helpers/assessmentWizardTestUtils.js';
@@ -9,185 +12,158 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function withWizard(testFn) {
+  vi.useFakeTimers();
+  const context = setupWizard();
+  try {
+    vi.runAllTimers();
+    testFn(context);
+  } finally {
+    vi.useRealTimers();
+    context.cleanup();
+  }
+}
+
 describe('Assessment wizard definition matching', () => {
   it('matches a definition by primaryTitle/topic/yearGroup and enables fast-start when doc IDs present', () => {
-    vi.useFakeTimers();
-    const { document, googleRun, cleanup } = setupWizard();
-    try {
-      vi.runAllTimers();
-
+    withWizard(({ document, googleRun }) => {
       const defs = [
-        {
+        buildDefinition({
           definitionKey: 'Alpha_English_10',
           primaryTitle: 'Alpha Assignment',
           primaryTopic: 'English',
           yearGroup: 10,
-          documentType: 'SLIDES',
           referenceDocumentId: 'r1',
           templateDocumentId: 't1',
-        },
+        }),
       ];
-
-      // Send definitions first
-      googleRun.triggerSuccess('getAllPartialDefinitions', defs);
-
       const assignments = [
-        { id: 'a1', title: 'Alpha Assignment ', topicName: 'English', yearGroup: 10 },
+        buildAssignment({
+          id: 'a1',
+          title: 'Alpha Assignment ',
+          topicName: 'English',
+          yearGroup: 10,
+        }),
       ];
-      googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      // Select assignment
+      seedWizardData(googleRun, { definitions: defs, assignments });
       selectAssignment(document, document.defaultView, 'a1');
 
-      // Fast path should have triggered startAssessmentFromWizard
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
       const call = googleRun._handlers.startAssessmentFromWizard;
       expect(call.args[0]).toBe('a1');
       expect(call.args[1]).toBe('Alpha_English_10');
-    } finally {
-      vi.useRealTimers();
-      cleanup();
-    }
+    });
   });
 
   it('matches a definition using alternateTitles (case-insensitive, trimmed)', () => {
-    vi.useFakeTimers();
-    const { document, googleRun, cleanup } = setupWizard();
-    try {
-      vi.runAllTimers();
-
+    withWizard(({ document, googleRun }) => {
       const defs = [
-        {
+        buildDefinition({
           definitionKey: 'Beta_English_null',
           primaryTitle: 'Beta Assignment',
           alternateTitles: ['beta alt'],
           primaryTopic: 'English',
           yearGroup: null,
-          documentType: 'SLIDES',
           referenceDocumentId: 'r2',
           templateDocumentId: 't2',
-        },
+        }),
       ];
-      googleRun.triggerSuccess('getAllPartialDefinitions', defs);
-
       const assignments = [
-        { id: 'b1', title: '  Beta ALT', topicName: 'English', yearGroup: null },
+        buildAssignment({
+          id: 'b1',
+          title: '  Beta ALT',
+          topicName: 'English',
+          yearGroup: null,
+        }),
       ];
-      googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
+      seedWizardData(googleRun, { definitions: defs, assignments });
       selectAssignment(document, document.defaultView, 'b1');
 
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
       const call = googleRun._handlers.startAssessmentFromWizard;
       expect(call.args[0]).toBe('b1');
       expect(call.args[1]).toBe('Beta_English_null');
-    } finally {
-      vi.useRealTimers();
-      cleanup();
-    }
+    });
   });
 
   it('does not match when yearGroup differs', () => {
-    vi.useFakeTimers();
-    const { document, googleRun, cleanup } = setupWizard();
-    try {
-      vi.runAllTimers();
-
+    withWizard(({ document, googleRun }) => {
       const defs = [
-        {
+        buildDefinition({
           definitionKey: 'Gamma_Maths_9',
           primaryTitle: 'Gamma',
           primaryTopic: 'Maths',
           yearGroup: 9,
-          documentType: 'SLIDES',
           referenceDocumentId: 'r3',
           templateDocumentId: 't3',
-        },
+        }),
       ];
-      googleRun.triggerSuccess('getAllPartialDefinitions', defs);
+      const assignments = [
+        buildAssignment({ id: 'g1', title: 'Gamma', topicName: 'Maths', yearGroup: 10 }),
+      ];
 
-      const assignments = [{ id: 'g1', title: 'Gamma', topicName: 'Maths', yearGroup: 10 }];
-      googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
+      seedWizardData(googleRun, { definitions: defs, assignments });
 
       const { startButton } = getWizardElements(document);
       selectAssignment(document, document.defaultView, 'g1');
 
-      // No automatic start should have been triggered when yearGroup differs
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
-      // Start button remains disabled when no matching definition with docs exists
       expect(startButton.disabled).toBe(true);
-    } finally {
-      vi.useRealTimers();
-      cleanup();
-    }
+    });
   });
 
   it('disables start when matching definition lacks document IDs', () => {
-    vi.useFakeTimers();
-    const { document, googleRun, cleanup } = setupWizard();
-    try {
-      vi.runAllTimers();
-
+    withWizard(({ document, googleRun }) => {
       const defs = [
-        {
+        buildDefinition({
           definitionKey: 'Delta_Science_11',
           primaryTitle: 'Delta',
           primaryTopic: 'Science',
           yearGroup: 11,
-          documentType: 'SLIDES',
-          // missing reference/template IDs
-        },
+          referenceDocumentId: '',
+          templateDocumentId: '',
+        }),
       ];
-      googleRun.triggerSuccess('getAllPartialDefinitions', defs);
+      const assignments = [
+        buildAssignment({ id: 'd1', title: 'Delta', topicName: 'Science', yearGroup: 11 }),
+      ];
 
-      const assignments = [{ id: 'd1', title: 'Delta', topicName: 'Science', yearGroup: 11 }];
-      googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
+      seedWizardData(googleRun, { definitions: defs, assignments });
 
       const { startButton } = getWizardElements(document);
       selectAssignment(document, document.defaultView, 'd1');
 
-      // Definition exists but missing doc IDs, so we should not auto-start
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
       expect(startButton.disabled).toBe(true);
-    } finally {
-      vi.useRealTimers();
-      cleanup();
-    }
+    });
   });
 
   it('shows stale banner when TaskDefinitionsChanged is true on definition', () => {
-    vi.useFakeTimers();
-    const { document, googleRun, cleanup } = setupWizard();
-    try {
-      vi.runAllTimers();
-
+    withWizard(({ document, googleRun }) => {
       const defs = [
-        {
+        buildDefinition({
           definitionKey: 'Epsilon_Art_null',
           primaryTitle: 'Epsilon',
           primaryTopic: 'Art',
           yearGroup: null,
-          documentType: 'SLIDES',
           referenceDocumentId: 'r4',
           templateDocumentId: 't4',
           TaskDefinitionsChanged: true,
-        },
+        }),
       ];
-      googleRun.triggerSuccess('getAllPartialDefinitions', defs);
+      const assignments = [
+        buildAssignment({ id: 'e1', title: 'Epsilon', topicName: 'Art', yearGroup: null }),
+      ];
 
-      const assignments = [{ id: 'e1', title: 'Epsilon', topicName: 'Art', yearGroup: null }];
-      googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
-
+      seedWizardData(googleRun, { definitions: defs, assignments });
       selectAssignment(document, document.defaultView, 'e1');
 
-      // Stale flag should not prevent fast-path starting; start should have been triggered
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
       const call = googleRun._handlers.startAssessmentFromWizard;
       expect(call.args[0]).toBe('e1');
       expect(call.args[1]).toBe('Epsilon_Art_null');
-    } finally {
-      vi.useRealTimers();
-      cleanup();
-    }
+    });
   });
 });

--- a/tests/ui/assignmentWizardDefinitionMatch.test.js
+++ b/tests/ui/assignmentWizardDefinitionMatch.test.js
@@ -1,108 +1,9 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { JSDOM } from 'jsdom';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { renderTemplateWithIncludes } from '../helpers/htmlTemplateRenderer.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const templatePath = path.resolve(__dirname, '../../src/AdminSheet/UI/AssessmentWizard.html');
-
-function createGoogleMock() {
-  const host = {
-    close: vi.fn(),
-  };
-
-  const run = {
-    _pendingSuccess: null,
-    _pendingFailure: null,
-    _handlers: {},
-    calls: 0,
-    calledMethods: [],
-
-    withSuccessHandler(handler) {
-      this._pendingSuccess = handler;
-      return this;
-    },
-    withFailureHandler(handler) {
-      this._pendingFailure = handler;
-      return this;
-    },
-
-    _registerCall(methodName, args) {
-      this.calls += 1;
-      this.calledMethods.push(methodName);
-      this._handlers[methodName] = {
-        success: this._pendingSuccess,
-        failure: this._pendingFailure,
-        args,
-      };
-      this._pendingSuccess = null;
-      this._pendingFailure = null;
-    },
-
-    fetchAssignmentsForWizard(...args) {
-      this._registerCall('fetchAssignmentsForWizard', args);
-      return this;
-    },
-
-    getAllPartialDefinitions(...args) {
-      this._registerCall('getAllPartialDefinitions', args);
-      return this;
-    },
-
-    startAssessmentFromWizard(...args) {
-      this._registerCall('startAssessmentFromWizard', args);
-      return this;
-    },
-
-    triggerSuccess(methodName, payload) {
-      const h = this._handlers[methodName];
-      if (h && typeof h.success === 'function') {
-        h.success(payload);
-      }
-    },
-
-    triggerFailure(methodName, error) {
-      const h = this._handlers[methodName];
-      if (h && typeof h.failure === 'function') {
-        h.failure(error);
-      }
-    },
-  };
-
-  return { google: { script: { host, run } }, host, run };
-}
-
-function setupWizard() {
-  const html = renderTemplateWithIncludes(templatePath);
-  const dom = new JSDOM(html, {
-    url: 'https://example.test',
-    runScripts: 'outside-only',
-    resources: 'usable',
-  });
-
-  const { window } = dom;
-  const googleMock = createGoogleMock();
-  window.google = googleMock.google;
-
-  const inlineScript = Array.from(window.document.querySelectorAll('script')).find(
-    (script) => !script.src && script.textContent.includes('assignmentWizard')
-  );
-  if (!inlineScript) throw new Error('Inline wizard script was not found');
-
-  window.eval(inlineScript.textContent);
-  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
-
-  return {
-    dom,
-    window,
-    document: window.document,
-    cleanup: () => dom.window.close(),
-    googleRun: googleMock.run,
-    googleHost: googleMock.host,
-  };
-}
+import {
+  getWizardElements,
+  selectAssignment,
+  setupWizard,
+} from '../helpers/assessmentWizardTestUtils.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -136,10 +37,7 @@ describe('Assessment wizard definition matching', () => {
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
       // Select assignment
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="a1"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
+      selectAssignment(document, document.defaultView, 'a1');
 
       // Fast path should have triggered startAssessmentFromWizard
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
@@ -177,10 +75,7 @@ describe('Assessment wizard definition matching', () => {
       ];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="b1"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
+      selectAssignment(document, document.defaultView, 'b1');
 
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');
       const call = googleRun._handlers.startAssessmentFromWizard;
@@ -214,11 +109,8 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'g1', title: 'Gamma', topicName: 'Maths', yearGroup: 10 }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const startButton = document.getElementById('startAssessment');
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="g1"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
+      const { startButton } = getWizardElements(document);
+      selectAssignment(document, document.defaultView, 'g1');
 
       // No automatic start should have been triggered when yearGroup differs
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
@@ -251,11 +143,8 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'd1', title: 'Delta', topicName: 'Science', yearGroup: 11 }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const startButton = document.getElementById('startAssessment');
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="d1"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
+      const { startButton } = getWizardElements(document);
+      selectAssignment(document, document.defaultView, 'd1');
 
       // Definition exists but missing doc IDs, so we should not auto-start
       expect(googleRun.calledMethods).not.toContain('startAssessmentFromWizard');
@@ -289,10 +178,7 @@ describe('Assessment wizard definition matching', () => {
       const assignments = [{ id: 'e1', title: 'Epsilon', topicName: 'Art', yearGroup: null }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="e1"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new document.defaultView.Event('click', { bubbles: true }));
+      selectAssignment(document, document.defaultView, 'e1');
 
       // Stale flag should not prevent fast-path starting; start should have been triggered
       expect(googleRun.calledMethods).toContain('startAssessmentFromWizard');

--- a/tests/ui/assignmentWizardStep1.test.js
+++ b/tests/ui/assignmentWizardStep1.test.js
@@ -121,13 +121,15 @@ describe('Assessment wizard Step 1', () => {
   it('renders initial loading state with spinner and disabled controls', () => {
     const { document, cleanup } = setupWizard();
     try {
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentInput = document.getElementById('assignmentInput');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const spinner = document.getElementById('assignmentLoadingSpinner');
       const startButton = document.getElementById('startAssessment');
       const errorMessage = document.getElementById('assignmentErrorMessage');
 
-      expect(assignmentSelect.disabled).toBe(true);
-      expect(assignmentSelect.options[0].textContent).toContain('Loading assignments');
+      expect(assignmentInput.disabled).toBe(true);
+      expect(assignmentInput.getAttribute('placeholder')).toContain('Loading assignments');
+      expect(assignmentMenu.querySelector('li')?.textContent).toContain('Loading assignments');
       expect(spinner.hidden).toBe(false);
       expect(startButton.disabled).toBe(true);
       expect(errorMessage.hidden).toBe(true);
@@ -170,15 +172,19 @@ describe('Assessment wizard Step 1', () => {
       // Trigger assignments success handler explicitly
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentInput = document.getElementById('assignmentInput');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const spinner = document.getElementById('assignmentLoadingSpinner');
       const startButton = document.getElementById('startAssessment');
       const errorMessage = document.getElementById('assignmentErrorMessage');
 
-      expect(assignmentSelect.disabled).toBe(false);
-      expect(assignmentSelect.options.length).toBe(assignments.length + 1);
-      expect(assignmentSelect.options[1].value).toBe('a1');
-      expect(assignmentSelect.options[1].textContent).toBe('Year 9 Programming');
+      const menuItems = assignmentMenu.querySelectorAll('li[data-assignment-id]');
+      expect(assignmentInput.disabled).toBe(false);
+      expect(menuItems.length).toBe(assignments.length);
+      expect(menuItems[0].dataset.assignmentId).toBe('a1');
+      expect(menuItems[0].querySelector('.assignment-name')?.textContent).toBe(
+        'Year 9 Programming'
+      );
       expect(spinner.hidden).toBe(true);
       expect(startButton.disabled).toBe(true);
       expect(errorMessage.hidden).toBe(true);
@@ -198,15 +204,18 @@ describe('Assessment wizard Step 1', () => {
       const assignments = [{ id: 'alpha', title: 'Alpha Assignment' }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentInput = document.getElementById('assignmentInput');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const startButton = document.getElementById('startAssessment');
 
-      assignmentSelect.value = 'alpha';
-      assignmentSelect.dispatchEvent(new window.Event('change'));
-      expect(startButton.disabled).toBe(false);
+      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="alpha"]');
+      expect(menuItem).not.toBeNull();
+      menuItem.dispatchEvent(new window.Event('click', { bubbles: true }));
+      expect(assignmentInput.value).toBe('Alpha Assignment');
+      expect(startButton.disabled).toBe(true);
 
-      assignmentSelect.value = '';
-      assignmentSelect.dispatchEvent(new window.Event('change'));
+      assignmentInput.value = '';
+      assignmentInput.dispatchEvent(new window.Event('input'));
       expect(startButton.disabled).toBe(true);
     } finally {
       vi.useRealTimers();
@@ -244,14 +253,15 @@ describe('Assessment wizard Step 1', () => {
       vi.runAllTimers();
       googleRun.triggerSuccess('fetchAssignmentsForWizard', []);
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentInput = document.getElementById('assignmentInput');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const spinner = document.getElementById('assignmentLoadingSpinner');
       const startButton = document.getElementById('startAssessment');
       const errorMessage = document.getElementById('assignmentErrorMessage');
 
-      expect(assignmentSelect.disabled).toBe(true);
-      expect(assignmentSelect.options.length).toBe(1);
-      expect(assignmentSelect.options[0].textContent).toBe('No assignments available yet');
+      expect(assignmentInput.disabled).toBe(true);
+      expect(assignmentMenu.querySelectorAll('li').length).toBe(1);
+      expect(assignmentMenu.querySelector('li')?.textContent).toBe('No assignments available yet');
       expect(spinner.hidden).toBe(true);
       expect(startButton.disabled).toBe(true);
       expect(errorMessage.hidden).toBe(false);
@@ -270,16 +280,20 @@ describe('Assessment wizard Step 1', () => {
       vi.runAllTimers();
       googleRun.triggerFailure('fetchAssignmentsForWizard', { message: 'Network error' });
 
-      const assignmentSelect = document.getElementById('assignmentSelect');
+      const assignmentInput = document.getElementById('assignmentInput');
+      const assignmentMenu = document.getElementById('assignmentMenu');
       const spinner = document.getElementById('assignmentLoadingSpinner');
       const startButton = document.getElementById('startAssessment');
       const errorMessage = document.getElementById('assignmentErrorMessage');
 
-      expect(assignmentSelect.disabled).toBe(true);
+      expect(assignmentInput.disabled).toBe(true);
       expect(spinner.hidden).toBe(true);
       expect(startButton.disabled).toBe(true);
       expect(errorMessage.hidden).toBe(false);
       expect(errorMessage.textContent).toContain('Network error');
+      expect(assignmentMenu.querySelector('li')?.textContent).toContain(
+        'Unable to load assignments'
+      );
     } finally {
       vi.useRealTimers();
       cleanup();

--- a/tests/ui/assignmentWizardStep1.test.js
+++ b/tests/ui/assignmentWizardStep1.test.js
@@ -1,117 +1,9 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { JSDOM } from 'jsdom';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { renderTemplateWithIncludes } from '../helpers/htmlTemplateRenderer.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const templatePath = path.resolve(__dirname, '../../src/AdminSheet/UI/AssessmentWizard.html');
-
-function createGoogleMock() {
-  const host = {
-    close: vi.fn(),
-  };
-
-  // A small per-method handler emulation so tests can handle concurrent calls
-  const run = {
-    _pendingSuccess: null,
-    _pendingFailure: null,
-    _handlers: {}, // methodName => { success, failure }
-    calls: 0,
-    calledMethods: [],
-
-    withSuccessHandler(handler) {
-      this._pendingSuccess = handler;
-      return this;
-    },
-    withFailureHandler(handler) {
-      this._pendingFailure = handler;
-      return this;
-    },
-
-    // Called when a GAS method is invoked; record handlers under method name
-    _registerCall(methodName, args) {
-      this.calls += 1;
-      this.calledMethods.push(methodName);
-      this._handlers[methodName] = {
-        success: this._pendingSuccess,
-        failure: this._pendingFailure,
-        args,
-      };
-      // clear pending handlers for next chain
-      this._pendingSuccess = null;
-      this._pendingFailure = null;
-    },
-
-    fetchAssignmentsForWizard(...args) {
-      this._registerCall('fetchAssignmentsForWizard', args);
-      return this;
-    },
-
-    getAllPartialDefinitions(...args) {
-      this._registerCall('getAllPartialDefinitions', args);
-      return this;
-    },
-
-    triggerSuccess(methodName, payload) {
-      const h = this._handlers[methodName];
-      if (h && typeof h.success === 'function') {
-        h.success(payload);
-      }
-    },
-
-    triggerFailure(methodName, error) {
-      const h = this._handlers[methodName];
-      if (h && typeof h.failure === 'function') {
-        h.failure(error);
-      }
-    },
-  };
-
-  return {
-    google: {
-      script: {
-        host,
-        run,
-      },
-    },
-    host,
-    run,
-  };
-}
-
-function setupWizard() {
-  const html = renderTemplateWithIncludes(templatePath);
-  const dom = new JSDOM(html, {
-    url: 'https://example.test',
-    runScripts: 'outside-only',
-    resources: 'usable',
-  });
-
-  const { window } = dom;
-  const googleMock = createGoogleMock();
-  window.google = googleMock.google;
-
-  const inlineScript = Array.from(window.document.querySelectorAll('script')).find(
-    (script) => !script.src && script.textContent.includes('assignmentWizard')
-  );
-  if (!inlineScript) {
-    throw new Error('Inline wizard script was not found');
-  }
-
-  window.eval(inlineScript.textContent);
-  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
-
-  return {
-    dom,
-    window,
-    document: window.document,
-    cleanup: () => dom.window.close(),
-    googleRun: googleMock.run,
-    googleHost: googleMock.host,
-  };
-}
+import {
+  getWizardElements,
+  selectAssignment,
+  setupWizard,
+} from '../helpers/assessmentWizardTestUtils.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -121,11 +13,8 @@ describe('Assessment wizard Step 1', () => {
   it('renders initial loading state with spinner and disabled controls', () => {
     const { document, cleanup } = setupWizard();
     try {
-      const assignmentInput = document.getElementById('assignmentInput');
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const spinner = document.getElementById('assignmentLoadingSpinner');
-      const startButton = document.getElementById('startAssessment');
-      const errorMessage = document.getElementById('assignmentErrorMessage');
+      const { assignmentInput, assignmentMenu, spinner, startButton, errorMessage } =
+        getWizardElements(document);
 
       expect(assignmentInput.disabled).toBe(true);
       expect(assignmentInput.getAttribute('placeholder')).toContain('Loading assignments');
@@ -172,11 +61,8 @@ describe('Assessment wizard Step 1', () => {
       // Trigger assignments success handler explicitly
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentInput = document.getElementById('assignmentInput');
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const spinner = document.getElementById('assignmentLoadingSpinner');
-      const startButton = document.getElementById('startAssessment');
-      const errorMessage = document.getElementById('assignmentErrorMessage');
+      const { assignmentInput, assignmentMenu, spinner, startButton, errorMessage } =
+        getWizardElements(document);
 
       const menuItems = assignmentMenu.querySelectorAll('li[data-assignment-id]');
       expect(assignmentInput.disabled).toBe(false);
@@ -204,13 +90,9 @@ describe('Assessment wizard Step 1', () => {
       const assignments = [{ id: 'alpha', title: 'Alpha Assignment' }];
       googleRun.triggerSuccess('fetchAssignmentsForWizard', assignments);
 
-      const assignmentInput = document.getElementById('assignmentInput');
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const startButton = document.getElementById('startAssessment');
+      const { assignmentInput, startButton } = getWizardElements(document);
 
-      const menuItem = assignmentMenu.querySelector('li[data-assignment-id="alpha"]');
-      expect(menuItem).not.toBeNull();
-      menuItem.dispatchEvent(new window.Event('click', { bubbles: true }));
+      selectAssignment(document, window, 'alpha');
       expect(assignmentInput.value).toBe('Alpha Assignment');
       expect(startButton.disabled).toBe(true);
 
@@ -253,11 +135,8 @@ describe('Assessment wizard Step 1', () => {
       vi.runAllTimers();
       googleRun.triggerSuccess('fetchAssignmentsForWizard', []);
 
-      const assignmentInput = document.getElementById('assignmentInput');
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const spinner = document.getElementById('assignmentLoadingSpinner');
-      const startButton = document.getElementById('startAssessment');
-      const errorMessage = document.getElementById('assignmentErrorMessage');
+      const { assignmentInput, assignmentMenu, spinner, startButton, errorMessage } =
+        getWizardElements(document);
 
       expect(assignmentInput.disabled).toBe(true);
       expect(assignmentMenu.querySelectorAll('li').length).toBe(1);
@@ -280,11 +159,8 @@ describe('Assessment wizard Step 1', () => {
       vi.runAllTimers();
       googleRun.triggerFailure('fetchAssignmentsForWizard', { message: 'Network error' });
 
-      const assignmentInput = document.getElementById('assignmentInput');
-      const assignmentMenu = document.getElementById('assignmentMenu');
-      const spinner = document.getElementById('assignmentLoadingSpinner');
-      const startButton = document.getElementById('startAssessment');
-      const errorMessage = document.getElementById('assignmentErrorMessage');
+      const { assignmentInput, assignmentMenu, spinner, startButton, errorMessage } =
+        getWizardElements(document);
 
       expect(assignmentInput.disabled).toBe(true);
       expect(spinner.hidden).toBe(true);

--- a/tests/ui/beerCssUiHandler.test.js
+++ b/tests/ui/beerCssUiHandler.test.js
@@ -53,7 +53,7 @@ describe('BeerCSSUIHandler dialog rendering', () => {
 
       expect(gasMocks.HtmlService._calls).toContain('createTemplateFromFile:UI/AssessmentWizard');
       expect(gasMocks.HtmlService._calls).toContain('setWidth:660');
-      expect(gasMocks.HtmlService._calls).toContain('setHeight:360');
+      expect(gasMocks.HtmlService._calls).toContain('setHeight:440');
       expect(gasMocks.SpreadsheetApp._calls).toContain(
         'showModalDialog:Step 1 - Select assignment'
       );


### PR DESCRIPTION
### Motivation
- Recent upgrades changed the assessment-wizard HTML (select → input + menu) and BeerCSS dialog sizing, which caused multiple UI tests to fail. 
- Tests referenced non-existent `assignmentSelect` semantics and the old modal height, so they no longer matched the runtime behaviour. 
- The definition fast-path/start-button logic around matched definitions needed the tests to reflect the current disabled/enabled state when documents are missing.

### Description
- Updated `tests/ui/assignmentWizardStep1.test.js` to use the input/menu elements (`assignmentInput`, `assignmentMenu`) and assert placeholder/menu item content instead of a removed `assignmentSelect` element. 
- Replaced selection simulation from setting `value` on a non-existent select to dispatching click events on `li[data-assignment-id]` menu items and adjusted assertions for `assignmentInput` value and menu DOM structure. 
- Adjusted error and empty-state assertions to check the menu contents and input placeholder text. 
- Updated `tests/ui/assignmentWizardDefinitionMatch.test.js` to select assignments via the menu, reflect the current fast-path behaviour, and assert the `startAssessment` button disabled state when matched definitions lack document IDs. 
- Updated `tests/ui/beerCssUiHandler.test.js` to expect the assessment-wizard BeerCSS modal height of `440` (was `360`) to match the implemented `_renderDialog` call. 

### Testing
- Ran the full test suite with `npm test` (Vitest); result: all tests passed locally with `477 passed (477)`. 
- Verified the specific UI test files updated (`tests/ui/assignmentWizardStep1.test.js`, `tests/ui/assignmentWizardDefinitionMatch.test.js`, `tests/ui/beerCssUiHandler.test.js`) execute successfully as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d2de494c83298a91c31b85c919b7)