### PR TITLE
Route frontend logs to console endpoints, remove in-memory sink, and update docs/tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,15 @@ Before changing any TypeScript or ESLint configuration, read:
 
 Keep shared standards in shared/root config and runtime-specific behaviour in leaf configs.
 
+### 5.1 Policy source-of-truth signposts
+
+To avoid policy drift, keep detailed policy in dedicated docs and use AGENTS files as routing signposts only:
+
+- Frontend logging and error-handling policy: `docs/developer/frontend/frontend-logging-and-error-handling.md`
+- Frontend testing policy and commands: `docs/developer/frontend/frontend-testing.md`
+
+If guidance appears in multiple places, update the canonical doc first, then keep AGENTS references brief and consistent.
+
 ### 6. Agentic Workflow for Non-Trivial Changes
 
 For non-trivial code changes (multi-file logic changes, behavioural changes, refactors, or risky fixes), follow this mandatory loop:

--- a/docs/developer/frontend/frontend-logging-and-error-handling.md
+++ b/docs/developer/frontend/frontend-logging-and-error-handling.md
@@ -46,7 +46,7 @@ Recommended flow:
 
 ## 3. Logging policy by environment
 
-Use one logger abstraction for all frontend code. Direct `console.*` calls are not permitted in feature/service/component code; confine browser console emission to the logger module.
+Use one logger abstraction for all frontend code. Direct `console.*` calls are not permitted in feature/service/component code; confine browser console emission to the logger module. Frontend ESLint configuration enforces this boundary by disallowing `console` usage outside `src/frontend/src/logging/frontendLogger.ts`.
 
 ### Development logging (local + dev builder mode)
 

--- a/docs/developer/frontend/frontend-logging-and-error-handling.md
+++ b/docs/developer/frontend/frontend-logging-and-error-handling.md
@@ -2,6 +2,8 @@
 
 This document defines practical standards for frontend debugging, production logging, and user-facing error handling in `src/frontend`.
 
+This is the canonical policy document for frontend logging and frontend error handling. AGENTS files should point here rather than restating policy details.
+
 Use this guide alongside:
 
 - `src/frontend/AGENTS.md`
@@ -44,7 +46,7 @@ Recommended flow:
 
 ## 3. Logging policy by environment
 
-Use one logger abstraction for all frontend code. Direct `console.*` calls are not permitted anywhere in frontend source.
+Use one logger abstraction for all frontend code. Direct `console.*` calls are not permitted in feature/service/component code; confine browser console emission to the logger module.
 
 ### Development logging (local + dev builder mode)
 
@@ -87,7 +89,7 @@ To keep logs both useful and safe, apply these baseline rules in all environment
 
 Keep redaction and normalisation in shared logger utilities (for example `src/frontend/src/logging/`) rather than duplicating checks in each feature.
 
-For test code, prefer exported logger helpers (`getFrontendLogBuffer()`, `clearFrontendLogBuffer()`) instead of directly reading internal global buffer keys.
+For test code, prefer `vi.spyOn(console, '<level>')` assertions over implementation-specific internals.
 
 ## 4. User feedback policy (Ant Design)
 

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -73,7 +73,7 @@ For frontend logging, error mapping, and environment-specific diagnostics policy
 
 - `docs/developer/frontend/frontend-logging-and-error-handling.md`
 
-When tests cover logging/error pathways, keep expectations aligned with that document (for example stack-trace gating by environment and redaction behaviour).
+When tests cover logging/error pathways, keep expectations aligned with that document (for example stack-trace gating by environment and redaction behaviour). Treat that logging/error document as canonical and avoid duplicating policy text here.
 
 ## Coverage requirement
 
@@ -83,7 +83,7 @@ Frontend unit/component tests must meet a minimum coverage threshold of **85%** 
 
 Use shared helpers to keep fixtures and mocks consistent and avoid duplicate test setup code.
 
-**Important:** for frontend logging assertions, use logger helper APIs rather than reading magic globals directly. Prefer `getFrontendLogBuffer()` and `clearFrontendLogBuffer()` from `src/frontend/src/logging/frontendLogger.ts` in tests, so logging tests stay resilient if buffer internals change.
+**Important:** for frontend logging assertions, spy on browser console endpoints (`console.debug/info/warn/error`) rather than reading implementation-specific globals.
 
 - Frontend runtime setup helper: `src/frontend/src/test/setup.ts` (Testing Library + jest-dom integration).
 - Builder JsonDb source fixture helpers: `scripts/builder/src/test/jsondb-source-test-helpers.ts` (shared by JsonDb source builder specs to build release archives, create path fixtures, and write release files/manifests).

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -52,7 +52,8 @@ Root scripts execute frontend tasks via `npm --prefix src/frontend ...`.
 ## 5. Error Handling and Quality
 
 - Fail loudly in development; do not hide failures behind broad catch-and-ignore logic.
-- When implementing or refactoring frontend logging/error handling, read `docs/developer/frontend/frontend-logging-and-error-handling.md` first and treat it as the canonical policy source.
+- When implementing or refactoring frontend logging/error handling, read `docs/developer/frontend/frontend-logging-and-error-handling.md` first and treat it as the single source of truth.
+- Keep this AGENTS file as a signpost only; do not duplicate detailed logging policy here.
 - Never implement or fall back to defaults unless explicitly instructed to do so.
 - Keep component state and side effects predictable and testable.
 

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -41,6 +41,22 @@ export default defineConfig([
       'unicorn/prevent-abbreviations': 'off',
       'unicorn/no-keyword-prefix': 'off',
       'unicorn/filename-case': 'off',
+      'no-console': 'error',
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'globalThis',
+          property: 'console',
+          message: 'Use the frontend logger module as the only browser console emission boundary.',
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/logging/frontendLogger.ts'],
+    rules: {
+      'no-console': 'off',
+      'no-restricted-properties': 'off',
     },
   },
   {

--- a/src/frontend/src/logging/frontendLogger.spec.ts
+++ b/src/frontend/src/logging/frontendLogger.spec.ts
@@ -1,20 +1,24 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import {
   logFrontendError,
   logFrontendEvent,
 } from './frontendLogger';
 
 describe('frontendLogger', () => {
-  const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-  const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  let debugSpy: MockInstance;
+  let infoSpy: MockInstance;
+  let warnSpy: MockInstance;
+  let errorSpy: MockInstance;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    debugSpy.mockClear();
-    infoSpy.mockClear();
-    warnSpy.mockClear();
-    errorSpy.mockClear();
+    vi.restoreAllMocks();
   });
 
   it('redacts sensitive metadata fields before writing to the console endpoint', () => {

--- a/src/frontend/src/logging/frontendLogger.spec.ts
+++ b/src/frontend/src/logging/frontendLogger.spec.ts
@@ -2,23 +2,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   logFrontendError,
   logFrontendEvent,
-  clearFrontendLogBuffer,
-  getFrontendLogBuffer,
-  resetFrontendLogSink,
-  setFrontendLogSink,
-  type FrontendLogEntry,
 } from './frontendLogger';
 
 describe('frontendLogger', () => {
+  const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
   afterEach(() => {
-    resetFrontendLogSink();
-    clearFrontendLogBuffer();
+    debugSpy.mockClear();
+    infoSpy.mockClear();
+    warnSpy.mockClear();
+    errorSpy.mockClear();
   });
 
-  it('redacts sensitive metadata fields before writing to the sink', () => {
+  it('redacts sensitive metadata fields before writing to the console endpoint', () => {
     const nestedSensitiveKey = 'secret';
-    const sink = vi.fn<(entry: FrontendLogEntry) => void>();
-    setFrontendLogSink(sink);
 
     logFrontendEvent('info', {
       context: 'test/logger',
@@ -30,8 +30,8 @@ describe('frontendLogger', () => {
       },
     });
 
-    expect(sink).toHaveBeenCalledTimes(1);
-    const [entry] = sink.mock.calls[0];
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const [, entry] = infoSpy.mock.calls[0];
     expect(entry.metadata).toEqual({
       token: '[REDACTED]',
       nested: {
@@ -40,10 +40,7 @@ describe('frontendLogger', () => {
     });
   });
 
-
-  it('buffers log entries in the default global sink', () => {
-    resetFrontendLogSink();
-
+  it('writes warning events to the console warning endpoint', () => {
     logFrontendEvent(
       'warn',
       {
@@ -53,23 +50,18 @@ describe('frontendLogger', () => {
       { includeStack: false }
     );
 
-    const bufferedEntries = getFrontendLogBuffer();
-
-    expect(bufferedEntries).toBeDefined();
-    expect(bufferedEntries).toContainEqual(
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [, entry] = warnSpy.mock.calls[0];
+    expect(entry).toEqual(
       expect.objectContaining({
         context: 'test/default-sink',
         errorMessage: 'Buffered warning',
+        level: 'warn',
       })
     );
   });
 
-
-
   it('drops debug and info logs when running in production mode', () => {
-    clearFrontendLogBuffer();
-    resetFrontendLogSink();
-
     logFrontendEvent(
       'debug',
       { context: 'test/debug', errorMessage: 'Hidden' },
@@ -86,20 +78,19 @@ describe('frontendLogger', () => {
       { includeStack: false, isDevelopmentRuntime: false }
     );
 
-    const bufferedEntries = getFrontendLogBuffer();
-    expect(bufferedEntries).toHaveLength(1);
-    expect(bufferedEntries[0]?.context).toBe('test/warn');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [, entry] = warnSpy.mock.calls[0];
+    expect(entry.context).toBe('test/warn');
   });
 
-
   it('suppresses stack traces when includeStack is false', () => {
-    const sink = vi.fn<(entry: FrontendLogEntry) => void>();
-    setFrontendLogSink(sink);
-
     const error = new Error('Operation failed.');
     logFrontendError('test/logger', error, undefined, { includeStack: false });
 
-    const [entry] = sink.mock.calls[0];
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, entry] = errorSpy.mock.calls[0];
     expect(entry.stack).toBeUndefined();
     expect(entry.errorMessage).toBe('Operation failed.');
   });

--- a/src/frontend/src/logging/frontendLogger.ts
+++ b/src/frontend/src/logging/frontendLogger.ts
@@ -16,8 +16,6 @@ export type FrontendLogEntry = FrontendLogPayload & {
   timestamp: string;
 };
 
-type FrontendLogSink = (entry: FrontendLogEntry) => void;
-
 type FrontendLogOptions = {
   includeStack?: boolean;
   isDevelopmentRuntime?: boolean;
@@ -26,58 +24,6 @@ type FrontendLogOptions = {
 const SENSITIVE_FIELD_NAMES = new Set(['token', 'secret', 'password', 'authorisation', 'authorization', 'email']);
 const REDACTED_VALUE = '[REDACTED]';
 const MAX_SERIALISED_METADATA_LENGTH = 2000;
-
-const LOG_BUFFER_GLOBAL_KEY = '__ASSESSMENT_BOT_FRONTEND_LOG_BUFFER__';
-const MAX_BUFFERED_LOG_ENTRIES = 200;
-
-type FrontendLogBufferHost = {
-  [LOG_BUFFER_GLOBAL_KEY]?: FrontendLogEntry[];
-};
-
-/**
- * Writes frontend logs to an in-memory global buffer for diagnostics.
- */
-function writeToGlobalLogBuffer(entry: FrontendLogEntry): void {
-  const host = globalThis as FrontendLogBufferHost;
-  const existingBuffer = host[LOG_BUFFER_GLOBAL_KEY] ?? [];
-  existingBuffer.push(entry);
-  if (existingBuffer.length > MAX_BUFFERED_LOG_ENTRIES) {
-    existingBuffer.splice(0, existingBuffer.length - MAX_BUFFERED_LOG_ENTRIES);
-  }
-  host[LOG_BUFFER_GLOBAL_KEY] = existingBuffer;
-}
-
-let logSink: FrontendLogSink = writeToGlobalLogBuffer;
-
-/**
- * Registers a sink for structured frontend log entries.
- */
-export function setFrontendLogSink(sink: FrontendLogSink): void {
-  logSink = sink;
-}
-
-/**
- * Restores the default in-memory sink.
- */
-export function resetFrontendLogSink(): void {
-  logSink = writeToGlobalLogBuffer;
-}
-
-/**
- * Returns a snapshot of buffered frontend log entries from the default sink.
- */
-export function getFrontendLogBuffer(): FrontendLogEntry[] {
-  const host = globalThis as FrontendLogBufferHost;
-  return [...(host[LOG_BUFFER_GLOBAL_KEY] ?? [])];
-}
-
-/**
- * Clears buffered frontend log entries from the default sink.
- */
-export function clearFrontendLogBuffer(): void {
-  const host = globalThis as FrontendLogBufferHost;
-  delete host[LOG_BUFFER_GLOBAL_KEY];
-}
 
 /**
  * Returns true when a metadata key should be redacted.
@@ -125,7 +71,7 @@ function redactValue(value: unknown): unknown {
 }
 
 /**
- * Sanitises metadata before emitting to the active sink.
+ * Sanitises metadata before emitting to the console endpoint.
  */
 function sanitiseMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!metadata) {
@@ -160,8 +106,22 @@ function isLevelEnabled(level: FrontendLogLevel, options: FrontendLogOptions | u
   return level === 'warn' || level === 'error';
 }
 
+const consoleMethodByLevel: Record<FrontendLogLevel, (message?: unknown, ...optionalParams: unknown[]) => void> = {
+  debug: (...args) => globalThis.console.debug(...args),
+  info: (...args) => globalThis.console.info(...args),
+  warn: (...args) => globalThis.console.warn(...args),
+  error: (...args) => globalThis.console.error(...args),
+};
+
 /**
- * Writes a structured frontend log event to the active sink.
+ * Emits a log entry to the browser console using a level-matched endpoint.
+ */
+function writeToConsole(entry: FrontendLogEntry): void {
+  consoleMethodByLevel[entry.level](entry.context, entry);
+}
+
+/**
+ * Writes a structured frontend log event to the console endpoint.
  */
 export function logFrontendEvent(
   level: FrontendLogLevel,
@@ -173,14 +133,15 @@ export function logFrontendEvent(
   }
 
   const stack = shouldIncludeStack(options) ? payload.stack : undefined;
-
-  logSink({
+  const entry: FrontendLogEntry = {
     ...payload,
     stack,
     metadata: sanitiseMetadata(payload.metadata),
     level,
     timestamp: new Date().toISOString(),
-  });
+  };
+
+  writeToConsole(entry);
 }
 
 /**


### PR DESCRIPTION
### Motivation

- Consolidate frontend logging behaviour by treating the logger module as the single console emission boundary instead of an in-memory global buffer sink.
- Make AGENTS and frontend testing docs point at the canonical logging policy and avoid duplicated policy text across signposts and implementation files.

### Description

- Replaced the buffered global log sink with direct browser console emission by adding `writeToConsole` and `consoleMethodByLevel` and removing the in-memory buffer and sink APIs (`setFrontendLogSink`, `resetFrontendLogSink`, `getFrontendLogBuffer`, `clearFrontendLogBuffer`, and `FrontendLogSink`).
- Updated `logFrontendEvent` to construct a `FrontendLogEntry` and call the console endpoint mapped to the log `level` instead of writing to a global buffer.
- Updated `frontendLogger.spec.ts` tests to spy on `console.debug/info/warn/error` and assert console calls and payload shapes rather than inspecting a global buffer or custom sink.
- Clarified documentation: added a "Policy source-of-truth signposts" section to `AGENTS.md`, designated `docs/developer/frontend/frontend-logging-and-error-handling.md` as the canonical logging policy, and amended `frontend-testing.md` and `src/frontend/AGENTS.md` to instruct tests to use console spies and treat the logging doc as the single source of truth.

### Testing

- Ran the frontend unit tests for logging using Vitest via `npm run frontend:test` and the updated `src/frontend/src/logging/frontendLogger.spec.ts` passed.
- Ran the affected frontend test suite (unit tests) and no regressions were observed in the modified specs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad2baf58e08329b7821cdfa6265e66)