### PR TITLE
Docs: switch canonical API surface to `src/backend/z_Api`, clarify config API plan and test-naming guidance

### DIFF
--- a/.github/agents/Testing.agent.md
+++ b/.github/agents/Testing.agent.md
@@ -59,6 +59,12 @@ If you add or modify tests, run the smallest targeted command first, then the re
 - Frontend and builder unit test suites must satisfy minimum coverage thresholds of **85%** for lines, functions, statements, and branches.
 - Use the dedicated coverage commands to verify the enforced thresholds before handoff.
 
+## 2.2 Test naming and traceability
+
+- Name tests, `describe(...)` blocks, helper constants, and fixtures after the behaviour or surface under test.
+- Do **not** use action-plan section numbering in test names or helpers (for example `Section 1`, `Section 2`, `SECTION_1_*`).
+- When migrating a transport surface, rename tests to the real method/class names and retire the old planning labels rather than carrying them forward.
+
 ## 3. Idiomatic Patterns
 
 - Reuse existing helpers/factories before creating new ones.

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -7,9 +7,9 @@
 - Replace the legacy ConfigurationManager frontend-callable globals with canonical `apiHandler` endpoints.
 - Introduce backend transport methods named `getBackendConfig` and `setBackendConfig`.
 - Add corresponding typed frontend service methods that route through `callApi`.
-- Preserve current configuration read/write semantics, including masked API-key handling and partial-update behaviour.
+- Preserve current configuration read/write semantics, including masked API-key handling, partial-update behaviour, and the existing save-result contract.
 - Update backend and frontend tests to validate the new transport boundary and remove reliance on legacy globals as the public entry surface.
-- Update developer documentation for the new configuration API boundary if implementation changes require it.
+- Update developer documentation and agent guidance for the new configuration API boundary and the current `z_Api` path authority.
 
 ### Out of scope
 
@@ -20,12 +20,15 @@
 
 ### Assumptions
 
-1. The canonical backend transport entrypoint remains `src/backend/z_Api/apiHandler.js`, despite some older docs referring to `Api` more generically.
+1. The canonical backend transport entrypoint for this feature is `src/backend/z_Api/apiHandler.js`, with method registration in `src/backend/z_Api/apiConstants.js`.
 2. The public transport method names should be `getBackendConfig` and `setBackendConfig` to make the frontend/backend boundary explicit.
-3. `getBackendConfig` should preserve the current public configuration payload shape exposed by legacy `getConfiguration()`, including masked `apiKey` and `hasApiKey`.
-4. `setBackendConfig` should preserve current partial-update semantics: fields with value `undefined` are ignored, while explicit empty-string API-key updates clear the stored key.
-5. Backend handlers should return plain data only; response envelope shaping must remain in `apiHandler`.
-6. Frontend feature code should consume typed service helpers and must not call `google.script.run` directly.
+3. `getBackendConfig` should preserve the current public configuration payload shape exposed by legacy `getConfiguration()`: `backendAssessorBatchSize`, masked `apiKey`, `hasApiKey`, `backendUrl`, `revokeAuthTriggerSet`, `daysUntilAuthRevoke`, `slidesFetchBatchSize`, `jsonDbMasterIndexKey`, `jsonDbLockTimeoutMs`, `jsonDbLogLevel`, `jsonDbBackupOnInitialise`, `jsonDbRootFolderId`, plus optional `loadError`.
+4. `setBackendConfig` should accept a flat partial-update object containing only writable configuration fields: `backendAssessorBatchSize`, `apiKey`, `backendUrl`, `revokeAuthTriggerSet`, `daysUntilAuthRevoke`, `slidesFetchBatchSize`, `jsonDbMasterIndexKey`, `jsonDbLockTimeoutMs`, `jsonDbLogLevel`, `jsonDbBackupOnInitialise`, and `jsonDbRootFolderId`.
+5. `setBackendConfig` should preserve current save semantics by returning plain data shaped as `{ success: true }` on success or `{ success: false, error: string }` on partial-save failure, matching the existing legacy write contract.
+6. `setBackendConfig` should preserve current partial-update semantics: fields with value `undefined` are ignored, while explicit empty-string API-key updates clear the stored key.
+7. Backend handlers should return plain data only; response envelope shaping must remain in `apiHandler`.
+8. Frontend feature code should consume typed service helpers and must not call `google.script.run` directly.
+9. Legacy-removal decisions in this plan are judged against active code and supported tests only; deprecated references are allowed to break so they can be removed later with clear visibility.
 
 ---
 
@@ -38,6 +41,7 @@
 - Avoid defensive guards that hide wiring issues.
 - Keep changes minimal, localised, and consistent with repository conventions.
 - Use British English in comments and documentation.
+- When updating tests, name cases after behaviour or the function/class under test; do not use action-plan section numbers in test names, helper constants, or describe-block labels.
 
 ### TDD workflow (mandatory per section)
 
@@ -55,6 +59,7 @@ For each section below:
 - Builder lint (if touched): `npm run builder:lint`
 - Backend tests: `npm test -- <target>`
 - Frontend unit tests: `npm run frontend:test -- <target>`
+- Frontend type check: `npm exec tsc -- -b src/frontend/tsconfig.json`
 - Frontend e2e tests (if UX changes): `npm run frontend:test:e2e -- <target>`
 
 ---
@@ -63,26 +68,30 @@ For each section below:
 
 ### Objective
 
-- Add canonical backend API handlers for configuration reads and writes through `apiHandler`, replacing the legacy frontend-callable globals as the transport surface.
+- Add canonical backend API handlers for configuration reads and writes through `apiHandler`, replacing the legacy frontend-callable globals as the active transport surface.
 
 ### Constraints
 
 - Register new methods in `src/backend/z_Api/apiConstants.js`.
 - Dispatch new methods from `ApiDispatcher._invokeAllowlistedMethod(...)` in `src/backend/z_Api/apiHandler.js`.
 - Keep handler logic thin and centred on `ConfigurationManager.getInstance()`.
-- Preserve existing configuration semantics from `src/backend/ConfigurationManager/99_globals.js` during migration.
+- Preserve existing configuration semantics from `src/backend/ConfigurationManager/99_globals.js` during migration, then delete that legacy transport file once active-code and supported-test callers have moved.
 - Do not expose the raw stored API key to the frontend.
 - Do not move envelope shaping out of `apiHandler`.
+- Treat `loadError` as part of the read contract: it is expected to remain optional.
+- Validate direct params at the API boundary and keep write-only vs read-only fields explicit.
 
 ### Acceptance criteria
 
 - `API_METHODS` contains `getBackendConfig` and `setBackendConfig`.
 - `API_ALLOWLIST` contains `getBackendConfig` and `setBackendConfig`.
 - `apiHandler` dispatches both methods successfully.
-- `getBackendConfig` returns the current configuration payload with masked `apiKey`, `hasApiKey`, and the existing public fields.
-- `setBackendConfig` applies supported configuration updates through `ConfigurationManager` setters.
+- `getBackendConfig` returns plain data with exactly the current public configuration fields, masked `apiKey`, `hasApiKey`, and optional `loadError`.
+- `setBackendConfig` accepts only the writable configuration patch fields listed in the assumptions section.
 - `setBackendConfig` ignores `undefined` fields and preserves explicit API-key clearing with `apiKey: ''`.
-- Legacy `src/backend/ConfigurationManager/99_globals.js` is no longer the intended frontend transport surface and is removed if nothing still depends on it.
+- `setBackendConfig` returns `{ success: true }` on success or `{ success: false, error: string }` on partial-save failure.
+- Read-only transport fields such as `hasApiKey` and `loadError` are not accepted as writable inputs.
+- Legacy `src/backend/ConfigurationManager/99_globals.js` is no longer the active frontend transport surface and is removed once the new API-path coverage is in place.
 
 ### Required test cases (Red first)
 
@@ -100,10 +109,14 @@ API layer tests:
 1. `tests/api/apiHandler.test.js` asserts `getBackendConfig` and `setBackendConfig` are present in `API_METHODS`.
 2. `tests/api/apiHandler.test.js` asserts both methods are allowlisted and dispatched by `ApiDispatcher`.
 3. Add focused backend API tests for `getBackendConfig` masked API-key behaviour.
-4. Add focused backend API tests for `setBackendConfig` partial update semantics.
-5. Add a test confirming `setBackendConfig` does not call setters for fields that are `undefined`.
-6. Add a test confirming `setBackendConfig` does call `setApiKey('')` for explicit clear.
-7. Add a test confirming error propagation remains envelope-based through `apiHandler`.
+4. Add focused backend API tests for `getBackendConfig` optional `loadError` propagation.
+5. Add focused backend API tests for `setBackendConfig` partial-update semantics.
+6. Add a test confirming `setBackendConfig` does not call setters for fields that are `undefined`.
+7. Add a test confirming `setBackendConfig` does call `setApiKey('')` for explicit clear.
+8. Add a test confirming read-only fields such as `hasApiKey` and `loadError` are rejected or ignored according to the final API validation decision, and document that decision explicitly during implementation.
+9. Add tests confirming `setBackendConfig` returns the plain save-result shape `{ success: true }` and `{ success: false, error }` through the `apiHandler` envelope.
+10. Add a test confirming error propagation remains envelope-based through `apiHandler`.
+11. Place new configuration transport tests in a behaviour-named API test file or describe block; do not use action-plan section numbering in test names.
 
 Frontend tests:
 
@@ -112,7 +125,7 @@ Frontend tests:
 ### Section checks
 
 - `npm test -- tests/api/apiHandler.test.js`
-- `npm test -- tests/configurationManager/saveConfiguration.test.js`
+- `npm test -- tests/api/backendConfigApi.test.js`
 
 ### Implementation notes / deviations / follow-up
 
@@ -135,6 +148,8 @@ Frontend tests:
 - Use Zod-first schemas and infer types from those schemas.
 - Keep service modules focused on transport and validation, not UI orchestration.
 - Preserve the backend’s masked-secret contract in the frontend types.
+- Treat `loadError` as an expected optional read field.
+- Keep the write-response schema aligned with the backend’s plain save-result contract: `{ success: true } | { success: false, error: string }`.
 
 ### Acceptance criteria
 
@@ -144,6 +159,7 @@ Frontend tests:
 - Both helpers validate inputs/outputs with Zod.
 - The service uses the exact backend method names `getBackendConfig` and `setBackendConfig`.
 - Malformed backend payloads are rejected by schema parsing rather than silently accepted.
+- The write-input schema excludes read-only fields such as `hasApiKey` and `loadError`.
 
 ### Required test cases (Red first)
 
@@ -164,10 +180,12 @@ Frontend tests:
 1. Add a spec for the configuration service following the style used by existing frontend service tests.
 2. Verify `getBackendConfig()` calls `callApi('getBackendConfig')`.
 3. Verify `setBackendConfig()` calls `callApi('setBackendConfig', parsedInput)`.
-4. Verify response parsing succeeds for a valid masked configuration payload.
+4. Verify response parsing succeeds for a valid masked configuration payload, including optional `loadError` handling.
 5. Verify malformed read responses are rejected.
 6. Verify malformed write responses are rejected.
 7. Verify write-input validation rejects invalid payload shapes before transport.
+8. Verify write-input validation rejects read-only fields such as `hasApiKey` and `loadError`.
+9. Keep test naming behaviour-focused; do not use action-plan section numbers in spec titles or helper names.
 
 ### Section checks
 
@@ -193,12 +211,14 @@ Frontend tests:
 - Keep changes minimal and avoid speculative refactors.
 - Preserve compatibility for any still-valid internal ConfigurationManager usage that is not part of the frontend transport boundary.
 - Remove legacy references only after equivalent coverage exists for the new path.
+- Evaluate removal against active code and supported tests only; deprecated references may break and should then be removed deliberately.
 
 ### Acceptance criteria
 
 - The codebase no longer relies on legacy configuration globals as the public frontend transport surface.
-- Any frontend or test references to legacy `getConfiguration` / `saveConfiguration` transport usage are updated or removed.
-- Legacy backend `globals.js` configuration transport file is removed if no longer required.
+- Any active frontend or supported test references to legacy `getConfiguration` / `saveConfiguration` transport usage are updated or removed.
+- No required test command in this plan imports or depends on `src/backend/ConfigurationManager/99_globals.js`.
+- Legacy backend `99_globals.js` configuration transport file is removed once the new API-path tests are in place.
 - The migrated boundary is clear from method names and service wrappers.
 
 ### Required test cases (Red first)
@@ -213,8 +233,9 @@ Backend controller tests:
 
 API layer tests:
 
-1. Update any configuration-related tests still targeting the legacy globals so they instead validate the new API path.
+1. Replace legacy configuration transport tests with API-path tests that validate `getBackendConfig` and `setBackendConfig` behaviour through `apiHandler`.
 2. Ensure no stale tests imply the legacy globals remain the supported frontend boundary.
+3. Remove action-plan section-number naming from any updated configuration transport tests.
 
 Frontend tests:
 
@@ -224,6 +245,7 @@ Frontend tests:
 ### Section checks
 
 - `npm test -- tests/api/apiHandler.test.js`
+- `npm test -- tests/api/backendConfigApi.test.js`
 - `npm run frontend:test -- src/services/configurationService.spec.ts`
 
 ### Implementation notes / deviations / follow-up
@@ -249,22 +271,25 @@ Frontend tests:
 - Backend API transport tests for configuration pass.
 - Frontend configuration service tests pass.
 - Relevant lint commands pass for touched areas.
+- Frontend TypeScript compilation passes for the new schemas/services.
 - Any broader touched test suites pass before considering feature complete.
 
 ### Required test cases/checks
 
 1. Run touched backend model/controller/API suites.
 2. Run touched frontend service/UI suites.
-3. Run backend frontend lint commands.
-4. Run any required e2e tests.
+3. Run backend and frontend lint commands.
+4. Run `npm exec tsc -- -b src/frontend/tsconfig.json`.
+5. Run any required e2e tests.
 
 ### Section checks
 
 - `npm test -- tests/api/apiHandler.test.js`
-- `npm test -- tests/configurationManager/saveConfiguration.test.js`
+- `npm test -- tests/api/backendConfigApi.test.js`
 - `npm run frontend:test -- src/services/configurationService.spec.ts`
 - `npm run lint`
 - `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Implementation notes / deviations / follow-up
 
@@ -277,23 +302,44 @@ Frontend tests:
 
 ### Objective
 
-- Update docs to reflect the new configuration transport boundary and naming.
+- Update docs to reflect the new configuration transport boundary, the active `z_Api` path authority, and the testing-naming guidance discovered during plan review.
 
 ### Constraints
 
 - Only modify documents relevant to the touched areas.
+- Use the concrete file list below rather than relying on broad “update docs” wording.
 
 ### Acceptance criteria
 
 - Documentation accurately reflects the new `getBackendConfig` and `setBackendConfig` methods.
 - API-layer documentation no longer implies configuration transport should use legacy globals.
+- Path guidance consistently points to `src/backend/z_Api` where it is the current active transport surface.
+- Testing guidance explicitly warns against naming tests after action-plan sections.
 - Any deviations or caveats are documented.
 
 ### Required checks
 
-1. Verify docs mention persistence/transport strategies.
-2. Verify API docs list new endpoints/methods.
-3. Confirm notes/deviations fields are filled during implementation.
+1. Verify docs mention the configuration transport and save-result strategies.
+2. Verify API docs list the new endpoints/methods and payloads.
+3. Verify path-guidance docs and agent files use `src/backend/z_Api` consistently where applicable.
+4. Confirm notes/deviations fields are filled during implementation.
+
+### Concrete documentation and guidance update list (from repo scan)
+
+Must update for this feature:
+
+- `docs/developer/backend/api-layer.md`
+- `docs/developer/backend/DATA_SHAPES.md`
+- `ACTION_PLAN.md`
+
+Also update for path-guidance and testing-guidance consistency:
+
+- `src/backend/AGENTS.md`
+- `src/frontend/AGENTS.md`
+- `docs/developer/backend/backend-testing.md`
+- `docs/developer/frontend/frontend-testing.md`
+- `.github/agents/Testing.agent.md`
+- `docs/developer/backend/AssessmentFlow.md`
 
 ### Implementation notes / deviations / follow-up
 
@@ -303,8 +349,8 @@ Frontend tests:
 
 ## Suggested implementation order
 
-1. Section 1 (backend configuration API migration)
-2. Section 2 (frontend configuration service and typed transport contract)
-3. Section 3 (legacy transport cleanup and usage migration)
+1. Backend configuration API migration
+2. Frontend configuration service and typed transport contract
+3. Legacy transport cleanup and usage migration
 4. Regression and contract hardening
 5. Documentation and rollout notes

--- a/docs/developer/backend/AssessmentFlow.md
+++ b/docs/developer/backend/AssessmentFlow.md
@@ -22,7 +22,7 @@ This document traces the complete assessment flow in AssessmentBot, starting fro
 
 ### Key Components
 
-- **Backend API Layer**: `src/backend/Api` thin GAS global wrappers for frontend `google.script.run` calls
+- **Backend API Layer**: `src/backend/z_Api` thin GAS global wrappers for frontend `apiHandler` transport calls
 - **UI Layer**: `UIManager`, HTML templates
 - **Controllers**: `AssignmentController`, `AssignmentDefinitionController`, `ABClassController`
 - **Models**: `Assignment` (base), `SlidesAssignment`, `SheetsAssignment`, `AssignmentDefinition`, `TaskDefinition`, `StudentSubmission`
@@ -53,7 +53,7 @@ This document traces the complete assessment flow in AssessmentBot, starting fro
 
 ## Migration Note: API Layer
 
-The active backend is moving to `src/backend/Api` as the canonical GAS entry layer for frontend calls.
+The active backend currently uses `src/backend/z_Api` as the canonical GAS entry layer for frontend calls.
 
 - API functions should stay thin and delegate to controllers.
 - Remaining `globals.js` files in backend are temporary references and should be deleted once equivalent API functions exist.

--- a/docs/developer/backend/backend-testing.md
+++ b/docs/developer/backend/backend-testing.md
@@ -147,6 +147,7 @@ Preferred:
 - name tests after the behaviour, method, or class they verify
 - use helper names that describe the transport or domain concept, not a temporary planning document
 - when a feature migrates from `globals.js` to `apiHandler`, replace legacy-surface tests with new transport tests rather than preserving both naming schemes
+- treat existing `SECTION_*` constants or "Section N ..." describe titles in the test suite as legacy names and rename them to behaviour-focused names when you next touch those tests, rather than copying the old pattern
 
 ## Test Framework
 

--- a/docs/developer/backend/backend-testing.md
+++ b/docs/developer/backend/backend-testing.md
@@ -6,7 +6,7 @@ AssessmentBot uses **Vitest** as the testing framework for unit and integration 
 
 Backend production code still runs as concatenated GAS script files, not as a Node module graph. Tests must adapt to that runtime model rather than forcing production files to behave like normal Node modules.
 
-Backend currently exposes API-style entry files under `src/backend/z_Api` while migration guidance still refers to `src/backend/Api` as the target surface. Tests should target the files that actually exist in the current runtime path.
+Backend currently exposes API-style entry files under `src/backend/z_Api`. Tests should target the files that actually exist in the current runtime path and avoid stale `src/backend/Api` references unless and until the codebase actually moves there.
 
 These API functions should be tested as thin wrappers around controller delegation and error propagation.
 
@@ -133,6 +133,20 @@ Preferred:
 
 - match the real numbered filename exactly
 - treat numeric prefixes as part of the dependency contract, not cosmetic naming
+
+### 4. Naming tests after action-plan sections
+
+Anti-patterns:
+
+- `describe('Section 1 transport', ...)`
+- `const SECTION_1_API_METHOD_NAMES = [...]`
+- test names that only refer to plan sections instead of the behaviour under test
+
+Preferred:
+
+- name tests after the behaviour, method, or class they verify
+- use helper names that describe the transport or domain concept, not a temporary planning document
+- when a feature migrates from `globals.js` to `apiHandler`, replace legacy-surface tests with new transport tests rather than preserving both naming schemes
 
 ## Test Framework
 
@@ -296,7 +310,7 @@ deprecated legacy UI/init coverage.
 - Test edge cases (null inputs, missing data, corrupt data)
 - Verify logging calls for all significant operations
 
-### 6.1 API Layer Tests (`src/backend/z_Api`, migrating towards `src/backend/Api`)
+### 6.1 API Layer Tests (`src/backend/z_Api`)
 
 Test API-layer functions as boundary wrappers:
 

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -107,6 +107,14 @@ Vitest + Testing Library may still assert user-visible component outcomes; use P
   - user sees light/dark mode switch reflected in the rendered UI
   - user sees motion disabled or minimal when reduced-motion preference is active
 
+## Test naming and traceability
+
+Name frontend tests after the behaviour, component, hook, or service they verify.
+
+Avoid temporary planning labels in test names and helpers. In particular, do not use action-plan section numbering such as `Section 1`, `Section 2`, or similar in `describe(...)` blocks, test titles, constants, or fixture names. Those labels become misleading as plans evolve or are deleted.
+
+Prefer names such as `getBackendConfig rejects malformed payloads` or `Configuration service calls callApi with the backend method name` over names that refer only to a planning document.
+
 ## Related standards
 
 For frontend logging, error mapping, and environment-specific diagnostics policy, use:

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -4,15 +4,15 @@ Applies when editing `src/backend/**` and backend runtime behaviour.
 
 ## 0. Backend API Entry Layer
 
-- `src/backend/Api` is the target entry surface for functions called from the frontend via `google.script.run` as migration progresses.
+- `src/backend/z_Api` is the current active entry surface for functions called from the frontend via `google.script.run` / `apiHandler` as migration progresses.
 - Organise API files by domain/resource in a REST-ish style.
 - Keep API functions thin and delegate to controller classes unless delegation would add unnecessary verbosity.
-- Existing backend `globals.js` files are migration references and should be removed once equivalent `Api` functions exist.
+- Existing backend `globals.js` files are migration references and should be removed once equivalent `z_Api` functions exist.
 
 ### 0.1 Required `apiHandler` migration pattern
 
-- Treat `src/backend/Api/apiHandler.js` as the single frontend transport entrypoint.
-- Register new frontend-callable methods in `src/backend/Api/apiConstants.js` (`API_METHODS` and `API_ALLOWLIST`).
+- Treat `src/backend/z_Api/apiHandler.js` as the single frontend transport entrypoint.
+- Register new frontend-callable methods in `src/backend/z_Api/apiConstants.js` (`API_METHODS` and `API_ALLOWLIST`).
 - Implement allowlisted dispatch in `ApiDispatcher._invokeAllowlistedMethod(...)` and keep the handler path thin.
 - Return plain response data from allowlisted methods; envelope shaping (`ok`, `requestId`, `error`) must stay in `apiHandler`.
 - Keep admission/completion tracking (`_runAdmissionPhase`, `_runCompletionPhase`) intact for all allowlisted methods.

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -46,7 +46,7 @@ Root scripts execute frontend tasks via `npm --prefix src/frontend ...`.
 ### 4.1 Required API transport pattern
 
 - Route backend calls through `src/frontend/src/services/apiService.ts` (`callApi`) and avoid direct `google.script.run.<method>` calls in feature code.
-- Keep method names aligned with backend `API_METHODS` in `src/backend/Api/apiConstants.js`.
+- Keep method names aligned with backend `API_METHODS` in `src/backend/z_Api/apiConstants.js`.
 - Treat backend responses as envelopes handled by `callApi`; feature services should consume typed `data` results only.
 - Keep retry behaviour centralised in `callApi`; do not add per-feature retry loops for rate-limit handling.
 


### PR DESCRIPTION
### Motivation

- Update documentation and agent guidance to reflect the active backend transport surface and the finalized design for migrating configuration reads/writes to the API handler.
- Capture precise transport method names (`getBackendConfig`, `setBackendConfig`), payload shapes, and save-result contract to avoid ambiguity during implementation.
- Improve test traceability by discouraging action-plan section numbering in test names and helpers, and add guidance for frontend type-checking and coverage gates.

### Description

- Normalised API-layer references to the active entry surface by replacing `src/backend/Api` with `src/backend/z_Api` in multiple agent/docs files including `src/backend/AGENTS.md`, `docs/developer/backend/AssessmentFlow.md`, and `docs/developer/backend/backend-testing.md`.
- Expanded the configuration migration `ACTION_PLAN.md` to specify method names, exact read/write field lists, the `{ success: true } | { success: false, error: string }` save-result contract, validation rules (ignore `undefined`, allow `apiKey: ''` to clear), and upgraded acceptance criteria and required tests for the new transport.
- Added testing and naming guidance to `docs/developer/frontend/frontend-testing.md`, `docs/developer/backend/backend-testing.md`, and `.github/agents/Testing.agent.md` to require behaviour-focused test names and to forbid action-plan section numbers in `describe` blocks and helper constants.
- Added explicit developer workflow notes to run TypeScript checks with `npm exec tsc -- -b src/frontend/tsconfig.json` and emphasised frontend/builder coverage gates and the 85% threshold for unit tests where applicable.

### Testing

- No automated tests were modified or executed as part of this PR; the changes are documentation and guidance only. 
- The updated plan includes explicit `npm` commands to run when implementing the feature (for example `npm test -- tests/api/backendConfigApi.test.js` and `npm run frontend:test -- src/services/configurationService.spec.ts`) which should be used when implementing code changes covered by this plan.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba62eccd908329aa97fc99a41595b7)