### PR TITLE
Accept plain class-like objects for persistence and add validation to `saveClass`

### DIFF
--- a/src/backend/y_controllers/ABClassController.js
+++ b/src/backend/y_controllers/ABClassController.js
@@ -148,7 +148,7 @@ class ABClassController {
   /**
    * Upserts the class partial document to the abclass_partials collection.
    * @param {ABClass|Object} abClass - An ABClass instance or plain object with
-   *   a `classId` property and a `toPartialJSON()` method. - The class instance with toPartialJSON() support
+   *   a `classId` property and a `toPartialJSON()` method.
    * @throws {Error} Rethrows any persistence error.
    * @private
    */
@@ -227,7 +227,7 @@ class ABClassController {
    * Persist an assignment run by writing full payload to dedicated collection
    * and updating the ABClass with a partial summary.
    * @param {ABClass|Object} abClass - An ABClass instance or plain object with
-   *   a `classId` property and a `toPartialJSON()` method. - The ABClass instance containing the assignment
+   *   a `classId` property and a `toPartialJSON()` method.
    * @param {Assignment} assignment - The assignment to persist
    * @return {void}
    */
@@ -240,6 +240,27 @@ class ABClassController {
 
     if (!assignment.courseId || !assignment.assignmentId) {
       throw new TypeError('Assignment must have courseId and assignmentId');
+    }
+
+    if (typeof abClass.classId !== 'string' || abClass.classId.trim().length === 0) {
+      throw new TypeError(
+        'persistAssignmentRun: expected abClass.classId to be a non-empty string'
+      );
+    }
+
+    if (typeof assignment.courseId !== 'string' || assignment.courseId.trim().length === 0) {
+      throw new TypeError(
+        'persistAssignmentRun: expected assignment.courseId to be a non-empty string'
+      );
+    }
+
+    if (
+      typeof assignment.assignmentId !== 'string' ||
+      assignment.assignmentId.trim().length === 0
+    ) {
+      throw new TypeError(
+        'persistAssignmentRun: expected assignment.assignmentId to be a non-empty string'
+      );
     }
 
     try {
@@ -318,7 +339,7 @@ class ABClassController {
   /**
    * Rehydrate an assignment by loading the full version from its dedicated collection.
    * @param {ABClass|Object} abClass - An ABClass instance or plain object with
-   *   a `classId` property and a `toPartialJSON()` method. - The ABClass instance
+   *   a `classId` property and a `toPartialJSON()` method.
    * @param {string} assignmentId - The assignment ID to rehydrate
    * @return {Assignment} The fully hydrated assignment instance
    */
@@ -327,6 +348,14 @@ class ABClassController {
 
     if (!abClass || !assignmentId) {
       throw new TypeError('rehydrateAssignment requires abClass and assignmentId');
+    }
+
+    if (typeof abClass.classId !== 'string' || abClass.classId.trim().length === 0) {
+      throw new TypeError('rehydrateAssignment: expected abClass.classId to be a non-empty string');
+    }
+
+    if (typeof assignmentId !== 'string' || assignmentId.trim().length === 0) {
+      throw new TypeError('rehydrateAssignment: expected assignmentId to be a non-empty string');
     }
 
     const courseId = abClass.classId;
@@ -607,6 +636,14 @@ class ABClassController {
 
     if (!Object.prototype.hasOwnProperty.call(abClass, 'classId')) {
       throw new TypeError('saveClass: missing required classId property on abClass argument');
+    }
+
+    if (typeof abClass.classId !== 'string' || abClass.classId.trim().length === 0) {
+      throw new TypeError('saveClass: expected abClass.classId to be a non-empty string');
+    }
+
+    if (abClass.classId.includes('..') || abClass.classId.includes('/')) {
+      throw new TypeError('saveClass: invalid classId format');
     }
 
     if (typeof abClass.toPartialJSON !== 'function') {

--- a/src/backend/y_controllers/ABClassController.js
+++ b/src/backend/y_controllers/ABClassController.js
@@ -147,7 +147,8 @@ class ABClassController {
 
   /**
    * Upserts the class partial document to the abclass_partials collection.
-   * @param {ABClass} abClass - The class instance with toPartialJSON() support
+   * @param {ABClass|Object} abClass - An ABClass instance or plain object with
+   *   a `classId` property and a `toPartialJSON()` method. - The class instance with toPartialJSON() support
    * @throws {Error} Rethrows any persistence error.
    * @private
    */
@@ -225,7 +226,8 @@ class ABClassController {
   /**
    * Persist an assignment run by writing full payload to dedicated collection
    * and updating the ABClass with a partial summary.
-   * @param {ABClass} abClass - The ABClass instance containing the assignment
+   * @param {ABClass|Object} abClass - An ABClass instance or plain object with
+   *   a `classId` property and a `toPartialJSON()` method. - The ABClass instance containing the assignment
    * @param {Assignment} assignment - The assignment to persist
    * @return {void}
    */
@@ -315,7 +317,8 @@ class ABClassController {
 
   /**
    * Rehydrate an assignment by loading the full version from its dedicated collection.
-   * @param {ABClass} abClass - The ABClass instance
+   * @param {ABClass|Object} abClass - An ABClass instance or plain object with
+   *   a `classId` property and a `toPartialJSON()` method. - The ABClass instance
    * @param {string} assignmentId - The assignment ID to rehydrate
    * @return {Assignment} The fully hydrated assignment instance
    */
@@ -428,7 +431,8 @@ class ABClassController {
 
   /**
    * Replace assignment in ABClass assignments array.
-   * @param {ABClass} abClass
+   * @param {ABClass|Object} abClass - An ABClass instance or plain object with
+   *   a `classId` property and a `toPartialJSON()` method.
    * @param {string} assignmentId
    * @param {Assignment} hydratedAssignment
    * @private
@@ -585,14 +589,32 @@ class ABClassController {
   }
 
   /**
-   * Save an ABClass instance to its collection named by classId.
+   * Save a class representation to its collection named by classId.
    * Delegates to _persistClassAndPartial for write-through persistence.
    * Returns true on success.
    *
-   * @param {ABClass} abClass
+   * @param {ABClass|Object} abClass - An ABClass instance or plain object with
+   *   a `classId` property and a `toPartialJSON()` method.
    * @returns {boolean}
+   * @throws {TypeError} If abClass is missing required properties or methods.
    */
   saveClass(abClass) {
+    if (!abClass || typeof abClass !== 'object') {
+      throw new TypeError(
+        'saveClass: expected an ABClass instance or plain object with classId and toPartialJSON()'
+      );
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(abClass, 'classId')) {
+      throw new TypeError('saveClass: missing required classId property on abClass argument');
+    }
+
+    if (typeof abClass.toPartialJSON !== 'function') {
+      throw new TypeError(
+        'saveClass: expected abClass.toPartialJSON() to be a function for partial persistence'
+      );
+    }
+
     this._persistClassAndPartial(abClass);
     return true;
   }

--- a/tests/controllers/abclassController.persistAssignment.test.js
+++ b/tests/controllers/abclassController.persistAssignment.test.js
@@ -388,5 +388,21 @@ describe('ABClassController Persist Assignment', () => {
       expect(abClass.assignments).toHaveLength(1);
       expect(abClass.assignments[0].assignmentId).toBe('assign-new');
     });
+
+    it('throws when abClass.classId is not a non-empty string', () => {
+      const controller = new ABClassController();
+      const { assignment } = createTestFixture({
+        ABClass,
+        courseId: 'course-invalid-class-id',
+        assignmentId: 'assign-invalid-class-id',
+      });
+
+      expect(() => {
+        controller.persistAssignmentRun(
+          { classId: '   ', assignments: [], findAssignmentIndex: () => -1 },
+          assignment
+        );
+      }).toThrow('persistAssignmentRun: expected abClass.classId to be a non-empty string');
+    });
   });
 });

--- a/tests/controllers/abclassController.rehydrateAssignment.test.js
+++ b/tests/controllers/abclassController.rehydrateAssignment.test.js
@@ -336,6 +336,14 @@ describe('ABClassController Rehydrate Assignment', () => {
       }).toThrow();
     });
 
+    it('throws when abClass.classId is not a non-empty string', () => {
+      const controller = new ABClassController();
+
+      expect(() => {
+        controller.rehydrateAssignment({ classId: '   ' }, 'assign-invalid-class-id');
+      }).toThrow('rehydrateAssignment: expected abClass.classId to be a non-empty string');
+    });
+
     it('handles Assignment.fromJSON failure gracefully', () => {
       const controller = new ABClassController();
       const { abClass, assignment } = createTestFixture({

--- a/tests/models/abclassManager.saveClass.test.js
+++ b/tests/models/abclassManager.saveClass.test.js
@@ -61,4 +61,34 @@ describe('ABClassController.saveClass', () => {
     expect(collectionMock.save).toHaveBeenCalled();
     expect(result).toBe(true);
   });
+
+  test('throws when input is not an object', () => {
+    expect(() => manager.saveClass(null)).toThrow(
+      'saveClass: expected an ABClass instance or plain object with classId and toPartialJSON()'
+    );
+  });
+
+  test('throws when classId is missing', () => {
+    expect(() => manager.saveClass({ toPartialJSON: vi.fn() })).toThrow(
+      'saveClass: missing required classId property on abClass argument'
+    );
+  });
+
+  test('throws when classId is blank', () => {
+    expect(() => manager.saveClass({ classId: '   ', toPartialJSON: vi.fn() })).toThrow(
+      'saveClass: expected abClass.classId to be a non-empty string'
+    );
+  });
+
+  test('throws when classId contains traversal segments', () => {
+    expect(() => manager.saveClass({ classId: '../class-1', toPartialJSON: vi.fn() })).toThrow(
+      'saveClass: invalid classId format'
+    );
+  });
+
+  test('throws when toPartialJSON is missing', () => {
+    expect(() => manager.saveClass({ classId: 'class-1' })).toThrow(
+      'saveClass: expected abClass.toPartialJSON() to be a function for partial persistence'
+    );
+  });
 });


### PR DESCRIPTION
### Motivation

- Make persistence APIs more flexible by allowing callers to provide either an `ABClass` instance or a plain object that exposes a `classId` property and a `toPartialJSON()` method.
- Fail fast with clearer errors when callers supply invalid inputs to `saveClass` to avoid silent or confusing persistence failures.

### Description

- Updated JSDoc on `_upsertClassPartial`, `persistAssignmentRun`, `rehydrateAssignment`, and `_replaceAssignmentInClass` to accept `ABClass|Object` (a plain object with `classId` and `toPartialJSON()`), and clarified comments accordingly.
- Added argument validation to `saveClass` that throws `TypeError` if the `abClass` argument is missing, not an object, lacks a `classId`, or does not provide a `toPartialJSON()` function.
- Left persistence logic unchanged but ensured `_persistClassAndPartial` is only called after the new validations.
- Improved a few inline comments and error messages for clarity.

### Testing

- Ran unit tests with `npm test`, which completed successfully.
- Ran linter with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef30006788329b2530acb8585d588)