### PR TITLE
Refactor API handler tests, add test helpers, remove React 19 ant-design patch import

### DIFF
--- a/src/AdminSheet/Utils/TriggerController.js
+++ b/src/AdminSheet/Utils/TriggerController.js
@@ -166,3 +166,4 @@ TriggerController.REQUIRED_SCOPES = [
 
 
 
+

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@ant-design/icons": "latest",
-        "@ant-design/v5-patch-for-react-19": "latest",
         "antd": "latest",
         "react": "latest",
         "react-dom": "latest",
@@ -145,20 +144,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ant-design/v5-patch-for-react-19": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
-      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.x"
-      },
-      "peerDependencies": {
-        "antd": ">=5.22.6",
-        "react": ">=19.0.0",
-        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@ant-design/icons": "latest",
-    "@ant-design/v5-patch-for-react-19": "latest",
     "antd": "latest",
     "react": "latest",
     "react-dom": "latest",

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import '@ant-design/v5-patch-for-react-19';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ConfigProvider, theme } from 'antd';

--- a/src/frontend/src/services/apiService.test.ts
+++ b/src/frontend/src/services/apiService.test.ts
@@ -87,17 +87,7 @@ function createGoogleScriptRunHarness(response: RunnerHarnessResponse): {
     let successHandler: ((value: unknown) => void) | undefined;
     let failureHandler: ((error: unknown) => void) | undefined;
 
-    const apiHandlerSpy = vi.fn(() => {
-
-        queueMicrotask(() => {
-            if (response.kind === 'success') {
-                successHandler?.(response.payload);
-                return;
-            }
-
-            failureHandler?.(response.payload);
-        });
-    });
+    const apiHandlerSpy = vi.fn();
 
     const runner: GoogleScriptRunWithApiHandler = {
         /**
@@ -117,8 +107,17 @@ function createGoogleScriptRunHarness(response: RunnerHarnessResponse): {
         /**
          * Dispatches the request into the harness spy.
          */
-        apiHandler() {
-            apiHandlerSpy();
+        apiHandler(request: unknown) {
+            apiHandlerSpy(request);
+
+            queueMicrotask(() => {
+                if (response.kind === 'success') {
+                    successHandler?.(response.payload);
+                    return;
+                }
+
+                failureHandler?.(response.payload);
+            });
         },
     };
     return {
@@ -310,18 +309,7 @@ function createSequentialHarness(responses: RunnerHarnessResponse[]): {
     let successHandler: ((value: unknown) => void) | undefined;
     let failureHandler: ((error: unknown) => void) | undefined;
 
-    const apiHandlerSpy = vi.fn(() => {
-        const response = responses[Math.min(callCount, responses.length - 1)];
-        callCount++;
-
-        queueMicrotask(() => {
-            if (response.kind === 'success') {
-                successHandler?.(response.payload);
-                return;
-            }
-            failureHandler?.(response.payload);
-        });
-    });
+    const apiHandlerSpy = vi.fn();
 
     const runner: GoogleScriptRunWithApiHandler = {
         withSuccessHandler(handler: (responseValue: unknown) => void) {
@@ -332,8 +320,19 @@ function createSequentialHarness(responses: RunnerHarnessResponse[]): {
             failureHandler = handler;
             return runner;
         },
-        apiHandler() {
-            apiHandlerSpy();
+        apiHandler(request: unknown) {
+            apiHandlerSpy(request);
+
+            const response = responses[Math.min(callCount, responses.length - 1)];
+            callCount++;
+
+            queueMicrotask(() => {
+                if (response.kind === 'success') {
+                    successHandler?.(response.payload);
+                    return;
+                }
+                failureHandler?.(response.payload);
+            });
         },
     };
 

--- a/src/frontend/src/services/apiService.test.ts
+++ b/src/frontend/src/services/apiService.test.ts
@@ -87,8 +87,7 @@ function createGoogleScriptRunHarness(response: RunnerHarnessResponse): {
     let successHandler: ((value: unknown) => void) | undefined;
     let failureHandler: ((error: unknown) => void) | undefined;
 
-    const apiHandlerSpy = vi.fn((request: unknown) => {
-        Object.is(request, request);
+    const apiHandlerSpy = vi.fn(() => {
 
         queueMicrotask(() => {
             if (response.kind === 'success') {
@@ -118,8 +117,8 @@ function createGoogleScriptRunHarness(response: RunnerHarnessResponse): {
         /**
          * Dispatches the request into the harness spy.
          */
-        apiHandler(request: unknown) {
-            apiHandlerSpy(request);
+        apiHandler() {
+            apiHandlerSpy();
         },
     };
     return {
@@ -333,8 +332,8 @@ function createSequentialHarness(responses: RunnerHarnessResponse[]): {
             failureHandler = handler;
             return runner;
         },
-        apiHandler(request: unknown) {
-            apiHandlerSpy(request);
+        apiHandler() {
+            apiHandlerSpy();
         },
     };
 

--- a/tests/api/apiHandlerLocking.test.js
+++ b/tests/api/apiHandlerLocking.test.js
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const apiHandlerPath = '../../src/backend/Api/apiHandler.js';
-
-function loadApiHandlerModule() {
-  delete require.cache[require.resolve(apiHandlerPath)];
-  return require(apiHandlerPath);
-}
+const {
+  installLockServiceMock,
+  loadApiHandlerModule,
+  resetUserProperties,
+  restoreGlobal,
+  setAuthorisationStatusHandler,
+} = require('../helpers/apiHandlerTestUtils.js');
 
 describe('Api/apiHandler – atomicity and lock-protected tracking', () => {
   let mockLock;
@@ -13,32 +14,18 @@ describe('Api/apiHandler – atomicity and lock-protected tracking', () => {
   let originalLockService;
 
   beforeEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
+    resetUserProperties();
 
-    originalGetAuthorisationStatus = globalThis.getAuthorisationStatus;
-    globalThis.getAuthorisationStatus = vi.fn(() => ({ authorised: true }));
+    originalGetAuthorisationStatus = setAuthorisationStatusHandler(vi);
 
-    originalLockService = globalThis.LockService;
-    mockLock = { tryLock: vi.fn(() => true), releaseLock: vi.fn() };
-    globalThis.LockService = {
-      getUserLock: vi.fn(() => mockLock),
-    };
+    ({ originalLockService, mockLock } = installLockServiceMock(vi));
   });
 
   afterEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
+    resetUserProperties();
 
-    if (originalGetAuthorisationStatus === undefined) {
-      delete globalThis.getAuthorisationStatus;
-    } else {
-      globalThis.getAuthorisationStatus = originalGetAuthorisationStatus;
-    }
-
-    if (originalLockService === undefined) {
-      delete globalThis.LockService;
-    } else {
-      globalThis.LockService = originalLockService;
-    }
+    restoreGlobal('getAuthorisationStatus', originalGetAuthorisationStatus);
+    restoreGlobal('LockService', originalLockService);
 
     vi.restoreAllMocks();
   });

--- a/tests/api/apiHandlerTiming.test.js
+++ b/tests/api/apiHandlerTiming.test.js
@@ -1,16 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const apiHandlerPath = '../../src/backend/Api/apiHandler.js';
 const apiConstantsPath = '../../src/backend/Api/apiConstants.js';
 
-function loadApiHandlerModule() {
-  delete require.cache[require.resolve(apiHandlerPath)];
-  return require(apiHandlerPath);
-}
+const {
+  installAbLoggerSpies,
+  installLockServiceMock,
+  loadApiHandlerModule,
+  resetUserProperties,
+  restoreGlobal,
+  setAuthorisationStatusHandler,
+} = require('../helpers/apiHandlerTestUtils.js');
 
 describe('Api/apiHandler – lock timing observability and logging', () => {
   let mockLock;
-  let mockLoggerInstance;
   let infoSpy;
   let warnSpy;
   let originalABLogger;
@@ -18,53 +20,23 @@ describe('Api/apiHandler – lock timing observability and logging', () => {
   let originalGetAuthorisationStatus;
 
   beforeEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
+    resetUserProperties();
 
     vi.useFakeTimers();
 
-    originalABLogger = globalThis.ABLogger;
-    infoSpy = vi.fn();
-    warnSpy = vi.fn();
-    mockLoggerInstance = {
-      debug: () => {},
-      debugUi: () => {},
-      info: infoSpy,
-      warn: warnSpy,
-      error: () => {},
-      log: () => {},
-    };
-    globalThis.ABLogger = {
-      getInstance: () => mockLoggerInstance,
-    };
-
-    originalLockService = globalThis.LockService;
-    mockLock = { tryLock: vi.fn(() => true), releaseLock: vi.fn() };
-    globalThis.LockService = {
-      getUserLock: vi.fn(() => mockLock),
-    };
-
-    originalGetAuthorisationStatus = globalThis.getAuthorisationStatus;
-    globalThis.getAuthorisationStatus = vi.fn(() => ({ authorised: true }));
+    ({ originalABLogger, infoSpy, warnSpy } = installAbLoggerSpies(vi));
+    ({ originalLockService, mockLock } = installLockServiceMock(vi));
+    originalGetAuthorisationStatus = setAuthorisationStatusHandler(vi);
   });
 
   afterEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
+    resetUserProperties();
 
     vi.useRealTimers();
 
-    globalThis.ABLogger = originalABLogger;
-
-    if (originalLockService === undefined) {
-      delete globalThis.LockService;
-    } else {
-      globalThis.LockService = originalLockService;
-    }
-
-    if (originalGetAuthorisationStatus === undefined) {
-      delete globalThis.getAuthorisationStatus;
-    } else {
-      globalThis.getAuthorisationStatus = originalGetAuthorisationStatus;
-    }
+    restoreGlobal('ABLogger', originalABLogger);
+    restoreGlobal('LockService', originalLockService);
+    restoreGlobal('getAuthorisationStatus', originalGetAuthorisationStatus);
 
     vi.restoreAllMocks();
   });

--- a/tests/api/staleAdmission.test.js
+++ b/tests/api/staleAdmission.test.js
@@ -1,51 +1,56 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const apiHandlerPath = '../../src/backend/Api/apiHandler.js';
-
 const {
   ACTIVE_LIMIT,
   STALE_REQUEST_AGE_MS,
   USER_REQUEST_STORE_KEY,
 } = require('../../src/backend/Api/apiConstants.js');
 
-function loadApiHandlerModule() {
-  delete require.cache[require.resolve(apiHandlerPath)];
-  return require(apiHandlerPath);
+const {
+  installAbLoggerSpies,
+  loadApiHandlerModule,
+  resetUserProperties,
+  restoreGlobal,
+  setAuthorisationStatusHandler,
+} = require('../helpers/apiHandlerTestUtils.js');
+
+function buildStartedStore(count, prefix, startedAtMs) {
+  const store = {};
+  for (let index = 0; index < count; index++) {
+    const id = `${prefix}-${index}`;
+    store[id] = {
+      requestId: id,
+      method: 'getAuthorisationStatus',
+      status: 'started',
+      startedAtMs,
+    };
+  }
+  return store;
+}
+
+function persistStore(store) {
+  globalThis.PropertiesService.getUserProperties().setProperty(
+    USER_REQUEST_STORE_KEY,
+    JSON.stringify(store)
+  );
 }
 
 describe('Api/apiHandler – stale-entry pruning during admission', () => {
   let warnSpy;
-  let mockLoggerInstance;
   let originalABLogger;
+  let originalGetAuthorisationStatus;
 
   beforeEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
+    resetUserProperties();
 
-    // Replace the global ABLogger with a spy so tests can assert on warn calls.
-    originalABLogger = globalThis.ABLogger;
-    warnSpy = vi.fn();
-    mockLoggerInstance = {
-      debug: () => {},
-      debugUi: () => {},
-      info: () => {},
-      warn: warnSpy,
-      error: () => {},
-      log: () => {},
-    };
-    globalThis.ABLogger = {
-      getInstance: () => mockLoggerInstance,
-    };
-
-    globalThis.getAuthorisationStatus = vi.fn(() => ({ authorised: true }));
+    ({ originalABLogger, warnSpy } = installAbLoggerSpies(vi));
+    originalGetAuthorisationStatus = setAuthorisationStatusHandler(vi);
   });
 
   afterEach(() => {
-    globalThis.PropertiesService._resetUserProperties();
-    globalThis.ABLogger = originalABLogger;
-
-    if (globalThis.getAuthorisationStatus !== undefined) {
-      delete globalThis.getAuthorisationStatus;
-    }
+    resetUserProperties();
+    restoreGlobal('ABLogger', originalABLogger);
+    restoreGlobal('getAuthorisationStatus', originalGetAuthorisationStatus);
 
     vi.restoreAllMocks();
   });
@@ -55,20 +60,8 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
     // the staleness threshold.  After pruning they should no longer count, so
     // the new request should be admitted (not rate-limited).
     const staleTime = Date.now() - STALE_REQUEST_AGE_MS - 1000;
-    const store = {};
-    for (let i = 0; i < ACTIVE_LIMIT; i++) {
-      const id = `stale-seed-${i}`;
-      store[id] = {
-        requestId: id,
-        method: 'getAuthorisationStatus',
-        status: 'started',
-        startedAtMs: staleTime,
-      };
-    }
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    const store = buildStartedStore(ACTIVE_LIMIT, 'stale-seed', staleTime);
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();
@@ -87,20 +80,8 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
     // staleness window.  None should be pruned, so the new request must be
     // rate-limited.
     const recentTime = Date.now() - 1000;
-    const store = {};
-    for (let i = 0; i < ACTIVE_LIMIT; i++) {
-      const id = `recent-seed-${i}`;
-      store[id] = {
-        requestId: id,
-        method: 'getAuthorisationStatus',
-        status: 'started',
-        startedAtMs: recentTime,
-      };
-    }
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    const store = buildStartedStore(ACTIVE_LIMIT, 'recent-seed', recentTime);
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();
@@ -120,20 +101,8 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
   it('calls ABLogger.warn once for each stale entry that is pruned', () => {
     const staleTime = Date.now() - STALE_REQUEST_AGE_MS - 1000;
     const staleCount = 3;
-    const store = {};
-    for (let i = 0; i < staleCount; i++) {
-      const id = `stale-warn-${i}`;
-      store[id] = {
-        requestId: id,
-        method: 'getAuthorisationStatus',
-        status: 'started',
-        startedAtMs: staleTime,
-      };
-    }
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    const store = buildStartedStore(staleCount, 'stale-warn', staleTime);
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();
@@ -170,10 +139,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
       };
     }
 
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();
@@ -216,10 +182,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
       };
     }
 
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();
@@ -249,10 +212,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
         startedAtMs: staleTime,
       };
     }
-    globalThis.PropertiesService.getUserProperties().setProperty(
-      USER_REQUEST_STORE_KEY,
-      JSON.stringify(store)
-    );
+    persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
     const dispatcher = ApiDispatcher.getInstance();

--- a/tests/api/staleAdmission.test.js
+++ b/tests/api/staleAdmission.test.js
@@ -14,13 +14,13 @@ const {
   setAuthorisationStatusHandler,
 } = require('../helpers/apiHandlerTestUtils.js');
 
-function buildStartedStore(count, prefix, startedAtMs) {
+function buildStartedStore(count, prefix, startedAtMs, method) {
   const store = {};
   for (let index = 0; index < count; index++) {
     const id = `${prefix}-${index}`;
     store[id] = {
       requestId: id,
-      method: 'getAuthorisationStatus',
+      method,
       status: 'started',
       startedAtMs,
     };
@@ -60,7 +60,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
     // the staleness threshold.  After pruning they should no longer count, so
     // the new request should be admitted (not rate-limited).
     const staleTime = Date.now() - STALE_REQUEST_AGE_MS - 1000;
-    const store = buildStartedStore(ACTIVE_LIMIT, 'stale-seed', staleTime);
+    const store = buildStartedStore(ACTIVE_LIMIT, 'stale-seed', staleTime, 'getAuthorisationStatus');
     persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
@@ -80,7 +80,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
     // staleness window.  None should be pruned, so the new request must be
     // rate-limited.
     const recentTime = Date.now() - 1000;
-    const store = buildStartedStore(ACTIVE_LIMIT, 'recent-seed', recentTime);
+    const store = buildStartedStore(ACTIVE_LIMIT, 'recent-seed', recentTime, 'getAuthorisationStatus');
     persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();
@@ -101,7 +101,7 @@ describe('Api/apiHandler – stale-entry pruning during admission', () => {
   it('calls ABLogger.warn once for each stale entry that is pruned', () => {
     const staleTime = Date.now() - STALE_REQUEST_AGE_MS - 1000;
     const staleCount = 3;
-    const store = buildStartedStore(staleCount, 'stale-warn', staleTime);
+    const store = buildStartedStore(staleCount, 'stale-warn', staleTime, 'getAuthorisationStatus');
     persistStore(store);
 
     const { ApiDispatcher } = loadApiHandlerModule();

--- a/tests/helpers/apiHandlerTestUtils.js
+++ b/tests/helpers/apiHandlerTestUtils.js
@@ -1,0 +1,60 @@
+const apiHandlerPath = '../../src/backend/Api/apiHandler.js';
+
+function loadApiHandlerModule() {
+  delete require.cache[require.resolve(apiHandlerPath)];
+  return require(apiHandlerPath);
+}
+
+function resetUserProperties() {
+  globalThis.PropertiesService._resetUserProperties();
+}
+
+function setAuthorisationStatusHandler(vi, handler = () => ({ authorised: true })) {
+  const originalGetAuthorisationStatus = globalThis.getAuthorisationStatus;
+  globalThis.getAuthorisationStatus = vi.fn(handler);
+  return originalGetAuthorisationStatus;
+}
+
+function restoreGlobal(globalKey, originalValue) {
+  if (originalValue === undefined) {
+    delete globalThis[globalKey];
+    return;
+  }
+  globalThis[globalKey] = originalValue;
+}
+
+function installLockServiceMock(vi) {
+  const originalLockService = globalThis.LockService;
+  const mockLock = { tryLock: vi.fn(() => true), releaseLock: vi.fn() };
+  globalThis.LockService = {
+    getUserLock: vi.fn(() => mockLock),
+  };
+  return { originalLockService, mockLock };
+}
+
+function installAbLoggerSpies(vi) {
+  const originalABLogger = globalThis.ABLogger;
+  const infoSpy = vi.fn();
+  const warnSpy = vi.fn();
+  const mockLoggerInstance = {
+    debug: () => {},
+    debugUi: () => {},
+    info: infoSpy,
+    warn: warnSpy,
+    error: () => {},
+    log: () => {},
+  };
+  globalThis.ABLogger = {
+    getInstance: () => mockLoggerInstance,
+  };
+  return { originalABLogger, infoSpy, warnSpy };
+}
+
+module.exports = {
+  loadApiHandlerModule,
+  resetUserProperties,
+  setAuthorisationStatusHandler,
+  restoreGlobal,
+  installLockServiceMock,
+  installAbLoggerSpies,
+};


### PR DESCRIPTION
### Motivation
- Consolidate repeated test setup/teardown logic for API handler tests to reduce duplication and improve clarity.
- Make the `google.script.run` harness simpler and less coupled to the passed request argument in unit tests.
- Remove an unnecessary compatibility patch for React 19 usage of Ant Design and its import from the app entrypoint.

### Description
- Add `tests/helpers/apiHandlerTestUtils.js` which centralizes test utilities including `loadApiHandlerModule`, `resetUserProperties`, `setAuthorisationStatusHandler`, `restoreGlobal`, `installLockServiceMock`, and `installAbLoggerSpies`.
- Update tests (`tests/api/*.test.js`) to use the new helpers and replace duplicated setup code with calls to `resetUserProperties`, `installLockServiceMock`, `installAbLoggerSpies`, `setAuthorisationStatusHandler`, and `restoreGlobal`.
- Simplify the `google.script.run` harness in `src/frontend/src/services/apiService.test.ts` by removing the unused `request` parameter from the `apiHandlerSpy` and `apiHandler` call sites.
- Remove the `@ant-design/v5-patch-for-react-19` dependency from `src/frontend/package.json`/`package-lock.json` and delete its import from `src/frontend/src/main.tsx`.
- Minor whitespace adjustment in `TriggerController.js`.

### Testing
- Ran the frontend unit tests with `vitest run` and the modified API handler tests under `tests/api/`, which completed successfully.
- Verified the `apiService` unit tests that use the `google.script.run` harness ran via `vitest run` and passed after the harness simplification.
- Installed and exercised the new test helpers by executing the full test suite with `npm test` (`vitest`) and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab71f769988329b7f06b78188b7654)