### PR TITLE
Fix builder HtmlService transform attribute-removal regex

### DIFF
--- a/scripts/builder/src/steps/frontend-htmlservice-transform.ts
+++ b/scripts/builder/src/steps/frontend-htmlservice-transform.ts
@@ -181,7 +181,7 @@ function readAttributeValue(attributes: string, name: string): string | undefine
 function removeAttribute(attributes: string, name: string): string {
   const trimmed = attributes
     .replaceAll(
-      new RegExp(String.raw`\s*\b${name}\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]+)'>]+)`, 'gi'),
+      new RegExp(String.raw`\s*\b${name}\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]+)`, 'gi'),
       '',
     )
     .trim();


### PR DESCRIPTION
### Motivation
- The builder CI `builder:test` was failing with a runtime `SyntaxError` during the HtmlService transform step due to an invalid regular expression used to strip attributes. 

### Description
- Fixed the malformed regex in `removeAttribute` inside `scripts/builder/src/steps/frontend-htmlservice-transform.ts` by removing the stray fragment that produced an invalid pattern at runtime. 
- The change is a single, local edit to the regex used to remove `src`/`href` attributes and preserves the transform behaviour of inlining module scripts and stylesheet content. 

### Testing
- I reproduced the failure locally and observed `npm run builder:ci` failed at `builder:test` with a `SyntaxError` prior to the fix. 
- After the change I ran `npm run builder:test` and the builder test suite passed (`99 tests, 0 failed`). 
- I also ran `npm run frontend:test`, `npm run frontend:test:coverage` and `npm test` and all suites completed successfully, and a full `npm run builder:ci` completed without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd5dff13c83299dae54922ececaf2)