### PR TITLE
Add agent frontmatter and switch Copilot examples to object-shaped `runSubagent` calls

### DIFF
--- a/.github/agents/Testing.agent.md
+++ b/.github/agents/Testing.agent.md
@@ -1,5 +1,7 @@
 ---
+name: 'Testing Specialist'
 description: 'Creates, runs and debugs tests'
+infer: true
 tools: ['vscode/getProjectSetupInfo', 'vscode/openSimpleBrowser', 'vscode/runCommand', 'execute', 'read/terminalSelection', 'read/terminalLastCommand', 'read/getTaskOutput', 'read/problems', 'read/readFile', 'edit/createDirectory', 'edit/createFile', 'edit/createJupyterNotebook', 'edit/editFiles', 'search', 'todo', 'sonarsource.sonarlint-vscode/sonarqube_getPotentialSecurityIssues', 'sonarsource.sonarlint-vscode/sonarqube_excludeFiles', 'sonarsource.sonarlint-vscode/sonarqube_setUpConnectedMode', 'sonarsource.sonarlint-vscode/sonarqube_analyzeFile']
 ---
 

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -1,5 +1,7 @@
 ---
+name: 'Code Reviewer'
 description: 'Reviews code for quality, standards adherence, and bugs'
+infer: true
 tools: ['read/problems', 'read/readFile', 'read/file_search', 'read/list_dir', 'execute/run_in_terminal', 'search/search', 'vscode/get_changed_files', 'sonarsource.sonarlint-vscode/sonarqube_analyzeFile', 'sonarsource.sonarlint-vscode/sonarqube_list_potential_security_issues']
 ---
 

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -1,5 +1,7 @@
 ---
+name: 'Docs'
 description: 'Reviews changed code and updates developer documentation, AGENTS guidance, and JSDoc accuracy'
+infer: true
 tools: ['read/problems', 'read/readFile', 'read/file_search', 'read/list_dir', 'execute/run_in_terminal', 'search/search', 'vscode/get_changed_files', 'edit/editFiles', 'edit/createFile']
 ---
 

--- a/.github/agents/implementation.agent.md
+++ b/.github/agents/implementation.agent.md
@@ -1,5 +1,7 @@
 ---
+name: 'Implementation'
 description: 'Implements code for the orchestrator'
+infer: true
 tools: ['read/problems', 'read/readFile', 'read/file_search', 'read/list_dir', 'execute/run_in_terminal', 'search/search', 'vscode/get_changed_files', 'edit/editFiles', 'edit/createFile']
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,35 @@ Sub-agents are stateless. Provide explicit context in prompts:
 
 Copilot environment:
 
-- Use `runSubagent` and pass full context in the `prompt` body.
+- Use `runSubagent` with an object argument and pass full context in the `prompt` body.
 - Include: files read, constraints, exact requested outcome, and expected deliverables.
-- Example pattern:
-  - `runSubagent(agent: "Testing Specialist", prompt: "<context + requirements + changed files>")`
+- Example patterns:
+
+```javascript
+// For source code review
+runSubagent({
+  prompt:
+    'Please review the updated AssignmentService for lint compliance, DRY, SOLID, and documentation quality.',
+  description: 'Code review for AssignmentService changes',
+  agentName: 'Code Reviewer',
+});
+
+// For test implementation and debugging
+runSubagent({
+  prompt:
+    'Please implement and debug tests for SubmissionRepository edge cases, then run the relevant test command.',
+  description: 'Test work for SubmissionRepository',
+  agentName: 'Testing Specialist',
+});
+
+// For focused implementation
+runSubagent({
+  prompt:
+    'Please implement the requested builder manifest merge fix with minimal scope and run the relevant lint/tests.',
+  description: 'Implementation for builder manifest merge fix',
+  agentName: 'Implementation',
+});
+```
 
 Codex environment:
 


### PR DESCRIPTION
### Motivation
- Ensure GitHub agent files expose explicit metadata so tooling can reliably identify each agent and enable inference. 
- Make the root `AGENTS.md` Copilot invocation guidance match the object-shaped `runSubagent({...})` pattern used in other projects and provide concrete, repo-specific examples.

### Description
- Added `name` and `infer: true` front matter to the agent definitions in `.github/agents` for `Implementation`, `Code Reviewer`, `Testing Specialist`, and `Docs`. 
- Replaced the single-line `runSubagent` sample in `AGENTS.md` with multiple object-shaped examples using this repo's agents (`Code Reviewer`, `Testing Specialist`, `Implementation`).
- Changes are localised to `.github/agents/implementation.agent.md`, `.github/agents/code-reviewer.agent.md`, `.github/agents/Testing.agent.md`, `.github/agents/docs.agent.md`, and `AGENTS.md`.

### Testing
- Ran `git diff --check` to validate whitespace and diff-style issues and observed no problems. 
- A pre-commit lint step attempted to run `npm run lint` (ESLint) and failed in this environment due to a missing dependency (`eslint-plugin-unicorn`). 
- The file updates themselves are textual/markdown-only and were validated by inspecting the changed front matter and the updated `runSubagent` examples.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5d65a5288329a2ce35363fb282cd)