### PR TITLE
Add tabbed Settings section, tests, Playwright tab coverage rule, and ResizeObserver test mock

### DIFF
--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -88,6 +88,8 @@ Use a strict behaviour split when writing frontend tests:
 When both are possible, default to Vitest first for fast feedback, then add Playwright coverage for the highest-value user journeys.
 Vitest + Testing Library may still assert user-visible component outcomes; use Playwright when the confidence target is full browser/runtime behaviour across integration boundaries.
 
+**Mandatory rule:** every new or changed **user-visible interaction** must have Playwright coverage. Do not treat Vitest coverage as sufficient for clicks, keyboard interaction, tab switching, toggles, navigation, or other visible browser behaviour. Where a Vitest test covers visible rendering, add or update a Playwright test that exercises the same interaction in a real browser so visible interaction coverage remains as comprehensive as the supporting Vitest coverage.
+
 ### Quick decision matrix
 
 - Is the assertion mostly about internal state or non-visual wiring? → **Vitest**.

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -88,7 +88,17 @@ Use a strict behaviour split when writing frontend tests:
 When both are possible, default to Vitest first for fast feedback, then add Playwright coverage for the highest-value user journeys.
 Vitest + Testing Library may still assert user-visible component outcomes; use Playwright when the confidence target is full browser/runtime behaviour across integration boundaries.
 
-**Mandatory rule:** every new or changed **user-visible interaction** must have Playwright coverage. Do not treat Vitest coverage as sufficient for clicks, keyboard interaction, tab switching, toggles, navigation, or other visible browser behaviour. Where a Vitest test covers visible rendering, add or update a Playwright test that exercises the same interaction in a real browser so visible interaction coverage remains as comprehensive as the supporting Vitest coverage.
+**Mandatory rule:** every new or changed **user-visible interaction** must have Playwright coverage.
+
+Do not treat Vitest coverage as sufficient for visible browser behaviour such as:
+
+- clicks
+- keyboard interaction
+- tab switching
+- toggles
+- navigation
+
+Where a Vitest test covers visible rendering, add or update a Playwright test that exercises the same interaction in a real browser so visible interaction coverage remains as comprehensive as the supporting Vitest coverage.
 
 ### Quick decision matrix
 

--- a/src/backend/z_Api/apiConfig.js
+++ b/src/backend/z_Api/apiConfig.js
@@ -30,7 +30,7 @@ function maskApiKey(key) {
  */
 function getBackendConfig() {
   const errors = [];
-  const configurationManager = ConfigurationManager.getInstance();
+  const configManager = ConfigurationManager.getInstance();
 
   /**
    * Reads a single configuration value while preserving legacy fallback behaviour.
@@ -52,53 +52,53 @@ function getBackendConfig() {
     }
   }
 
-  const rawApiKey = safeGet(() => configurationManager.getApiKey(), 'apiKey', '');
+  const rawApiKey = safeGet(() => configManager.getApiKey(), 'apiKey', '');
   const config = {
     backendAssessorBatchSize: safeGet(
-      () => configurationManager.getBackendAssessorBatchSize(),
+      () => configManager.getBackendAssessorBatchSize(),
       'backendAssessorBatchSize',
       DEFAULT_BACKEND_ASSESSOR_BATCH_SIZE
     ),
     apiKey: maskApiKey(rawApiKey),
     hasApiKey: !!rawApiKey,
-    backendUrl: safeGet(() => configurationManager.getBackendUrl(), 'backendUrl', ''),
+    backendUrl: safeGet(() => configManager.getBackendUrl(), 'backendUrl', ''),
     revokeAuthTriggerSet: safeGet(
-      () => configurationManager.getRevokeAuthTriggerSet(),
+      () => configManager.getRevokeAuthTriggerSet(),
       'revokeAuthTriggerSet',
       false
     ),
     daysUntilAuthRevoke: safeGet(
-      () => configurationManager.getDaysUntilAuthRevoke(),
+      () => configManager.getDaysUntilAuthRevoke(),
       'daysUntilAuthRevoke',
       DEFAULT_DAYS_UNTIL_AUTH_REVOKE
     ),
     slidesFetchBatchSize: safeGet(
-      () => configurationManager.getSlidesFetchBatchSize(),
+      () => configManager.getSlidesFetchBatchSize(),
       'slidesFetchBatchSize',
       DEFAULT_SLIDES_FETCH_BATCH_SIZE
     ),
     jsonDbMasterIndexKey: safeGet(
-      () => configurationManager.getJsonDbMasterIndexKey(),
+      () => configManager.getJsonDbMasterIndexKey(),
       'jsonDbMasterIndexKey',
       ConfigurationManager.DEFAULTS.JSON_DB_MASTER_INDEX_KEY
     ),
     jsonDbLockTimeoutMs: safeGet(
-      () => configurationManager.getJsonDbLockTimeoutMs(),
+      () => configManager.getJsonDbLockTimeoutMs(),
       'jsonDbLockTimeoutMs',
       ConfigurationManager.DEFAULTS.JSON_DB_LOCK_TIMEOUT_MS
     ),
     jsonDbLogLevel: safeGet(
-      () => configurationManager.getJsonDbLogLevel(),
+      () => configManager.getJsonDbLogLevel(),
       'jsonDbLogLevel',
       ConfigurationManager.DEFAULTS.JSON_DB_LOG_LEVEL
     ),
     jsonDbBackupOnInitialise: safeGet(
-      () => configurationManager.getJsonDbBackupOnInitialise(),
+      () => configManager.getJsonDbBackupOnInitialise(),
       'jsonDbBackupOnInitialise',
       ConfigurationManager.DEFAULTS.JSON_DB_BACKUP_ON_INITIALISE
     ),
     jsonDbRootFolderId: safeGet(
-      () => configurationManager.getJsonDbRootFolderId(),
+      () => configManager.getJsonDbRootFolderId(),
       'jsonDbRootFolderId',
       ''
     ),
@@ -125,62 +125,62 @@ function setBackendConfig(config) {
   }
 
   const errors = [];
-  const configurationManager = ConfigurationManager.getInstance();
+  const configManager = ConfigurationManager.getInstance();
   const updates = [
     {
       name: 'backendAssessorBatchSize',
       value: config.backendAssessorBatchSize,
-      applySetting: (value) => configurationManager.setBackendAssessorBatchSize(value),
+      applySetting: (value) => configManager.setBackendAssessorBatchSize(value),
     },
     {
       name: 'slidesFetchBatchSize',
       value: config.slidesFetchBatchSize,
-      applySetting: (value) => configurationManager.setSlidesFetchBatchSize(value),
+      applySetting: (value) => configManager.setSlidesFetchBatchSize(value),
     },
     {
       name: 'apiKey',
       value: config.apiKey,
-      applySetting: (value) => configurationManager.setApiKey(value),
+      applySetting: (value) => configManager.setApiKey(value),
     },
     {
       name: 'backendUrl',
       value: config.backendUrl,
-      applySetting: (value) => configurationManager.setBackendUrl(value),
+      applySetting: (value) => configManager.setBackendUrl(value),
     },
     {
       name: 'revokeAuthTriggerSet',
       value: config.revokeAuthTriggerSet,
-      applySetting: (value) => configurationManager.setRevokeAuthTriggerSet(value),
+      applySetting: (value) => configManager.setRevokeAuthTriggerSet(value),
     },
     {
       name: 'daysUntilAuthRevoke',
       value: config.daysUntilAuthRevoke,
-      applySetting: (value) => configurationManager.setDaysUntilAuthRevoke(value),
+      applySetting: (value) => configManager.setDaysUntilAuthRevoke(value),
     },
     {
       name: 'jsonDbMasterIndexKey',
       value: config.jsonDbMasterIndexKey,
-      applySetting: (value) => configurationManager.setJsonDbMasterIndexKey(value),
+      applySetting: (value) => configManager.setJsonDbMasterIndexKey(value),
     },
     {
       name: 'jsonDbLockTimeoutMs',
       value: config.jsonDbLockTimeoutMs,
-      applySetting: (value) => configurationManager.setJsonDbLockTimeoutMs(value),
+      applySetting: (value) => configManager.setJsonDbLockTimeoutMs(value),
     },
     {
       name: 'jsonDbLogLevel',
       value: config.jsonDbLogLevel,
-      applySetting: (value) => configurationManager.setJsonDbLogLevel(value),
+      applySetting: (value) => configManager.setJsonDbLogLevel(value),
     },
     {
       name: 'jsonDbBackupOnInitialise',
       value: config.jsonDbBackupOnInitialise,
-      applySetting: (value) => configurationManager.setJsonDbBackupOnInitialise(value),
+      applySetting: (value) => configManager.setJsonDbBackupOnInitialise(value),
     },
     {
       name: 'jsonDbRootFolderId',
       value: config.jsonDbRootFolderId,
-      applySetting: (value) => configurationManager.setJsonDbRootFolderId(value),
+      applySetting: (value) => configManager.setJsonDbRootFolderId(value),
     },
   ];
 

--- a/src/frontend/e2e-tests/app.spec.ts
+++ b/src/frontend/e2e-tests/app.spec.ts
@@ -165,6 +165,24 @@ test.describe('app shell', () => {
     await expect(settingsItem).toHaveClass(/ant-menu-item-selected/);
   });
 
+  test('settings tabs switch visible panels in the browser', async ({ page }) => {
+    await mockPendingGoogleScriptRun(page);
+    await page.goto('/');
+
+    await page.getByRole('menuitem', { name: settingsLabel }).click();
+
+    const classesTab = page.getByRole('tab', { name: 'Classes' });
+    const backendSettingsTab = page.getByRole('tab', { name: 'Backend settings' });
+
+    await expect(classesTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('region', { name: 'Classes panel' })).toBeVisible();
+
+    await backendSettingsTab.click();
+
+    await expect(backendSettingsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByRole('region', { name: 'Backend settings panel' })).toBeVisible();
+  });
+
   test('shows shell on initial load', async ({ page }) => {
     await mockPendingGoogleScriptRun(page);
     await page.goto('/');

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -82,6 +82,14 @@ body {
   width: min(100%, 720px);
 }
 
+.app-tabbed-page {
+  width: 100%;
+}
+
+.settings-tab-panel {
+  min-height: 16rem;
+}
+
 .auth-card {
   width: min(100%, 720px);
   text-align: center;

--- a/src/frontend/src/pages/SettingsPage.spec.tsx
+++ b/src/frontend/src/pages/SettingsPage.spec.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SettingsPage } from './SettingsPage';
+import { pageContent } from './pageContent';
+
+describe('SettingsPage', () => {
+  it('renders the shared settings heading and summary copy', () => {
+    render(<SettingsPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: pageContent.settings.heading })
+    ).toBeInTheDocument();
+    expect(screen.getByText(pageContent.settings.summary)).toBeInTheDocument();
+  });
+
+  it('renders the settings tabs and switches between placeholder panels', () => {
+    render(<SettingsPage />);
+
+    const classesTab = screen.getByRole('tab', { name: 'Classes' });
+    const backendSettingsTab = screen.getByRole('tab', { name: 'Backend settings' });
+
+    expect(classesTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('region', { name: 'Classes panel' })).toBeInTheDocument();
+
+    fireEvent.click(backendSettingsTab);
+
+    expect(backendSettingsTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('region', { name: 'Backend settings panel' })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/SettingsPage.tsx
+++ b/src/frontend/src/pages/SettingsPage.tsx
@@ -3,18 +3,27 @@ import type { TabsProps } from 'antd';
 import { TabbedPageSection } from './TabbedPageSection';
 import { pageContent } from './pageContent';
 
-const settingsTabs = [
+type SettingsTabDefinition = Readonly<{
+  key: string;
+  label: string;
+}>;
+
+const settingsTabDefinitions: SettingsTabDefinition[] = [
   {
     key: 'classes',
     label: 'Classes',
-    children: <SettingsPlaceholderPanel label="Classes" />,
   },
   {
     key: 'backend-settings',
     label: 'Backend settings',
-    children: <SettingsPlaceholderPanel label="Backend settings" />,
   },
-] satisfies NonNullable<TabsProps['items']>;
+];
+
+const settingsTabs = settingsTabDefinitions.map(({ key, label }) => ({
+  key,
+  label,
+  children: <SettingsPlaceholderPanel label={label} />,
+})) satisfies NonNullable<TabsProps['items']>;
 
 /**
  * Renders a blank placeholder panel for a settings section.
@@ -22,9 +31,7 @@ const settingsTabs = [
  * @param {Readonly<{ label: string }>} properties Placeholder panel properties.
  * @returns {JSX.Element} The placeholder panel.
  */
-function SettingsPlaceholderPanel(properties: Readonly<{ label: string }>) {
-  const { label } = properties;
-
+function SettingsPlaceholderPanel({ label }: Readonly<{ label: string }>) {
   return <Card className="settings-tab-panel" role="region" aria-label={`${label} panel`} />;
 }
 

--- a/src/frontend/src/pages/SettingsPage.tsx
+++ b/src/frontend/src/pages/SettingsPage.tsx
@@ -1,16 +1,45 @@
-import { PageSection } from './PageSection';
+import { Card } from 'antd';
+import type { TabsProps } from 'antd';
+import { TabbedPageSection } from './TabbedPageSection';
 import { pageContent } from './pageContent';
 
+const settingsTabs = [
+  {
+    key: 'classes',
+    label: 'Classes',
+    children: <SettingsPlaceholderPanel label="Classes" />,
+  },
+  {
+    key: 'backend-settings',
+    label: 'Backend settings',
+    children: <SettingsPlaceholderPanel label="Backend settings" />,
+  },
+] satisfies NonNullable<TabsProps['items']>;
+
 /**
- * Renders the settings placeholder page.
+ * Renders a blank placeholder panel for a settings section.
+ *
+ * @param {Readonly<{ label: string }>} properties Placeholder panel properties.
+ * @returns {JSX.Element} The placeholder panel.
+ */
+function SettingsPlaceholderPanel(properties: Readonly<{ label: string }>) {
+  const { label } = properties;
+
+  return <Card className="settings-tab-panel" role="region" aria-label={`${label} panel`} />;
+}
+
+/**
+ * Renders the settings page with reusable Ant Design tabs for each section.
  *
  * @returns {JSX.Element} The settings page.
  */
 export function SettingsPage() {
   return (
-    <PageSection
+    <TabbedPageSection
+      defaultActiveKey="classes"
       heading={pageContent.settings.heading}
       summary={pageContent.settings.summary}
+      tabs={settingsTabs}
     />
   );
 }

--- a/src/frontend/src/pages/TabbedPageSection.spec.tsx
+++ b/src/frontend/src/pages/TabbedPageSection.spec.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { TabsProps } from 'antd';
+import { TabbedPageSection } from './TabbedPageSection';
+
+const tabbedPageSectionTabs = [
+  {
+    key: 'overview',
+    label: 'Overview',
+    children: <div>Overview panel</div>,
+  },
+  {
+    key: 'advanced',
+    label: 'Advanced',
+    children: <div>Advanced panel</div>,
+  },
+] satisfies NonNullable<TabsProps['items']>;
+
+describe('TabbedPageSection', () => {
+  it('renders shared page chrome with the supplied default tab content', () => {
+    render(
+      <TabbedPageSection
+        defaultActiveKey="overview"
+        heading="Reusable settings"
+        summary="Shared tabbed layout summary"
+        tabs={tabbedPageSectionTabs}
+      />
+    );
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Reusable settings' })).toBeInTheDocument();
+    expect(screen.getByText('Shared tabbed layout summary')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Overview panel')).toBeInTheDocument();
+  });
+
+  it('switches panel content when a different tab is selected', () => {
+    render(
+      <TabbedPageSection
+        defaultActiveKey="overview"
+        heading="Reusable settings"
+        summary="Shared tabbed layout summary"
+        tabs={tabbedPageSectionTabs}
+      />
+    );
+
+    const advancedTab = screen.getByRole('tab', { name: 'Advanced' });
+
+    fireEvent.click(advancedTab);
+
+    expect(advancedTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Advanced panel')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/pages/TabbedPageSection.tsx
+++ b/src/frontend/src/pages/TabbedPageSection.tsx
@@ -1,0 +1,26 @@
+import { Tabs } from 'antd';
+import type { TabsProps } from 'antd';
+import { PageSection } from './PageSection';
+
+type TabbedPageSectionProperties = Readonly<{
+  defaultActiveKey: string;
+  heading: string;
+  summary: string;
+  tabs: NonNullable<TabsProps['items']>;
+}>;
+
+/**
+ * Renders shared page chrome with an Ant Design tabset for sectioned settings views.
+ *
+ * @param {TabbedPageSectionProperties} properties Tabbed page configuration.
+ * @returns {JSX.Element} The tabbed page section.
+ */
+export function TabbedPageSection(properties: TabbedPageSectionProperties) {
+  const { defaultActiveKey, heading, summary, tabs } = properties;
+
+  return (
+    <PageSection heading={heading} summary={summary}>
+      <Tabs className="app-tabbed-page" defaultActiveKey={defaultActiveKey} items={tabs} />
+    </PageSection>
+  );
+}

--- a/src/frontend/src/pages/pages.spec.tsx
+++ b/src/frontend/src/pages/pages.spec.tsx
@@ -23,7 +23,7 @@ const pageComponentLoaders: Record<AppNavigationKey, () => Promise<ComponentType
   },
 };
 
-describe('section 5 page components', () => {
+describe('page components', () => {
   it.each(pageExpectations)(
     'renders the expected heading and summary text for $heading',
     async ({ heading, key, summary }) => {
@@ -36,3 +36,4 @@ describe('section 5 page components', () => {
     }
   );
 });
+

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -1,1 +1,27 @@
 import '@testing-library/jest-dom/vitest';
+
+/**
+ * Minimal ResizeObserver test double required by Ant Design tab measurements in jsdom.
+ */
+class ResizeObserverMock {
+  /**
+   * Starts observing the supplied element.
+   */
+  observe() {}
+
+  /**
+   * Stops observing the supplied element.
+   */
+  unobserve() {}
+
+  /**
+   * Disconnects all active observations.
+   */
+  disconnect() {}
+}
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  configurable: true,
+  value: ResizeObserverMock,
+  writable: true,
+});

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -6,18 +6,30 @@ import '@testing-library/jest-dom/vitest';
 class ResizeObserverMock {
   /**
    * Starts observing the supplied element.
+   *
+   * @returns {void} No return value.
    */
-  observe() {}
+  observe() {
+    return;
+  }
 
   /**
    * Stops observing the supplied element.
+   *
+   * @returns {void} No return value.
    */
-  unobserve() {}
+  unobserve() {
+    return;
+  }
 
   /**
    * Disconnects all active observations.
+   *
+   * @returns {void} No return value.
    */
-  disconnect() {}
+  disconnect() {
+    return;
+  }
 }
 
 Object.defineProperty(globalThis, 'ResizeObserver', {

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.spec.{ts,tsx}'],
     setupFiles: './src/test/setup.ts',
+    // Keep jsdom + Ant Design suites below the default worker fan-out to avoid
+    // intermittent App.spec.tsx timeouts caused by worker contention.
+    maxWorkers: 2,
     testTimeout: 15_000,
     coverage: {
       include: ['src/**/*.{ts,tsx}'],


### PR DESCRIPTION
### Motivation

- Provide a reusable tabbed layout for settings pages and ensure visible tab interactions are covered by browser-level tests.
- Make component tab behaviour testable in jsdom by adding a minimal `ResizeObserver` test double required by Ant Design.

### Description

- Add a new `TabbedPageSection` component that renders shared page chrome and an Ant Design `Tabs` instance, and add `.app-tabbed-page` and `.settings-tab-panel` CSS rules.
- Refactor `SettingsPage` to use `TabbedPageSection` and introduce `SettingsPlaceholderPanel` for tab content placeholders.
- Add unit tests `TabbedPageSection.spec.tsx` and `SettingsPage.spec.tsx`, and rename the pages test suite title in `pages.spec.tsx` for clarity.
- Add a Playwright e2e test that verifies settings tabs switch visible panels in the browser and add a `ResizeObserver` mock in `src/test/setup.ts` to support Ant tab measurements in jsdom.
- Update developer docs to require Playwright coverage for every new or changed user-visible interaction.

### Testing

- Ran unit/component tests with `npm run frontend:test` (Vitest) which executed `TabbedPageSection.spec.tsx` and `SettingsPage.spec.tsx` and they passed.
- Ran the Playwright e2e suite with `npm run frontend:test:e2e` which included the new settings tab interaction test and it passed.
- Verified the test setup by adding `src/test/setup.ts` to provide `ResizeObserver` so Ant Design tabs render in the jsdom environment and unit tests remain stable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf46df0808329b5d39fe0c63b97bb)