### PR TITLE
Document Zod validation and type-definition standard for builder and frontend

### DIFF
--- a/scripts/builder/AGENTS.md
+++ b/scripts/builder/AGENTS.md
@@ -61,3 +61,9 @@ Key outputs:
 
 - Before changing TS/ESLint config, read `docs/developer/builder/TypeScriptAndLintConfigHierarchy.md`.
 - Delegate test implementation work to `Testing Specialist`.
+
+## 8. Validation and Type Definition Standard
+
+- Use **Zod** as the validation framework for all new and updated builder validation logic.
+- Define the Zod schema first, then derive TypeScript types from that schema using `z.infer<typeof ...>` to avoid duplicated type declarations.
+- Store validation schemas in a dedicated adjacent schema file (for example `*.zod.ts` or `zodSchemas.ts`) near the code consuming them.

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -74,3 +74,9 @@ Frontend build output is consumed by the GAS builder pipeline.
 
 - Before changing TS/ESLint config, read `docs/developer/builder/TypeScriptAndLintConfigHierarchy.md`.
 - Delegate test implementation work to `Testing Specialist`.
+
+## 8. Validation and Type Definition Standard
+
+- Use **Zod** as the validation framework for all new and updated frontend validation logic.
+- Define the Zod schema first, then derive TypeScript types from that schema using `z.infer<typeof ...>` to avoid duplicated type declarations.
+- Store validation schemas in a dedicated adjacent schema file (for example `*.zod.ts` or `zodSchemas.ts`) near the code consuming them.


### PR DESCRIPTION
### Motivation
- Establish a consistent validation and TypeScript type-definition pattern across the builder and frontend documentation by standardizing on Zod schemas, deriving types with `z.infer`, and colocating schemas next to consuming code.

### Description
- Add `## 8. Validation and Type Definition Standard` to `scripts/builder/AGENTS.md` and `src/frontend/AGENTS.md` that mandates using **Zod** for validation, defining the Zod schema first and deriving types via `z.infer<typeof ...>`, and storing schemas in adjacent files such as `*.zod.ts` or `zodSchemas.ts`.

### Testing
- This is a documentation-only change so no automated tests were added or modified and the change does not affect existing CI or test configurations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf4c300d88329a953fdd808de2d52)