### PR TITLE
Make ClassroomApiClient read-only, switch to ABLogger, and add tests for read-only behavior

### DIFF
--- a/docs/developer/backend/backend-testing.md
+++ b/docs/developer/backend/backend-testing.md
@@ -412,7 +412,7 @@ const mocks = setupGlobalGASMocks(vi, { mockConsole: true });
 - `createMockUtils(vi)` - Utils with hash generation
 - `createMockDriveApp(vi)` - DriveApp for file operations
 - `createMockSpreadsheetApp(vi, options)` - SpreadsheetApp with sheets
-- `createMockClassroomApiClient()` - ClassroomApiClient wrapping Classroom API
+- `createMockClassroomApiClient()` - read-only ClassroomApiClient mock for `fetchCourse`, `fetchTeachers`, and `fetchAllStudents`
 - `createMockMimeType()` - Google MIME type constants
 - `createMockCollection(vi, options)` - Mock database collection with optional overrides
 - `createMockSlidesParser(options)` - Mock SlidesParser class for testing document parsing

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,7 +235,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -276,7 +275,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2149,7 +2147,6 @@
       "version": "24.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2210,7 +2207,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2608,7 +2604,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2912,7 +2907,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3595,7 +3589,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4015,7 +4008,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4482,7 +4474,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5193,7 +5184,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7033,7 +7023,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7136,7 +7125,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7212,7 +7200,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -7460,7 +7447,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/backend/GoogleClassroom/ClassroomApiClient.js
+++ b/src/backend/GoogleClassroom/ClassroomApiClient.js
@@ -215,8 +215,6 @@ class ClassroomApiClient {
             const studentInstance = new Student(name, email, id);
             studentList.push(studentInstance);
           });
-        } else {
-          ABLogger.getInstance().info('No students found on fetched page.', { courseId });
         }
 
         pageToken = response.nextPageToken;

--- a/src/backend/GoogleClassroom/ClassroomApiClient.js
+++ b/src/backend/GoogleClassroom/ClassroomApiClient.js
@@ -4,133 +4,13 @@
  * Handles operations related to Google Classroom entities.
  *
  * @class ClassroomApiClient
- * This class is responsible solely for direct interactions with the Google Classroom API:
- * creating, updating, and fetching courses, and inviting teachers.
+ * This class is responsible solely for read-only interactions with the Google Classroom API.
  */
 class ClassroomApiClient {
   /**
    * Exists to satisfy lint rules that disallow static-only classes.
    */
   constructor() {}
-
-  /**
-   * Creates a new Google Classroom.
-   * @param {string} name - The name of the classroom.
-   * @param {string} ownerId - The email of the owner teacher.
-   * @param {Array<string>} teacherEmails - The emails of additional teachers.
-   * @returns {GoogleAppsScript.Classroom.Schema.Course} The created course object.
-   */
-  static createClassroom(name, ownerId, teacherEmails = []) {
-    const progressTracker = ProgressTracker.getInstance();
-    try {
-      const course = {
-        name: name,
-        ownerId: ownerId,
-        courseState: 'ACTIVE',
-      };
-      const newCourse = Classroom.Courses.create(course);
-      console.log(`Created Classroom: ${name} (${newCourse.id})`);
-
-      // Invite additional teachers
-      teacherEmails.forEach((email) => {
-        if (email !== ownerId) {
-          // Avoid inviting the owner again
-          this.inviteTeacher(newCourse.id, email);
-        }
-      });
-
-      return newCourse;
-    } catch (error) {
-      progressTracker.logAndThrowError(
-        `Failed to create classroom '${name}': ${error.message}`,
-        error
-      );
-    }
-  }
-
-  /**
-   * Sends an invitation to a teacher to join a classroom.
-   * @param {string} courseId - The ID of the classroom.
-   * @param {string} teacherEmail - The email of the teacher to invite.
-   */
-  static inviteTeacher(courseId, teacherEmail) {
-    const progressTracker = ProgressTracker.getInstance();
-    try {
-      // Check if the teacher is already part of the course
-      const existingTeachers = Classroom.Courses.Teachers.list(courseId).teachers || [];
-      const existingTeacherEmails = new Set(
-        existingTeachers.map((teacher) => teacher.profile.emailAddress)
-      );
-
-      if (existingTeacherEmails.has(teacherEmail)) {
-        console.log(
-          `Teacher ${teacherEmail} is already part of course ${courseId}. Skipping invitation.`
-        );
-        return;
-      }
-
-      const invitation = {
-        courseId: courseId,
-        role: 'TEACHER',
-        userId: teacherEmail,
-      };
-      Classroom.Invitations.create(invitation);
-      console.log(`Sent invitation to teacher: ${teacherEmail} for course: ${courseId}`);
-    } catch (error) {
-      progressTracker.logError(
-        `Failed to invite teacher (${teacherEmail}) to course (${courseId}): ${error.message}`,
-        error
-      );
-    }
-  }
-
-  /**
-   * Updates an existing Google Classroom based on provided data.
-   * @param {string} courseId - The ID of the classroom to update.
-   * @param {string} newName - The new name for the classroom.
-   * @param {string} newOwnerId - The new owner email, if changing owner.
-   * @param {Array<string>} newTeacherEmails - The updated list of teacher emails.
-   */
-  static updateClassroom(courseId, newName, newOwnerId, newTeacherEmails = []) {
-    const progressTracker = ProgressTracker.getInstance();
-    try {
-      const course = Classroom.Courses.get(courseId);
-
-      // Update course name if changed
-      if (course.name !== newName) {
-        course.name = newName;
-        Classroom.Courses.update(course, courseId);
-        console.log(`Updated course name to '${newName}' for course ID: ${courseId}`);
-      }
-
-      // Update owner if changed
-      if (newOwnerId && course.ownerId !== newOwnerId) {
-        course.ownerId = newOwnerId;
-        Classroom.Courses.update(course, courseId);
-        console.log(`Updated course owner to '${newOwnerId}' for course ID: ${courseId}`);
-      }
-
-      // Get existing teachers
-      const existingTeachers = Classroom.Courses.Teachers.list(courseId).teachers || [];
-      const existingTeacherEmails = new Set(
-        existingTeachers.map((teacher) => teacher.profile.emailAddress)
-      );
-
-      // Invite new teachers who are not already teachers
-      newTeacherEmails.forEach((email) => {
-        if (email !== newOwnerId && !existingTeacherEmails.has(email)) {
-          this.inviteTeacher(courseId, email);
-        }
-      });
-
-      console.log(`Updated classroom (${courseId}) successfully.`);
-    } catch (error) {
-      progressTracker.logAndThrowError(
-        `Failed to update classroom (${courseId}): ${error.message}`,
-        error
-      );
-    }
-  }
 
   /**
    * Fetches all classrooms where the user is a teacher.
@@ -141,7 +21,7 @@ class ClassroomApiClient {
     try {
       const response = Classroom.Courses.list({ teacherId: 'me', courseStates: ['ACTIVE'] });
       const courses = response.courses || [];
-      console.log(`Fetched ${courses.length} classrooms.`);
+      ABLogger.getInstance().info('Fetched classrooms.', { count: courses.length });
       return courses;
     } catch (error) {
       progressTracker.logAndThrowError(`Failed to fetch classrooms: ${error.message}`, error);
@@ -336,7 +216,7 @@ class ClassroomApiClient {
             studentList.push(studentInstance);
           });
         } else {
-          console.log(`No students found for course ID: ${courseId} on this page.`);
+          ABLogger.getInstance().info('No students found on fetched page.', { courseId });
         }
 
         pageToken = response.nextPageToken;

--- a/src/backend/GoogleClassroom/ClassroomApiClient.js
+++ b/src/backend/GoogleClassroom/ClassroomApiClient.js
@@ -146,10 +146,9 @@ class ClassroomApiClient {
 
   /**
    * Fetch teachers for a given course.
-   * Returns the raw teacher objects as provided by the API (so callers can
-   * inspect profile fields).
+   * Maps Classroom API teacher resources to `Teacher` model instances.
    * @param {string} courseId
-   * @returns {Array<Object>} array of teacher resource objects
+   * @returns {Teacher[]} array of Teacher model instances
    */
   static fetchTeachers(courseId) {
     const progressTracker = ProgressTracker.getInstance();

--- a/tests/googleClassroom/classroomApiClient.test.js
+++ b/tests/googleClassroom/classroomApiClient.test.js
@@ -6,6 +6,204 @@ if (!globalThis.ProgressTracker) {
 
 const modulePath = '../../src/backend/GoogleClassroom/ClassroomApiClient.js';
 
+describe('ClassroomApiClient (read-only methods)', () => {
+  let ClassroomApiClient;
+  let progressTrackerInstance;
+  let abLoggerInstance;
+
+  beforeEach(() => {
+    progressTrackerInstance = {
+      logAndThrowError: vi.fn((message) => {
+        throw new Error(message);
+      }),
+      logError: vi.fn(),
+    };
+    globalThis.ProgressTracker.getInstance = vi.fn(() => progressTrackerInstance);
+
+    abLoggerInstance = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+    globalThis.ABLogger = { getInstance: vi.fn(() => abLoggerInstance) };
+
+    globalThis.Classroom = {
+      Courses: {
+        list: vi.fn(),
+        get: vi.fn(),
+        Topics: {
+          get: vi.fn(),
+        },
+        Teachers: {
+          list: vi.fn(),
+        },
+        Students: {
+          list: vi.fn(),
+        },
+      },
+    };
+
+    const teacherExport = require('../../src/backend/Models/Teacher.js');
+    globalThis.Teacher = teacherExport.Teacher || teacherExport;
+
+    const studentExport = require('../../src/backend/Models/Student.js');
+    globalThis.Student = studentExport.Student || studentExport;
+
+    delete require.cache[require.resolve(modulePath)];
+    const exported = require(modulePath);
+    ClassroomApiClient = exported.ClassroomApiClient || exported;
+  });
+
+  afterEach(() => {
+    delete globalThis.Classroom;
+    delete globalThis.ABLogger;
+    delete globalThis.Teacher;
+    delete globalThis.Student;
+    vi.restoreAllMocks();
+  });
+
+  it('does not expose mutating methods', () => {
+    expect(ClassroomApiClient.createClassroom).toBeUndefined();
+    expect(ClassroomApiClient.updateClassroom).toBeUndefined();
+    expect(ClassroomApiClient.inviteTeacher).toBeUndefined();
+  });
+
+  it('fetchClassrooms returns active courses', () => {
+    const courses = [{ id: 'course-1', name: 'Maths' }];
+    globalThis.Classroom.Courses.list.mockReturnValue({ courses });
+
+    const result = ClassroomApiClient.fetchClassrooms();
+
+    expect(globalThis.Classroom.Courses.list).toHaveBeenCalledWith({
+      teacherId: 'me',
+      courseStates: ['ACTIVE'],
+    });
+    expect(result).toEqual(courses);
+  });
+
+  it('fetchAllActiveClassrooms maps paginated responses', () => {
+    globalThis.Classroom.Courses.list
+      .mockReturnValueOnce({
+        courses: [{ id: 'course-1', name: 'Maths', enrollmentCode: 'A1' }],
+        nextPageToken: 'next-page',
+      })
+      .mockReturnValueOnce({
+        courses: [{ id: 'course-2', name: 'English', enrollmentCode: 'B2' }],
+      });
+
+    const result = ClassroomApiClient.fetchAllActiveClassrooms();
+
+    expect(result).toEqual([
+      { id: 'course-1', name: 'Maths', enrollmentCode: 'A1' },
+      { id: 'course-2', name: 'English', enrollmentCode: 'B2' },
+    ]);
+    expect(abLoggerInstance.info).toHaveBeenCalledWith('Active classrooms retrieved', {
+      count: 2,
+    });
+  });
+
+  it('fetchAllActiveClassrooms returns [] and logs when Classroom API throws', () => {
+    const apiError = new Error('API failure');
+    globalThis.Classroom.Courses.list.mockImplementation(() => {
+      throw apiError;
+    });
+
+    const result = ClassroomApiClient.fetchAllActiveClassrooms();
+
+    expect(result).toEqual([]);
+    expect(progressTrackerInstance.logError).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchCourse returns a course when found', () => {
+    const course = { id: 'course-123', name: 'Physics' };
+    globalThis.Classroom.Courses.get.mockReturnValue(course);
+
+    const result = ClassroomApiClient.fetchCourse('course-123');
+
+    expect(result).toEqual(course);
+  });
+
+  it('fetchCourse returns null and logs when lookup fails', () => {
+    globalThis.Classroom.Courses.get.mockImplementation(() => {
+      throw new Error('Not found');
+    });
+
+    const result = ClassroomApiClient.fetchCourse('missing-course');
+
+    expect(result).toBeNull();
+    expect(progressTrackerInstance.logError).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetchTopicName returns topic name', () => {
+    globalThis.Classroom.Courses.Topics.get.mockReturnValue({ name: 'Homework' });
+
+    const result = ClassroomApiClient.fetchTopicName('course-1', 'topic-1');
+
+    expect(result).toBe('Homework');
+  });
+
+  it('fetchTopicName throws when required params are missing', () => {
+    expect(() => ClassroomApiClient.fetchTopicName('', 'topic-1')).toThrow(
+      'courseId and topicId are required to fetch topic name.'
+    );
+  });
+
+  it('fetchTeachers maps API teachers into Teacher model instances', () => {
+    globalThis.Classroom.Courses.Teachers.list.mockReturnValue({
+      teachers: [
+        {
+          profile: {
+            id: 'teacher-1',
+            emailAddress: 'teacher1@example.com',
+            name: { fullName: 'Teacher One' },
+          },
+        },
+      ],
+    });
+
+    const result = ClassroomApiClient.fetchTeachers('course-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(globalThis.Teacher);
+    expect(result[0].email).toBe('teacher1@example.com');
+    expect(result[0].teacherName).toBe('Teacher One');
+    expect(result[0].userId).toBe('teacher-1');
+  });
+
+  it('fetchAllStudents maps paginated API responses into Student model instances', () => {
+    globalThis.Classroom.Courses.Students.list
+      .mockReturnValueOnce({
+        students: [
+          {
+            profile: {
+              id: 'student-1',
+              name: { fullName: 'Student One' },
+              emailAddress: 'student1@example.com',
+            },
+          },
+        ],
+        nextPageToken: 'next',
+      })
+      .mockReturnValueOnce({
+        students: [
+          {
+            profile: {
+              id: 'student-2',
+              name: { fullName: 'Student Two' },
+              emailAddress: 'student2@example.com',
+            },
+          },
+        ],
+      });
+
+    const result = ClassroomApiClient.fetchAllStudents('course-1');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBeInstanceOf(globalThis.Student);
+    expect(result[0].name).toBe('Student One');
+    expect(result[1].id).toBe('student-2');
+  });
+});
+
 describe('ClassroomApiClient.fetchCourseUpdateTime', () => {
   let ClassroomApiClient;
   let abLoggerErrorSpy;

--- a/tests/googleClassroom/classroomApiClient.test.js
+++ b/tests/googleClassroom/classroomApiClient.test.js
@@ -10,8 +10,19 @@ describe('ClassroomApiClient (read-only methods)', () => {
   let ClassroomApiClient;
   let progressTrackerInstance;
   let abLoggerInstance;
+  let originalProgressTrackerGetInstance;
+  let originalABLogger;
+  let originalClassroom;
+  let originalTeacher;
+  let originalStudent;
 
   beforeEach(() => {
+    originalProgressTrackerGetInstance = globalThis.ProgressTracker.getInstance;
+    originalABLogger = globalThis.ABLogger;
+    originalClassroom = globalThis.Classroom;
+    originalTeacher = globalThis.Teacher;
+    originalStudent = globalThis.Student;
+
     progressTrackerInstance = {
       logAndThrowError: vi.fn((message) => {
         throw new Error(message);
@@ -54,10 +65,11 @@ describe('ClassroomApiClient (read-only methods)', () => {
   });
 
   afterEach(() => {
-    delete globalThis.Classroom;
-    delete globalThis.ABLogger;
-    delete globalThis.Teacher;
-    delete globalThis.Student;
+    globalThis.ProgressTracker.getInstance = originalProgressTrackerGetInstance;
+    globalThis.ABLogger = originalABLogger;
+    globalThis.Classroom = originalClassroom;
+    globalThis.Teacher = originalTeacher;
+    globalThis.Student = originalStudent;
     vi.restoreAllMocks();
   });
 
@@ -92,6 +104,14 @@ describe('ClassroomApiClient (read-only methods)', () => {
 
     const result = ClassroomApiClient.fetchAllActiveClassrooms();
 
+    expect(globalThis.Classroom.Courses.list).toHaveBeenNthCalledWith(1, {
+      pageToken: undefined,
+      courseStates: ['ACTIVE'],
+    });
+    expect(globalThis.Classroom.Courses.list).toHaveBeenNthCalledWith(2, {
+      pageToken: 'next-page',
+      courseStates: ['ACTIVE'],
+    });
     expect(result).toEqual([
       { id: 'course-1', name: 'Maths', enrollmentCode: 'A1' },
       { id: 'course-2', name: 'English', enrollmentCode: 'B2' },
@@ -207,8 +227,13 @@ describe('ClassroomApiClient (read-only methods)', () => {
 describe('ClassroomApiClient.fetchCourseUpdateTime', () => {
   let ClassroomApiClient;
   let abLoggerErrorSpy;
+  let originalABLogger;
+  let originalClassroom;
 
   beforeEach(() => {
+    originalABLogger = globalThis.ABLogger;
+    originalClassroom = globalThis.Classroom;
+
     const abLoggerInstance = {
       error: vi.fn(),
     };
@@ -228,8 +253,8 @@ describe('ClassroomApiClient.fetchCourseUpdateTime', () => {
   });
 
   afterEach(() => {
-    delete globalThis.Classroom;
-    delete globalThis.ABLogger;
+    globalThis.Classroom = originalClassroom;
+    globalThis.ABLogger = originalABLogger;
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
### Motivation

- Limit `ClassroomApiClient` to read-only interactions with the Google Classroom API and remove mutating operations to prevent side effects from this client. 
- Centralize structured logging by replacing `console.log` calls with `ABLogger.getInstance()` usages.
- Improve test coverage for the read-only surface and pagination/edge-case handling.

### Description

- Removed mutating methods `createClassroom`, `inviteTeacher`, and `updateClassroom` so the class only exposes read-only methods. 
- Replaced `console.log` statements with `ABLogger.getInstance().info` (and similar) for structured logging in `fetchClassrooms`, `fetchAllActiveClassrooms`, and `fetchAllStudents`. 
- Kept existing read-only methods (pagination-aware `fetchAllActiveClassrooms`, `fetchAllStudents`, `fetchCourse`, `fetchTopicName`, `fetchTeachers`, etc.) and preserved error handling via `ProgressTracker`. 
- Added comprehensive unit tests in `tests/googleClassroom/classroomApiClient.test.js` that mock `ProgressTracker`, `ABLogger`, `Classroom` API calls, and `Teacher`/`Student` models to validate read-only behavior, pagination, error paths, and mapping to model instances.

### Testing

- Ran the unit test suite for the classroom client with `vitest` targeting `tests/googleClassroom/classroomApiClient.test.js` and the tests completed successfully. 
- New tests verify that mutating methods are not exposed and that `fetchAllActiveClassrooms`, `fetchClassrooms`, `fetchCourse`, `fetchTopicName`, `fetchTeachers`, and `fetchAllStudents` handle pagination and errors as expected. 
- Existing `fetchCourseUpdateTime` tests remain and passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b0d665008329970ffae946d7d90a)