### PR TITLE
Add 85% coverage gates, coverage tooling and new unit tests for builder and frontend

### DIFF
--- a/.github/agents/Testing.agent.md
+++ b/.github/agents/Testing.agent.md
@@ -45,9 +45,16 @@ Use commands relevant to the component under test:
 - Backend full: `npm test`
 - Frontend targeted/full: `npm run frontend:test -- <pattern>` or `npm run frontend:test`
 - Frontend E2E: `npm run frontend:test:e2e`
+- Frontend coverage gate (minimum 85%): `npm run frontend:test:coverage`
 - Builder tests: `npm run builder:test`
+- Builder coverage gate (minimum 85%): `npm run builder:test:coverage`
 
 If you add or modify tests, run the smallest targeted command first, then the relevant broader suite.
+
+## 2.1 Coverage requirements
+
+- Frontend and builder unit test suites must satisfy minimum coverage thresholds of **85%** for lines, functions, statements, and branches.
+- Use the dedicated coverage commands to verify the enforced thresholds before handoff.
 
 ## 3. Idiomatic Patterns
 

--- a/.github/workflows/builder-ci.yml
+++ b/.github/workflows/builder-ci.yml
@@ -1,26 +1,32 @@
-name: Builder CI
+name: Builder and Coverage CI
 
 on:
   push:
     paths:
       - '.github/workflows/builder-ci.yml'
       - 'scripts/builder/**'
+      - 'src/frontend/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'src/frontend/package.json'
+      - 'src/frontend/package-lock.json'
       - 'tsconfig.base.json'
       - 'config/eslint/ts-base-rules.cjs'
   pull_request:
     paths:
       - '.github/workflows/builder-ci.yml'
       - 'scripts/builder/**'
+      - 'src/frontend/**'
       - 'package.json'
       - 'package-lock.json'
+      - 'src/frontend/package.json'
+      - 'src/frontend/package-lock.json'
       - 'tsconfig.base.json'
       - 'config/eslint/ts-base-rules.cjs'
   workflow_dispatch:
 
 jobs:
-  builder:
+  quality-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -38,6 +44,12 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm --prefix src/frontend ci
+
+      - name: Run frontend coverage gate
+        run: npm run frontend:test:coverage
+
+      - name: Run builder coverage gate
+        run: npm run builder:test:coverage
 
       - name: Run builder lint, tests and pipeline
         run: npm run builder:ci

--- a/.github/workflows/builder-ci.yml
+++ b/.github/workflows/builder-ci.yml
@@ -1,32 +1,43 @@
-name: Builder and Coverage CI
+name: Component Quality CI
 
 on:
   push:
     paths:
       - '.github/workflows/builder-ci.yml'
       - 'scripts/builder/**'
+      - 'src/backend/**'
       - 'src/frontend/**'
+      - 'tests/**'
       - 'package.json'
       - 'package-lock.json'
       - 'src/frontend/package.json'
       - 'src/frontend/package-lock.json'
+      - 'vitest.config.js'
+      - 'scripts/builder/vitest.config.ts'
+      - 'src/frontend/vite.config.ts'
       - 'tsconfig.base.json'
       - 'config/eslint/ts-base-rules.cjs'
   pull_request:
     paths:
       - '.github/workflows/builder-ci.yml'
       - 'scripts/builder/**'
+      - 'src/backend/**'
       - 'src/frontend/**'
+      - 'tests/**'
       - 'package.json'
       - 'package-lock.json'
       - 'src/frontend/package.json'
       - 'src/frontend/package-lock.json'
+      - 'vitest.config.js'
+      - 'scripts/builder/vitest.config.ts'
+      - 'src/frontend/vite.config.ts'
       - 'tsconfig.base.json'
       - 'config/eslint/ts-base-rules.cjs'
   workflow_dispatch:
 
 jobs:
-  quality-checks:
+  frontend-checks:
+    name: Frontend checks
     runs-on: ubuntu-latest
 
     steps:
@@ -45,8 +56,51 @@ jobs:
       - name: Install frontend dependencies
         run: npm --prefix src/frontend ci
 
+      - name: Run frontend tests
+        run: npm run frontend:test
+
       - name: Run frontend coverage gate
         run: npm run frontend:test:coverage
+
+  backend-checks:
+    name: Backend checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run backend tests
+        run: npm test
+
+  builder-checks:
+    name: Builder checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install frontend dependencies
+        run: npm --prefix src/frontend ci
 
       - name: Run builder coverage gate
         run: npm run builder:test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Component Quality CI
 on:
   push:
     paths:
-      - '.github/workflows/builder-ci.yml'
+      - '.github/workflows/ci.yml'
       - 'scripts/builder/**'
       - 'src/backend/**'
       - 'src/frontend/**'
@@ -19,7 +19,7 @@ on:
       - 'config/eslint/ts-base-rules.cjs'
   pull_request:
     paths:
-      - '.github/workflows/builder-ci.yml'
+      - '.github/workflows/ci.yml'
       - 'scripts/builder/**'
       - 'src/backend/**'
       - 'src/frontend/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            src/frontend/package-lock.json
 
       - name: Install root dependencies
         run: npm ci
@@ -75,6 +78,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            src/frontend/package-lock.json
 
       - name: Install root dependencies
         run: npm ci
@@ -95,16 +101,15 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            src/frontend/package-lock.json
 
       - name: Install root dependencies
         run: npm ci
 
       - name: Install frontend dependencies
         run: npm --prefix src/frontend ci
-
-      - name: Run builder coverage gate
-        run: npm run builder:test:coverage
-
       - name: Run builder lint, tests and pipeline
         run: npm run builder:ci
 

--- a/docs/developer/builder/builder-script.md
+++ b/docs/developer/builder/builder-script.md
@@ -50,7 +50,7 @@ npm run builder:test
 # Builder coverage check (minimum 85%)
 npm run builder:test:coverage
 
-# Full builder CI sequence: lint -> test -> build -> run
+# Full builder CI sequence: lint -> coverage -> build -> run
 npm run builder:ci
 ```
 

--- a/docs/developer/builder/builder-script.md
+++ b/docs/developer/builder/builder-script.md
@@ -47,9 +47,16 @@ npm run builder:lint
 # Builder unit tests
 npm run builder:test
 
+# Builder coverage check (minimum 85%)
+npm run builder:test:coverage
+
 # Full builder CI sequence: lint -> test -> build -> run
 npm run builder:ci
 ```
+
+### Coverage requirement
+
+Builder unit tests must meet a minimum coverage threshold of **85%** for lines, functions, statements, and branches. The threshold is enforced in `scripts/builder/vitest.config.ts` and checked via `npm run builder:test:coverage`.
 
 ### Typical local workflow
 

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -71,6 +71,15 @@ npm run frontend:test:e2e -- --headed --debug src/frontend/tests/auth-status.spe
 
 Frontend unit/component tests must meet a minimum coverage threshold of **85%** for lines, functions, statements, and branches. The threshold is enforced in `src/frontend/vite.config.ts` and checked via `npm run frontend:test:coverage`.
 
+## Shared test helpers
+
+Use shared helpers to keep fixtures and mocks consistent and avoid duplicate test setup code.
+
+- Frontend runtime setup helper: `src/frontend/src/test/setup.ts` (Testing Library + jest-dom integration).
+- Builder JsonDb source fixture helpers: `scripts/builder/src/test/jsondb-source-test-helpers.ts` (shared by JsonDb source builder specs to build release archives, create path fixtures, and write release files/manifests).
+
+When adding test scenarios, prefer extending an existing helper before copying setup logic into each spec.
+
 ## Current Structure
 
 - Unit/component tests: `src/frontend/src/**/*.test.tsx`

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -22,6 +22,9 @@ npm run frontend:test:watch
 
 # Frontend Playwright E2E suite
 npm run frontend:test:e2e
+
+# Frontend unit/component coverage check (minimum 85%)
+npm run frontend:test:coverage
 ```
 
 Target a specific unit test pattern:
@@ -29,6 +32,44 @@ Target a specific unit test pattern:
 ```bash
 npm run frontend:test -- src/App.test.tsx
 ```
+
+## Previewing mocked frontend pages locally
+
+If you want to inspect page rendering and usability with the same mocked runtime states used in E2E tests, use Playwright in interactive mode.
+
+### Quick preview options
+
+From repository root:
+
+```bash
+# Open Playwright UI (good for clicking through scenarios)
+npm run frontend:test:e2e -- --ui
+
+# Run in a visible browser with Playwright Inspector
+npm run frontend:test:e2e -- --headed --debug
+```
+
+Run a single mocked scenario by test name:
+
+```bash
+npm run frontend:test:e2e -- --headed --debug src/frontend/tests/auth-status.spec.ts -g "shows Authorised when backend returns true"
+```
+
+### How this maps to existing mocks
+
+- `src/frontend/tests/auth-status.spec.ts` already installs `google.script.run` mocks before the app loads.
+- Each test scenario then navigates to `/` and asserts user-visible state.
+- In `--ui` or `--headed --debug` mode, those same scenarios double as a manual preview harness.
+
+### Recommended VS Code workflow
+
+- Install and use the Playwright Test extension.
+- Run or debug individual tests from the Testing panel.
+- Keep a dedicated preview-style spec for key UI states (for example authorised, unauthorised, backend error, delayed loading) so you can quickly verify usability during development.
+
+## Coverage requirement
+
+Frontend unit/component tests must meet a minimum coverage threshold of **85%** for lines, functions, statements, and branches. The threshold is enforced in `src/frontend/vite.config.ts` and checked via `npm run frontend:test:coverage`.
 
 ## Current Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^24.3.1",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.43.0",
+        "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.39.2",
         "eslint-plugin-googleappsscript": "^1.0.5",
         "eslint-plugin-jsdoc": "^62.5.0",
@@ -87,12 +88,62 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -183,7 +234,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -224,7 +274,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1586,12 +1635,33 @@
         }
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@material/material-color-utilities": {
       "version": "0.3.0",
@@ -2075,7 +2145,6 @@
       "version": "24.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2136,7 +2205,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2374,6 +2442,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -2503,7 +2602,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2644,6 +2742,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2795,7 +2905,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3478,7 +3587,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3809,7 +3917,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4269,7 +4376,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4318,6 +4424,13 @@
           "url": "https://patreon.com/mdevils"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-errors": {
@@ -4889,6 +5002,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -4897,6 +5049,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -4927,7 +5086,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -5154,6 +5312,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/material-dynamic-colors": {
@@ -6674,7 +6860,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6777,7 +6962,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7100,7 +7284,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
     "frontend:test": "npm --prefix src/frontend run test",
     "frontend:test:watch": "npm --prefix src/frontend run test:watch",
     "frontend:test:e2e": "npm --prefix src/frontend run test:e2e",
+    "frontend:test:coverage": "npm --prefix src/frontend run test:coverage",
     "builder:build": "tsc -p scripts/builder/tsconfig.json",
     "builder:run": "node scripts/builder/dist/build-gas-bundle.js",
     "builder:test": "vitest run --config scripts/builder/vitest.config.ts",
+    "builder:test:coverage": "vitest run --config scripts/builder/vitest.config.ts --coverage",
     "builder:lint": "eslint --config scripts/builder/eslint.config.js scripts/builder/src/**/*.ts",
     "builder:ci": "npm run builder:lint && npm run builder:test && npm run builder:build && npm run builder:run"
   },
@@ -43,7 +45,8 @@
     "jsdom": "^27.4.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.2",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "@vitest/coverage-v8": "^4.0.18"
   },
   "dependencies": {
     "@google/clasp": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "builder:test": "vitest run --config scripts/builder/vitest.config.ts",
     "builder:test:coverage": "vitest run --config scripts/builder/vitest.config.ts --coverage",
     "builder:lint": "eslint --config scripts/builder/eslint.config.js scripts/builder/src/**/*.ts",
-    "builder:ci": "npm run builder:lint && npm run builder:test && npm run builder:build && npm run builder:run"
+    "builder:ci": "npm run builder:lint && npm run builder:test:coverage && npm run builder:build && npm run builder:run"
   },
   "keywords": [],
   "author": "",
@@ -37,6 +37,7 @@
     "@types/node": "^24.3.1",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
     "eslint-plugin-googleappsscript": "^1.0.5",
     "eslint-plugin-jsdoc": "^62.5.0",
@@ -45,8 +46,7 @@
     "jsdom": "^27.4.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.2",
-    "vitest": "^4.0.18",
-    "@vitest/coverage-v8": "^4.0.18"
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "@google/clasp": "^3.1.3",

--- a/scripts/builder/src/lib/fs.spec.ts
+++ b/scripts/builder/src/lib/fs.spec.ts
@@ -1,0 +1,99 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { BuildStageError, asError, isBuildStageError } from './errors.js';
+import { ensureDirs, pathExists, removeDir, requireDirectory, requireFile } from './fs.js';
+
+let tempRoot = '';
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'builder-fs-spec-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('pathExists', () => {
+  it('returns true when the path exists', async () => {
+    const existing = path.join(tempRoot, 'exists.txt');
+    await fs.writeFile(existing, 'x');
+
+    await expect(pathExists(existing)).resolves.toBe(true);
+  });
+
+  it('returns false when the path is missing', async () => {
+    await expect(pathExists(path.join(tempRoot, 'missing.txt'))).resolves.toBe(false);
+  });
+});
+
+describe('requireDirectory and requireFile', () => {
+  it('accepts valid directory and file paths', async () => {
+    const folder = path.join(tempRoot, 'folder');
+    const file = path.join(tempRoot, 'file.txt');
+    await fs.mkdir(folder, { recursive: true });
+    await fs.writeFile(file, 'ok');
+
+    await expect(requireDirectory(folder, 'Folder', 'preflight-clean')).resolves.toBeUndefined();
+    await expect(requireFile(file, 'File', 'preflight-clean')).resolves.toBeUndefined();
+  });
+
+  it('throws stage errors for invalid directory and file path types', async () => {
+    const file = path.join(tempRoot, 'file.txt');
+    const folder = path.join(tempRoot, 'folder');
+    await fs.writeFile(file, 'ok');
+    await fs.mkdir(folder, { recursive: true });
+
+    await expect(requireDirectory(file, 'Folder', 'preflight-clean')).rejects.toBeInstanceOf(
+      BuildStageError,
+    );
+    await expect(requireFile(folder, 'File', 'preflight-clean')).rejects.toBeInstanceOf(
+      BuildStageError,
+    );
+  });
+
+  it('throws stage errors when required paths are missing', async () => {
+    await expect(
+      requireDirectory(path.join(tempRoot, 'none'), 'Folder', 'preflight-clean'),
+    ).rejects.toBeInstanceOf(BuildStageError);
+    await expect(
+      requireFile(path.join(tempRoot, 'none.txt'), 'File', 'preflight-clean'),
+    ).rejects.toBeInstanceOf(BuildStageError);
+  });
+});
+
+describe('ensureDirs and removeDir', () => {
+  it('creates one or more directories and removes directories recursively', async () => {
+    const singleDir = path.join(tempRoot, 'single');
+    const nestedDir = path.join(tempRoot, 'a', 'b', 'c');
+
+    await ensureDirs(singleDir);
+    await ensureDirs([nestedDir]);
+
+    await expect(pathExists(singleDir)).resolves.toBe(true);
+    await expect(pathExists(nestedDir)).resolves.toBe(true);
+
+    await removeDir(path.join(tempRoot, 'a'));
+
+    await expect(pathExists(nestedDir)).resolves.toBe(false);
+  });
+});
+
+describe('error helpers', () => {
+  it('identifies BuildStageError instances', () => {
+    const stageError = new BuildStageError('frontend-build', 'failed');
+
+    expect(isBuildStageError(stageError)).toBe(true);
+    expect(isBuildStageError(new Error('nope'))).toBe(false);
+  });
+
+  it('normalises unknown values to Error', () => {
+    const existing = new Error('existing');
+
+    expect(asError(existing)).toBe(existing);
+    expect(asError('wrapped').message).toBe('wrapped');
+  });
+});

--- a/scripts/builder/src/lib/process.spec.ts
+++ b/scripts/builder/src/lib/process.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BuildStageError } from './errors.js';
+import {
+  CommandExecutionError,
+  logBuildFailure,
+  logError,
+  logInfo,
+  runCommand,
+} from './process.js';
+
+describe('runCommand', () => {
+  it('captures stdout and stderr for successful commands', async () => {
+    const result = await runCommand(
+      process.execPath,
+      ['-e', "process.stdout.write('hello');process.stderr.write('warn');"],
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    expect(result.stdout).toBe('hello');
+    expect(result.stderr).toBe('warn');
+  });
+
+  it('throws CommandExecutionError with diagnostics for non-zero exit codes', async () => {
+    await expect(
+      runCommand(
+        process.execPath,
+        ['-e', "process.stderr.write('boom');process.exit(2);"],
+        {
+          cwd: process.cwd(),
+        },
+      ),
+    ).rejects.toBeInstanceOf(CommandExecutionError);
+
+    await expect(
+      runCommand(
+        process.execPath,
+        ['-e', "process.stderr.write('boom');process.exit(2);"],
+        {
+          cwd: process.cwd(),
+        },
+      ),
+    ).rejects.toMatchObject({
+      diagnostics: {
+        exitCode: 2,
+        command: process.execPath,
+      },
+    });
+  });
+
+  it('throws CommandExecutionError when command cannot be started', async () => {
+    await expect(
+      runCommand('definitely-not-a-real-command', [], {
+        cwd: process.cwd(),
+      }),
+    ).rejects.toMatchObject({
+      diagnostics: {
+        command: 'definitely-not-a-real-command',
+        exitCode: null,
+      },
+    });
+  });
+});
+
+describe('logging helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes logInfo output to stdout and logError output to stderr', () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    logInfo('Builder started');
+    logError('Builder failed');
+
+    expect(stdoutSpy).toHaveBeenCalledWith('Builder started\n');
+    expect(stderrSpy).toHaveBeenCalledWith('Builder failed\n');
+  });
+
+  it('logs stage and cause details for BuildStageError failures', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    logBuildFailure(new BuildStageError('frontend-build', 'Transform failed', new Error('Boom')));
+
+    expect(stderrSpy).toHaveBeenCalledWith('Build failed during frontend-build: Transform failed\n');
+    expect(stderrSpy).toHaveBeenCalledWith('Cause: Boom\n');
+  });
+
+  it('logs fallback error details for non-stage failures', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    logBuildFailure('unexpected failure');
+
+    expect(stderrSpy).toHaveBeenCalledWith('Build failed: unexpected failure\n');
+  });
+});

--- a/scripts/builder/src/steps/merge-manifest.spec.ts
+++ b/scripts/builder/src/steps/merge-manifest.spec.ts
@@ -164,7 +164,7 @@ describe('runMergeManifest', () => {
   });
 
 
-  it('fails with BuildStageError when output directory is not writable', async () => {
+  it('fails with BuildStageError when output directory does not exist', async () => {
     await fs.writeFile(paths.backendManifestPath, JSON.stringify({ oauthScopes: [] }), 'utf-8');
     await fs.writeFile(paths.jsonDbAppManifestPath, JSON.stringify({ oauthScopes: [] }), 'utf-8');
 

--- a/scripts/builder/src/steps/merge-manifest.spec.ts
+++ b/scripts/builder/src/steps/merge-manifest.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import type { BuilderPaths } from '../types.js';
 import { BuildStageError } from '../lib/errors.js';
-import { mergeScopes, mergeServices, runMergeManifest } from './merge-manifest.js';
+import { mergeScopes, mergeServices, runMergeManifest, sortKeysDeep } from './merge-manifest.js';
 
 /**
  * Creates a unique temporary directory for a test case.
@@ -48,6 +48,21 @@ function createBuilderPaths(rootDir: string): BuilderPaths {
   };
 }
 
+
+
+describe('sortKeysDeep', () => {
+  it('sorts object keys recursively while preserving arrays', () => {
+    const sorted = sortKeysDeep({
+      b: { d: 1, c: 2 },
+      a: [{ z: 1, y: 2 }],
+    }) as { a: Array<Record<string, number>>; b: Record<string, number> };
+
+    expect(Object.keys(sorted)).toEqual(['a', 'b']);
+    expect(Object.keys(sorted.b)).toEqual(['c', 'd']);
+    expect(Object.keys(sorted.a[0])).toEqual(['y', 'z']);
+  });
+});
+
 describe('mergeScopes', () => {
   it('de-duplicates and sorts scopes deterministically', () => {
     expect(mergeScopes(['scope.b', 'scope.a'], ['scope.b', 'scope.c'])).toEqual([
@@ -56,6 +71,11 @@ describe('mergeScopes', () => {
       'scope.c',
     ]);
   });
+
+  it('returns an empty list when both scope lists are undefined', () => {
+    expect(mergeScopes(undefined, undefined)).toEqual([]);
+  });
+
 });
 
 describe('mergeServices', () => {
@@ -77,6 +97,11 @@ describe('mergeServices', () => {
       { userSymbol: 'Slides', serviceId: 'slides', version: 'v1' },
     ]);
   });
+
+  it('returns an empty list when both service lists are undefined', () => {
+    expect(mergeServices(undefined, undefined)).toEqual([]);
+  });
+
 });
 
 describe('runMergeManifest', () => {
@@ -136,6 +161,17 @@ describe('runMergeManifest', () => {
       { userSymbol: 'Sheets', serviceId: 'sheets', version: 'v4' },
     ]);
     expect(Object.keys(parsed)).toEqual(['dependencies', 'oauthScopes', 'runtimeVersion']);
+  });
+
+
+  it('fails with BuildStageError when output directory is not writable', async () => {
+    await fs.writeFile(paths.backendManifestPath, JSON.stringify({ oauthScopes: [] }), 'utf-8');
+    await fs.writeFile(paths.jsonDbAppManifestPath, JSON.stringify({ oauthScopes: [] }), 'utf-8');
+
+    paths.buildGasDir = path.join(tempRoot, 'missing-output-dir');
+
+    await expect(runMergeManifest(paths)).rejects.toBeInstanceOf(BuildStageError);
+    await expect(runMergeManifest(paths)).rejects.toThrow('Unable to write merged manifest');
   });
 
   it('fails with BuildStageError when JsonDb manifest is missing', async () => {

--- a/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
+++ b/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
@@ -2,61 +2,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 
-import type { BuilderPaths } from '../types.js';
 import { BuildStageError } from '../lib/errors.js';
+import {
+  createBuilderPaths,
+  createReleaseArchive,
+  writeReleaseFile,
+  writeReleaseManifest,
+} from '../test/jsondb-source-test-helpers.js';
 import { runResolveJsonDbSource } from './resolve-jsondb-source.js';
 
-const execFileAsync = promisify(execFile);
-
 /**
- * Builds a complete `BuilderPaths` object rooted at a temporary directory.
+ * Mocks a successful release download for resolve-jsondb-source tests.
  *
- * @param {string} rootDir - Root temporary directory for the test fixture.
- * @return {BuilderPaths} Fully resolved builder path values.
+ * @param {Uint8Array} archiveBytes - Tar archive payload returned by mocked fetch.
+ * @return {void} No return value.
  */
-function createBuilderPaths(rootDir: string): BuilderPaths {
-  return {
-    repoRoot: rootDir,
-    builderRoot: path.join(rootDir, 'scripts', 'builder'),
-    configPath: path.join(rootDir, 'scripts', 'builder', 'builder.config.json'),
-    frontendDir: path.join(rootDir, 'src', 'frontend'),
-    backendDir: path.join(rootDir, 'src', 'backend'),
-    buildDir: path.join(rootDir, 'build'),
-    buildFrontendDir: path.join(rootDir, 'build', 'frontend'),
-    buildWorkDir: path.join(rootDir, 'build', 'work'),
-    buildGasDir: path.join(rootDir, 'build', 'gas'),
-    buildGasUiDir: path.join(rootDir, 'build', 'gas', 'UI'),
-    backendManifestPath: path.join(rootDir, 'src', 'backend', 'appsscript.json'),
-    jsonDbAppPinnedSnapshotDir: path.join(rootDir, 'vendor', 'jsondbapp'),
-    jsonDbAppManifestPath: path.join(rootDir, 'vendor', 'jsondbapp', 'appsscript.json'),
-    jsonDbAppSourceFiles: [],
-    jsonDbAppPublicExports: ['loadDatabase', 'createAndInitialiseDatabase'],
-  };
-}
-
-/**
- * Creates a tar.gz release fixture and returns its bytes for mocked download tests.
- *
- * @param {string} tempRoot - Temporary root directory for fixture files.
- * @param {(releaseFixtureRoot: string) => Promise<void>} setup - Fixture setup callback.
- * @return {Promise<Uint8Array>} Archive bytes for use in mocked fetch responses.
- */
-async function createReleaseArchive(
-  tempRoot: string,
-  setup: (releaseFixtureRoot: string) => Promise<void>,
-): Promise<Uint8Array> {
-  const releaseFixtureDir = path.join(tempRoot, 'release-fixture');
-  const releaseFixtureRoot = path.join(releaseFixtureDir, 'JsonDbApp-0.1.0');
-  const archivePath = path.join(tempRoot, 'jsondbapp-release.tar.gz');
-
-  await fs.mkdir(releaseFixtureRoot, { recursive: true });
-  await setup(releaseFixtureRoot);
-  await execFileAsync('tar', ['-czf', archivePath, '-C', releaseFixtureDir, 'JsonDbApp-0.1.0']);
-
-  return fs.readFile(archivePath);
+function mockSuccessfulReleaseDownload(archiveBytes: Uint8Array): void {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(archiveBytes, { status: 200, statusText: 'OK' }),
+  );
 }
 
 describe('runResolveJsonDbSource', () => {
@@ -75,15 +40,12 @@ describe('runResolveJsonDbSource', () => {
     const paths = createBuilderPaths(tempRoot);
 
     const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
-      await fs.mkdir(path.join(releaseFixtureRoot, 'src', 'nested'), { recursive: true });
-      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
-      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'z-last.js'), 'function z(){}', 'utf-8');
-      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'a-first.js'), 'function a(){}', 'utf-8');
-      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'nested', 'b-middle.js'), 'function b(){}', 'utf-8');
+      await writeReleaseManifest(releaseFixtureRoot);
+      await writeReleaseFile(releaseFixtureRoot, 'src/z-last.js', 'function z(){}');
+      await writeReleaseFile(releaseFixtureRoot, 'src/a-first.js', 'function a(){}');
+      await writeReleaseFile(releaseFixtureRoot, 'src/nested/b-middle.js', 'function b(){}');
     });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
-    );
+    mockSuccessfulReleaseDownload(archiveBytes);
 
     const result = await runResolveJsonDbSource(paths);
 
@@ -98,11 +60,9 @@ describe('runResolveJsonDbSource', () => {
   it('throws BuildStageError when the release is missing a source directory', async () => {
     const paths = createBuilderPaths(tempRoot);
     const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
-      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
+      await writeReleaseManifest(releaseFixtureRoot);
     });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
-    );
+    mockSuccessfulReleaseDownload(archiveBytes);
 
     await expect(runResolveJsonDbSource(paths)).rejects.toThrow('missing source directory');
   });
@@ -110,12 +70,9 @@ describe('runResolveJsonDbSource', () => {
   it('throws BuildStageError when the release is missing a manifest', async () => {
     const paths = createBuilderPaths(tempRoot);
     const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
-      await fs.mkdir(path.join(releaseFixtureRoot, 'src'), { recursive: true });
-      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'entry.js'), 'const x = 1;', 'utf-8');
+      await writeReleaseFile(releaseFixtureRoot, 'src/entry.js', 'const x = 1;');
     });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
-    );
+    mockSuccessfulReleaseDownload(archiveBytes);
 
     await expect(runResolveJsonDbSource(paths)).rejects.toThrow('missing manifest');
   });
@@ -123,13 +80,10 @@ describe('runResolveJsonDbSource', () => {
   it('throws BuildStageError when src has no JavaScript files', async () => {
     const paths = createBuilderPaths(tempRoot);
     const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
-      await fs.mkdir(path.join(releaseFixtureRoot, 'src'), { recursive: true });
-      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
-      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'README.md'), '# not js', 'utf-8');
+      await writeReleaseManifest(releaseFixtureRoot);
+      await writeReleaseFile(releaseFixtureRoot, 'src/README.md', '# not js');
     });
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
-    );
+    mockSuccessfulReleaseDownload(archiveBytes);
 
     await expect(runResolveJsonDbSource(paths)).rejects.toThrow('contains no JavaScript source files');
   });

--- a/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
+++ b/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
@@ -37,6 +37,22 @@ function createBuilderPaths(rootDir: string): BuilderPaths {
   };
 }
 
+
+async function createReleaseArchive(
+  tempRoot: string,
+  setup: (releaseFixtureRoot: string) => Promise<void>,
+): Promise<Uint8Array> {
+  const releaseFixtureDir = path.join(tempRoot, 'release-fixture');
+  const releaseFixtureRoot = path.join(releaseFixtureDir, 'JsonDbApp-0.1.0');
+  const archivePath = path.join(tempRoot, 'jsondbapp-release.tar.gz');
+
+  await fs.mkdir(releaseFixtureRoot, { recursive: true });
+  await setup(releaseFixtureRoot);
+  await execFileAsync('tar', ['-czf', archivePath, '-C', releaseFixtureDir, 'JsonDbApp-0.1.0']);
+
+  return fs.readFile(archivePath);
+}
+
 describe('runResolveJsonDbSource', () => {
   let tempRoot: string;
 
@@ -50,19 +66,15 @@ describe('runResolveJsonDbSource', () => {
   });
 
   it('downloads, extracts, and resolves sorted src JavaScript files from the release archive', async () => {
-    const releaseFixtureDir = path.join(tempRoot, 'release-fixture');
-    const releaseFixtureRoot = path.join(releaseFixtureDir, 'JsonDbApp-0.1.0');
-    const archivePath = path.join(tempRoot, 'jsondbapp-release.tar.gz');
     const paths = createBuilderPaths(tempRoot);
 
-    await fs.mkdir(path.join(releaseFixtureRoot, 'src', 'nested'), { recursive: true });
-    await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
-    await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'z-last.js'), 'function z(){}', 'utf-8');
-    await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'a-first.js'), 'function a(){}', 'utf-8');
-    await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'nested', 'b-middle.js'), 'function b(){}', 'utf-8');
-    await execFileAsync('tar', ['-czf', archivePath, '-C', releaseFixtureDir, 'JsonDbApp-0.1.0']);
-
-    const archiveBytes = await fs.readFile(archivePath);
+    const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
+      await fs.mkdir(path.join(releaseFixtureRoot, 'src', 'nested'), { recursive: true });
+      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
+      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'z-last.js'), 'function z(){}', 'utf-8');
+      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'a-first.js'), 'function a(){}', 'utf-8');
+      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'nested', 'b-middle.js'), 'function b(){}', 'utf-8');
+    });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(archiveBytes, { status: 200, statusText: 'OK' }),
     );
@@ -75,6 +87,47 @@ describe('runResolveJsonDbSource', () => {
       path.join(paths.buildWorkDir, 'jsondbapp-v0.1.0', 'appsscript.json'),
     );
     expect(paths.jsonDbAppSourceFiles).toEqual(result.sourceFiles);
+  });
+
+
+
+  it('throws BuildStageError when the release is missing a source directory', async () => {
+    const paths = createBuilderPaths(tempRoot);
+    const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
+      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
+    );
+
+    await expect(runResolveJsonDbSource(paths)).rejects.toThrow('missing source directory');
+  });
+
+  it('throws BuildStageError when the release is missing a manifest', async () => {
+    const paths = createBuilderPaths(tempRoot);
+    const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
+      await fs.mkdir(path.join(releaseFixtureRoot, 'src'), { recursive: true });
+      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'entry.js'), 'const x = 1;', 'utf-8');
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
+    );
+
+    await expect(runResolveJsonDbSource(paths)).rejects.toThrow('missing manifest');
+  });
+
+  it('throws BuildStageError when src has no JavaScript files', async () => {
+    const paths = createBuilderPaths(tempRoot);
+    const archiveBytes = await createReleaseArchive(tempRoot, async (releaseFixtureRoot) => {
+      await fs.mkdir(path.join(releaseFixtureRoot, 'src'), { recursive: true });
+      await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
+      await fs.writeFile(path.join(releaseFixtureRoot, 'src', 'README.md'), '# not js', 'utf-8');
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(archiveBytes, { status: 200, statusText: 'OK' }),
+    );
+
+    await expect(runResolveJsonDbSource(paths)).rejects.toThrow('contains no JavaScript source files');
   });
 
   it('throws BuildStageError when the release download fails', async () => {

--- a/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
+++ b/scripts/builder/src/steps/resolve-jsondb-source.spec.ts
@@ -37,7 +37,13 @@ function createBuilderPaths(rootDir: string): BuilderPaths {
   };
 }
 
-
+/**
+ * Creates a tar.gz release fixture and returns its bytes for mocked download tests.
+ *
+ * @param {string} tempRoot - Temporary root directory for fixture files.
+ * @param {(releaseFixtureRoot: string) => Promise<void>} setup - Fixture setup callback.
+ * @return {Promise<Uint8Array>} Archive bytes for use in mocked fetch responses.
+ */
 async function createReleaseArchive(
   tempRoot: string,
   setup: (releaseFixtureRoot: string) => Promise<void>,
@@ -88,8 +94,6 @@ describe('runResolveJsonDbSource', () => {
     );
     expect(paths.jsonDbAppSourceFiles).toEqual(result.sourceFiles);
   });
-
-
 
   it('throws BuildStageError when the release is missing a source directory', async () => {
     const paths = createBuilderPaths(tempRoot);

--- a/scripts/builder/src/steps/resolve-jsondb-source.ts
+++ b/scripts/builder/src/steps/resolve-jsondb-source.ts
@@ -12,6 +12,7 @@ const JSON_DB_RELEASE_TAG = 'v0.1.0';
 const JSON_DB_RELEASE_TARBALL_URL =
   'https://github.com/h-arnold/JsonDbApp/archive/refs/tags/v0.1.0.tar.gz';
 const execFileAsync = promisify(execFile);
+const TAR_VERBOSE_NAME_COLUMN_INDEX = 5;
 
 /**
  * Downloads a URL to disk using fetch with curl fallback.
@@ -98,7 +99,7 @@ async function validateArchiveContents(archivePath: string): Promise<void> {
     }
 
     // The entry path is the name field; for symlinks it is before ' -> target'.
-    const nameWithMaybeTarget = columns.slice(5).join(' ');
+    const nameWithMaybeTarget = columns.slice(TAR_VERBOSE_NAME_COLUMN_INDEX).join(' ');
     const [entryPath] = nameWithMaybeTarget.split(' -> ');
 
     if (path.isAbsolute(entryPath)) {

--- a/scripts/builder/src/test/jsondb-source-test-helpers.ts
+++ b/scripts/builder/src/test/jsondb-source-test-helpers.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { BuilderPaths } from '../types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Builds a complete `BuilderPaths` object rooted at a temporary directory.
+ *
+ * @param {string} rootDir - Root temporary directory for the test fixture.
+ * @return {BuilderPaths} Fully resolved builder path values.
+ */
+export function createBuilderPaths(rootDir: string): BuilderPaths {
+  return {
+    repoRoot: rootDir,
+    builderRoot: path.join(rootDir, 'scripts', 'builder'),
+    configPath: path.join(rootDir, 'scripts', 'builder', 'builder.config.json'),
+    frontendDir: path.join(rootDir, 'src', 'frontend'),
+    backendDir: path.join(rootDir, 'src', 'backend'),
+    buildDir: path.join(rootDir, 'build'),
+    buildFrontendDir: path.join(rootDir, 'build', 'frontend'),
+    buildWorkDir: path.join(rootDir, 'build', 'work'),
+    buildGasDir: path.join(rootDir, 'build', 'gas'),
+    buildGasUiDir: path.join(rootDir, 'build', 'gas', 'UI'),
+    backendManifestPath: path.join(rootDir, 'src', 'backend', 'appsscript.json'),
+    jsonDbAppPinnedSnapshotDir: path.join(rootDir, 'vendor', 'jsondbapp'),
+    jsonDbAppManifestPath: path.join(rootDir, 'vendor', 'jsondbapp', 'appsscript.json'),
+    jsonDbAppSourceFiles: [],
+    jsonDbAppPublicExports: ['loadDatabase', 'createAndInitialiseDatabase'],
+  };
+}
+
+/**
+ * Creates a tar.gz release fixture and returns its bytes for mocked download tests.
+ *
+ * @param {string} tempRoot - Temporary root directory for fixture files.
+ * @param {(releaseFixtureRoot: string) => Promise<void>} setup - Fixture setup callback.
+ * @return {Promise<Uint8Array>} Archive bytes for use in mocked fetch responses.
+ */
+export async function createReleaseArchive(
+  tempRoot: string,
+  setup: (releaseFixtureRoot: string) => Promise<void>,
+): Promise<Uint8Array> {
+  const releaseFixtureDir = path.join(tempRoot, 'release-fixture');
+  const releaseFixtureRoot = path.join(releaseFixtureDir, 'JsonDbApp-0.1.0');
+  const archivePath = path.join(tempRoot, 'jsondbapp-release.tar.gz');
+
+  await fs.mkdir(releaseFixtureRoot, { recursive: true });
+  await setup(releaseFixtureRoot);
+  await execFileAsync('tar', ['-czf', archivePath, '-C', releaseFixtureDir, 'JsonDbApp-0.1.0']);
+
+  return fs.readFile(archivePath);
+}
+
+/**
+ * Writes a minimal JsonDb release manifest fixture.
+ *
+ * @param {string} releaseFixtureRoot - Root fixture directory containing release files.
+ * @return {Promise<void>} Resolves once the manifest is written.
+ */
+export async function writeReleaseManifest(releaseFixtureRoot: string): Promise<void> {
+  await fs.writeFile(path.join(releaseFixtureRoot, 'appsscript.json'), '{"oauthScopes":[]}', 'utf-8');
+}
+
+/**
+ * Writes a release source file fixture, creating parent directories as needed.
+ *
+ * @param {string} releaseFixtureRoot - Root fixture directory containing release files.
+ * @param {string} relativeFilePath - File path relative to the release root.
+ * @param {string} content - File content.
+ * @return {Promise<void>} Resolves once the file is written.
+ */
+export async function writeReleaseFile(
+  releaseFixtureRoot: string,
+  relativeFilePath: string,
+  content: string,
+): Promise<void> {
+  const absoluteFilePath = path.join(releaseFixtureRoot, relativeFilePath);
+  await fs.mkdir(path.dirname(absoluteFilePath), { recursive: true });
+  await fs.writeFile(absoluteFilePath, content, 'utf-8');
+}

--- a/scripts/builder/vitest.config.ts
+++ b/scripts/builder/vitest.config.ts
@@ -10,5 +10,14 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.spec.ts'],
     globals: false,
+    coverage: {
+      reporter: ['text', 'html'],
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });

--- a/scripts/builder/vitest.config.ts
+++ b/scripts/builder/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
     include: ['src/**/*.spec.ts'],
     globals: false,
     coverage: {
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.spec.ts'],
       reporter: ['text', 'html'],
       thresholds: {
         lines: 85,

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -247,7 +247,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -619,7 +618,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -660,7 +658,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2577,7 +2574,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2662,7 +2660,6 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2673,7 +2670,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2684,7 +2680,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2734,7 +2729,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3154,7 +3148,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3205,6 +3198,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3230,7 +3224,6 @@
       "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.1.tgz",
       "integrity": "sha512-8pRjvxitZFyrYAtgwml93Km7fCXjw9IeqlmzpIsusRsmO3eWFVrOMum6+0TsGCtR/WrXVnPwfsgrFg3ChzGCeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
         "@ant-design/cssinjs": "^2.1.0",
@@ -3397,7 +3390,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3605,8 +3597,7 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3655,7 +3646,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3755,7 +3747,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4325,7 +4316,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -4480,6 +4470,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4732,7 +4723,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4832,6 +4822,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4847,6 +4838,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4859,7 +4851,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4876,7 +4869,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4886,7 +4878,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5270,7 +5261,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5367,7 +5357,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5443,7 +5432,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -5650,7 +5638,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -56,7 +56,7 @@ describe('App', () => {
     render(<App />);
 
     expect(screen.getByText('Checking authorisation status...')).toBeInTheDocument();
-    expect(await screen.findByText('Unauthroised')).toBeInTheDocument();
+    expect(await screen.findByText('Unauthorised')).toBeInTheDocument();
   });
 
   it('shows backend failure message when backend call fails', async () => {
@@ -83,7 +83,7 @@ describe('App', () => {
     render(<App />);
 
     expect(screen.getByText('Checking authorisation status...')).toBeInTheDocument();
-    expect(await screen.findByText('Unauthroised')).toBeInTheDocument();
+    expect(await screen.findByText('Unauthorised')).toBeInTheDocument();
     expect(await screen.findByText('Backend authorisation check failed.')).toBeInTheDocument();
   });
 
@@ -111,7 +111,7 @@ describe('App', () => {
     render(<App />);
 
     expect(screen.getByText('Checking authorisation status...')).toBeInTheDocument();
-    expect(await screen.findByText('Unauthroised')).toBeInTheDocument();
+    expect(await screen.findByText('Unauthorised')).toBeInTheDocument();
     expect(await screen.findByText('Backend call failed with a string.')).toBeInTheDocument();
   });
 
@@ -119,7 +119,7 @@ describe('App', () => {
     render(<App />);
 
     expect(screen.getByText('Checking authorisation status...')).toBeInTheDocument();
-    expect(await screen.findByText('Unauthroised')).toBeInTheDocument();
+    expect(await screen.findByText('Unauthorised')).toBeInTheDocument();
     expect(
       await screen.findByText('google.script.run is unavailable in this runtime.'),
     ).toBeInTheDocument();

--- a/src/frontend/src/App.test.tsx
+++ b/src/frontend/src/App.test.tsx
@@ -87,6 +87,34 @@ describe('App', () => {
     expect(await screen.findByText('Backend authorisation check failed.')).toBeInTheDocument();
   });
 
+
+  it('shows string failure message when backend call fails with non-Error values', async () => {
+    const runMock = {
+      withSuccessHandler() {
+        return runMock;
+      },
+      withFailureHandler(handler: (error: unknown) => void) {
+        queueMicrotask(() => {
+          handler('Backend call failed with a string.');
+        });
+        return runMock;
+      },
+      getAuthorisationStatus() {},
+    };
+
+    globalThis.google = {
+      script: {
+        run: runMock,
+      },
+    };
+
+    render(<App />);
+
+    expect(screen.getByText('Checking authorisation status...')).toBeInTheDocument();
+    expect(await screen.findByText('Unauthroised')).toBeInTheDocument();
+    expect(await screen.findByText('Backend call failed with a string.')).toBeInTheDocument();
+  });
+
   it('shows runtime failure message when google.script.run is unavailable', async () => {
     render(<App />);
 

--- a/src/frontend/src/features/auth/AuthStatusCard.tsx
+++ b/src/frontend/src/features/auth/AuthStatusCard.tsx
@@ -22,7 +22,7 @@ export function AuthStatusCard() {
         ) : (
           <Result
             status={isAuthorised ? 'success' : 'error'}
-            title={isAuthorised ? 'Authorised' : 'Unauthroised'}
+            title={isAuthorised ? 'Authorised' : 'Unauthorised'}
             subTitle={authError ?? undefined}
           />
         )}

--- a/src/frontend/src/main.test.tsx
+++ b/src/frontend/src/main.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const renderMock = vi.fn();
+const createRootMock = vi.fn(() => ({ render: renderMock }));
+
+vi.mock('react-dom/client', () => ({
+  createRoot: createRootMock,
+}));
+
+vi.mock('./App', () => ({
+  default: () => null,
+}));
+
+describe('main entrypoint', () => {
+  afterEach(() => {
+    createRootMock.mockClear();
+    renderMock.mockClear();
+    vi.resetModules();
+    document.body.innerHTML = '';
+  });
+
+  it('throws when the root element is missing', async () => {
+    await expect(import('./main')).rejects.toThrow('Root element "#root" was not found.');
+  });
+
+  it('creates a React root and renders the app shell', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+
+    await import('./main');
+
+    expect(createRootMock).toHaveBeenCalledTimes(1);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/tests/app.spec.ts
+++ b/src/frontend/tests/app.spec.ts
@@ -3,6 +3,6 @@ import { expect, test } from '@playwright/test';
 test('shows the frontend title', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByText('AssessmentBot Frontend')).toBeVisible();
-  await expect(page.getByText('Unauthroised')).toBeVisible();
+  await expect(page.getByText('Unauthorised')).toBeVisible();
   await expect(page.getByText('google.script.run is unavailable in this runtime.')).toBeVisible();
 });

--- a/src/frontend/tests/auth-status.spec.ts
+++ b/src/frontend/tests/auth-status.spec.ts
@@ -83,7 +83,7 @@ test.describe('auth status flow', () => {
 
     await page.goto('/');
 
-    await expect(page.getByText('Unauthroised')).toBeVisible();
+    await expect(page.getByText('Unauthorised')).toBeVisible();
   });
 
   test('shows backend error subtitle when backend call fails', async ({ page }) => {
@@ -94,14 +94,14 @@ test.describe('auth status flow', () => {
 
     await page.goto('/');
 
-    await expect(page.getByText('Unauthroised')).toBeVisible();
+    await expect(page.getByText('Unauthorised')).toBeVisible();
     await expect(page.getByText('Backend authorisation check failed.')).toBeVisible();
   });
 
   test('shows runtime error when google.script.run is unavailable', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page.getByText('Unauthroised')).toBeVisible();
+    await expect(page.getByText('Unauthorised')).toBeVisible();
     await expect(page.getByText('google.script.run is unavailable in this runtime.')).toBeVisible();
   });
 });

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: './src/test/setup.ts',
     coverage: {
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/test/**'],
       reporter: ['text', 'html'],
       thresholds: {
         lines: 85,

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -8,5 +8,14 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: './src/test/setup.ts',
+    coverage: {
+      reporter: ['text', 'html'],
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        statements: 85,
+        branches: 85,
+      },
+    },
   },
 });


### PR DESCRIPTION
### Motivation

- Introduce enforced coverage gates for builder and frontend test suites to ensure minimum test quality and deterministic builder outputs.
- Add unit tests that exercise builder filesystem helpers, process/command runner logging and manifest/JsonDb release handling to increase confidence in build pipeline stages.

### Description

- Add coverage commands and thresholds: `frontend:test:coverage` and `builder:test:coverage` scripts and coverage settings in `src/frontend/vite.config.ts` and `scripts/builder/vitest.config.ts` with 85% thresholds for lines, functions, statements, and branches.
- Update docs and agent guidance to document coverage commands and the new 85% coverage requirement in `.github/agents/Testing.agent.md`, `docs/developer/builder/builder-script.md`, and `docs/developer/frontend/frontend-testing.md`.
- Add `@vitest/coverage-v8` as a dev dependency and update lockfiles to pull in coverage/reporting packages required by Vitest coverage reporting.
- Add and extend unit tests: new builder specs `scripts/builder/src/lib/fs.spec.ts` and `scripts/builder/src/lib/process.spec.ts`, enhancements to `scripts/builder/src/steps/merge-manifest.spec.ts` (including `sortKeysDeep` tests and additional failure cases), extended `scripts/builder/src/steps/resolve-jsondb-source.spec.ts` with a reusable `createReleaseArchive` helper and more failure-path tests, and a frontend test in `src/frontend/src/App.test.tsx` to assert non-Error backend failure messages are rendered.

### Testing

- Ran builder unit tests with `npm run builder:test`, and they completed successfully against the modified builder test suite.
- Verified builder coverage gate using `npm run builder:test:coverage` to ensure the configured 85% thresholds are reported and enforced.
- Ran frontend unit tests with `npm run frontend:test`, and they completed successfully after adding the new frontend test.
- Verified frontend coverage using `npm run frontend:test:coverage` to confirm coverage reporting and thresholds are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8b41380f883298f9b16f267803c40)