### PR TITLE
Remove onOpen trigger helpers, add WebApp entrypoint, and add unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,14 @@ Rules:
 State 1-2 concise assumptions and proceed with the simplest compliant implementation.
 
 **REMEMBER**: You must always adhere to the prime directives and core principles, even when making assumptions.
+
+### 8. Lint Command Hierarchy
+
+When validating lint output, use the runtime-specific commands defined in the config hierarchy:
+
+- Backend GAS JavaScript: `npm run lint`
+- Frontend TypeScript/React: `npm run frontend:lint`
+- Builder TypeScript: `npm run builder:lint`
+- All lint checks in sequence: `npm run lint && npm run frontend:lint && npm run builder:lint`
+
+Do not run frontend or builder files through the root backend ESLint command directly; use their leaf configs via the commands above.

--- a/src/backend/Api/WebApp.js
+++ b/src/backend/Api/WebApp.js
@@ -1,0 +1,12 @@
+/**
+ * GAS web-app entrypoint that serves the built React HtmlService template.
+ *
+ * @returns {GoogleAppsScript.HTML.HtmlOutput} Rendered web-app HTML output.
+ */
+function doGet() {
+  return HtmlService.createTemplateFromFile('UI/ReactApp').evaluate();
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { doGet };
+}

--- a/src/backend/Utils/TriggerController.js
+++ b/src/backend/Utils/TriggerController.js
@@ -45,48 +45,6 @@ class TriggerController {
   }
 
   /**
-   * Removes existing onOpen triggers.
-   */
-  removeOnOpenTriggers() {
-    const triggers = ScriptApp.getProjectTriggers();
-    triggers.forEach((trigger) => {
-      if (trigger.getEventType() === ScriptApp.EventType.ON_OPEN) {
-        ScriptApp.deleteTrigger(trigger);
-        console.log(`Existing onOpen trigger deleted.`);
-      }
-    });
-  }
-
-  /**
-   * Creates an onOpen trigger for the specified function, removing any existing onOpen triggers beforehand.
-   *
-   * @param {string} functionName - The name of the function to trigger on open.
-   * @returns {string} The unique ID of the created trigger.
-   */
-  createOnOpenTrigger(functionName) {
-    try {
-      // Ensure user has granted required permissions for trigger installation and execution
-      ScriptApp.requireScopes(ScriptApp.AuthMode.FULL, TriggerController.REQUIRED_SCOPES);
-
-      this.removeOnOpenTriggers();
-
-      // Create new onOpen trigger
-      const trigger = ScriptApp.newTrigger(functionName)
-        .forSpreadsheet(SpreadsheetApp.getActiveSpreadsheet())
-        .onOpen()
-        .create();
-      console.log(`OnOpen trigger created for ${functionName}.`);
-      return trigger.getUniqueId();
-    } catch (error) {
-      const progressTracker = ProgressTracker.getInstance();
-      progressTracker.logAndThrowError(
-        `Error creating onOpen trigger for ${functionName}: ${error.message}`,
-        error
-      );
-    }
-  }
-
-  /**
    * Removes all triggers associated with the specified function name.
    *
    * @param {string} functionName - The name of the function whose triggers are to be removed.
@@ -136,3 +94,7 @@ TriggerController.REQUIRED_SCOPES = [
   'https://www.googleapis.com/auth/script.scriptapp',
   'https://www.googleapis.com/auth/classroom.topics.readonly',
 ];
+
+if (typeof module !== 'undefined') {
+  module.exports = { TriggerController };
+}

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -4,6 +4,11 @@ import { Button, Card, Layout, Space, Statistic, Typography } from 'antd';
 const { Header, Content } = Layout;
 const { Title, Paragraph } = Typography;
 
+/**
+ * Renders the main frontend scaffold view.
+ *
+ * @returns {JSX.Element} Frontend application shell.
+ */
 function App() {
   return (
     <Layout>

--- a/tests/api/webApp.test.js
+++ b/tests/api/webApp.test.js
@@ -21,7 +21,6 @@ describe('backend API WebApp doGet', () => {
 
   afterEach(() => {
     delete globalThis.HtmlService;
-    delete require.cache[require.resolve('../../src/backend/Api/WebApp.js')];
   });
 
   it('renders the React app HtmlService template', () => {

--- a/tests/api/webApp.test.js
+++ b/tests/api/webApp.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('backend API WebApp doGet', () => {
+  let doGet;
+  let evaluate;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    evaluate = vi.fn(() => ({ html: true }));
+
+    globalThis.HtmlService = {
+      createTemplateFromFile: vi.fn(() => ({
+        evaluate,
+      })),
+    };
+
+    delete require.cache[require.resolve('../../src/backend/Api/WebApp.js')];
+    ({ doGet } = require('../../src/backend/Api/WebApp.js'));
+  });
+
+  afterEach(() => {
+    delete globalThis.HtmlService;
+    delete require.cache[require.resolve('../../src/backend/Api/WebApp.js')];
+  });
+
+  it('renders the React app HtmlService template', () => {
+    const output = doGet();
+
+    expect(globalThis.HtmlService.createTemplateFromFile).toHaveBeenCalledWith('UI/ReactApp');
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(output).toEqual({ html: true });
+  });
+});

--- a/tests/utils/triggerController.test.js
+++ b/tests/utils/triggerController.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('backend TriggerController', () => {
+  let TriggerController;
+  let progressTracker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    progressTracker = {
+      logAndThrowError: vi.fn((message, error) => {
+        throw error || new Error(message);
+      }),
+    };
+
+    globalThis.ProgressTracker = {
+      getInstance: vi.fn(() => progressTracker),
+    };
+
+    globalThis.ScriptApp = {
+      AuthMode: { FULL: 'FULL' },
+      requireScopes: vi.fn(),
+      newTrigger: vi.fn(() => ({
+        timeBased: vi.fn().mockReturnThis(),
+        at: vi.fn().mockReturnThis(),
+        create: vi.fn(() => ({ getUniqueId: vi.fn(() => 'trigger-1') })),
+      })),
+      getProjectTriggers: vi.fn(() => []),
+      deleteTrigger: vi.fn(),
+    };
+
+    delete require.cache[require.resolve('../../src/backend/Utils/TriggerController.js')];
+    ({ TriggerController } = require('../../src/backend/Utils/TriggerController.js'));
+  });
+
+  afterEach(() => {
+    delete globalThis.ScriptApp;
+    delete globalThis.ProgressTracker;
+    delete require.cache[require.resolve('../../src/backend/Utils/TriggerController.js')];
+  });
+
+  it('does not expose removed on-open helper methods', () => {
+    const controller = new TriggerController();
+
+    expect(controller.createOnOpenTrigger).toBeUndefined();
+    expect(controller.removeOnOpenTriggers).toBeUndefined();
+  });
+
+  it('still creates time-based triggers', () => {
+    const controller = new TriggerController();
+
+    const triggerId = controller.createTimeBasedTrigger('runTask');
+
+    expect(globalThis.ScriptApp.requireScopes).toHaveBeenCalledWith(
+      globalThis.ScriptApp.AuthMode.FULL,
+      TriggerController.REQUIRED_SCOPES
+    );
+    expect(globalThis.ScriptApp.newTrigger).toHaveBeenCalledWith('runTask');
+    expect(triggerId).toBe('trigger-1');
+  });
+});

--- a/tests/utils/triggerController.test.js
+++ b/tests/utils/triggerController.test.js
@@ -36,7 +36,6 @@ describe('backend TriggerController', () => {
   afterEach(() => {
     delete globalThis.ScriptApp;
     delete globalThis.ProgressTracker;
-    delete require.cache[require.resolve('../../src/backend/Utils/TriggerController.js')];
   });
 
   it('does not expose removed on-open helper methods', () => {


### PR DESCRIPTION
### Motivation
- Simplify trigger management by removing specialized on-open helper methods and rely on general trigger utilities.  
- Provide a GAS web-app entrypoint that serves the built React `HtmlService` template.  
- Add unit tests to validate `doGet` rendering and `TriggerController` behavior in a Node environment.

### Description
- Added `src/backend/Api/WebApp.js` which implements `doGet()` to render the `UI/ReactApp` template via `HtmlService` and exports `doGet` for testability.  
- Removed the `removeOnOpenTriggers` and `createOnOpenTrigger` methods from `src/backend/Utils/TriggerController.js` and kept general trigger removal and time-based trigger creation logic.  
- Added `module.exports` export for `TriggerController` and `doGet` to support unit tests running under Node.  
- Added unit tests `tests/api/webApp.test.js` and `tests/utils/triggerController.test.js` to cover the new `doGet` behavior and that on-open helpers are no longer exposed while time-based triggers still work.

### Testing
- Ran the new unit tests with `vitest` for `tests/api/webApp.test.js` which asserts `doGet` calls `HtmlService.createTemplateFromFile('UI/ReactApp')` and returns the evaluated template; the test passed.  
- Ran `vitest` for `tests/utils/triggerController.test.js` which asserts the absence of `createOnOpenTrigger`/`removeOnOpenTriggers` and that `createTimeBasedTrigger` still creates a trigger with required scopes; the test passed.  
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bfdfe11c8329b4102c0b07e18ab9)