### PR TITLE
Add TDD-first Action Plan and refine Settings layout and frontend agent rules

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -1,0 +1,448 @@
+# Feature Delivery Plan (TDD-First)
+
+## Scope and assumptions
+
+### Scope
+
+- Implement the new frontend **Backend settings** feature under the existing `SettingsPage` tab structure.
+- Replace the current backend settings placeholder with a sectioned Ant Design form that follows `SETTINGS_PAGE_LAYOUT.md`.
+- Keep frontend/backend integration routed through the existing frontend service layer (`apiService.ts` → `backendConfigurationService.ts` → backend `apiHandler`).
+- Add the required frontend feature files under `src/frontend/src/features/settings/backend/` and wire them into the existing settings page composition.
+- Implement frontend-only validation, mapping, hook state management, user feedback, accessibility behaviour, and automated test coverage for the feature.
+- Reuse existing shared frontend facilities wherever possible, including:
+  - `src/frontend/src/services/apiService.ts`
+  - `src/frontend/src/services/backendConfigurationService.ts`
+  - `src/frontend/src/services/backendConfiguration.zod.ts`
+  - shared frontend logging/error handling utilities
+  - existing `SettingsPage` / `TabbedPageSection` composition
+  - existing frontend test helpers and Playwright harness patterns
+
+### Out of scope
+
+- Changing the backend configuration transport contract unless implementation uncovers a genuine mismatch with the agreed layout plan.
+- Introducing a bespoke recovery workflow for hard configuration load failures.
+- Adding UI support for `revokeAuthTriggerSet`.
+- Adding UI support for explicit API key clearing.
+- Reworking the broader Settings information architecture beyond replacing the backend settings placeholder tab content.
+- Changing TypeScript or ESLint configuration unless implementation uncovers a true blocker.
+
+### Assumptions
+
+1. `getBackendConfig` and `setBackendConfig` remain the canonical backend configuration methods, exposed through `backendConfigurationService.ts` and ultimately routed via `callApi(...)`.
+2. The current backend validation limits and field semantics remain authoritative, so the new frontend form schema should mirror them rather than inventing parallel rules.
+3. A successful save should immediately re-fetch backend configuration and re-base the form from the returned payload.
+4. A complete initial load failure should fail fast and render a top-level Ant Design `Alert`.
+5. Partial-load warnings returned as backend `loadError` should keep the form visible but block saving.
+6. Shared frontend error contracts/mappers should be preferred, with backend-settings-specific mapping added only if the feature ends up with genuinely unique semantics.
+
+---
+
+## Global constraints and quality gates
+
+### Engineering constraints
+
+- Keep `SettingsPage.tsx` as a composition layer only.
+- Keep `BackendSettingsPanel.tsx` presentational; place orchestration and side effects in `useBackendSettings.ts`.
+- Route all frontend-to-backend calls through `callApi(...)`; never call backend globals or `google.script.run` directly.
+- Reuse `backendConfigurationService.ts` and `backendConfiguration.zod.ts` rather than duplicating transport logic.
+- Reuse shared error contracts/mappers and shared logging utilities before creating feature-specific abstractions.
+- Fail fast on invalid inputs, transport failures, and persistence failures.
+- Do not add a bespoke recovery path for hard load failures in this iteration.
+- Keep changes minimal, localised, and consistent with repository conventions.
+- Use British English in comments and documentation.
+
+### TDD workflow (mandatory per section)
+
+For each section below:
+
+1. **Red**: write failing tests for the section’s acceptance criteria.
+2. **Green**: implement the smallest change needed to pass.
+3. **Refactor**: tidy implementation with all tests still green.
+4. Run section-level verification commands.
+
+### Validation commands hierarchy
+
+- Backend lint: `npm run lint`
+- Frontend lint: `npm run frontend:lint`
+- Builder lint (if touched): `npm run builder:lint`
+- Backend tests: `npm test -- <target>`
+- Frontend unit tests: `npm run frontend:test -- <target>`
+- Frontend e2e tests (if UX changes): `npm run frontend:test:e2e -- <target>`
+- Frontend coverage: `npm run frontend:test:coverage`
+- Frontend type-check: `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+---
+
+## Section 1 — Frontend entry wiring and shell prerequisites
+
+### Objective
+
+- Replace the backend settings placeholder with a real feature entry point and add the shell prerequisites needed for context-aware Ant Design feedback.
+
+### Constraints
+
+- Keep `src/frontend/src/App.tsx` thin and avoid introducing feature orchestration there.
+- Add Ant Design `App` support at the shell/root level rather than inside the backend settings feature.
+- Preserve the existing `SettingsPage` tab structure and reuse `TabbedPageSection`.
+- Do not introduce any direct backend calls in page components.
+
+### Acceptance criteria
+
+- `SettingsPage` renders `BackendSettingsPanel` for the backend settings tab instead of a blank placeholder card.
+- The application shell provides the Ant Design `App` context required for `App.useApp()`.
+- The existing settings heading/summary and tab structure still render correctly.
+- No service calls or feature state machines are introduced into `App.tsx` or `SettingsPage.tsx`.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None unless frontend integration work uncovers a required transport contract adjustment.
+
+Frontend tests:
+
+1. `SettingsPage` renders the backend settings feature entry instead of the old placeholder panel.
+2. `SettingsPage` still preserves the existing tabs and switches correctly between Classes and Backend settings.
+3. The shell provides Ant Design `App` context without regressing the existing app render path.
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/pages/SettingsPage.spec.tsx src/frontend/src/App.spec.tsx`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Section 2 — Form contract, validation, and mapping
+
+### Objective
+
+- Introduce the backend settings form schema and mapping layer so frontend input rules mirror the backend contract while keeping transport validation and form validation separate.
+
+### Constraints
+
+- Reuse `src/frontend/src/services/backendConfiguration.zod.ts` for transport shape validation; do not duplicate that contract in the feature.
+- Keep form-specific rules in `backendSettingsForm.zod.ts`.
+- Mirror backend numeric ranges, enum values, URL semantics, and optional field rules exactly.
+- Prefer shared frontend error contracts/mappers; add feature-specific mapping only if genuinely necessary.
+- Keep API key handling to replacement or retention only.
+
+### Acceptance criteria
+
+- A dedicated `backendSettingsForm.zod.ts` exists and derives its TypeScript types from the schema.
+- A dedicated mapper converts between backend configuration payloads, form values, and write payloads without duplicating transport logic.
+- Form validation enforces the agreed field rules for `backendUrl`, integer ranges, log-level enum, optional Drive folder ID, and API key conditional requirements.
+- API key handling preserves the stored-key/blank-field semantics described in `SETTINGS_PAGE_LAYOUT.md`.
+- Error mapping uses shared contracts/utilities where possible and only adds backend-settings-specific mapping if unique semantics appear.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. Extend `tests/api/backendConfigApi.test.js` only if implementation reveals a real transport mismatch that must be fixed in backend configuration transport.
+
+Frontend tests:
+
+1. `backendSettingsForm.zod.ts` accepts valid form values matching backend ranges and enums.
+2. `backendSettingsForm.zod.ts` rejects invalid URL, integer range, enum, and folder-ID inputs.
+3. API key validation requires a value only when `hasStoredApiKey` is false.
+4. Mapper logic converts backend masked payloads into form values without leaking masked API key content into the input.
+5. Mapper logic omits `apiKey` from the write payload when a stored key exists and the field is left blank.
+6. Mapper logic includes `apiKey` when a replacement value is entered.
+7. Error mapping uses shared contracts for generic transport/domain failures and only introduces feature-specific mapping when warranted.
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/features/settings/backend/backendSettingsForm.zod.spec.ts src/frontend/src/features/settings/backend/backendSettingsFormMapper.spec.ts src/frontend/src/services/backendConfigurationService.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Section 3 — Hook orchestration and state model
+
+### Objective
+
+- Implement `useBackendSettings.ts` as the single orchestration point for load, save, state transitions, blocking rules, error mapping, and successful-save re-fetch behaviour.
+
+### Constraints
+
+- Keep all backend interaction inside the hook/service boundary.
+- Use the explicit state model from `SETTINGS_PAGE_LAYOUT.md` (`isInitialLoading`, `loadError`, `partialLoadError`, `isSaveBlocked`, `isSaving`, `saveError`, `hasStoredApiKey`).
+- A complete initial load failure must fail fast and surface a top-level `Alert` state.
+- Partial-load warnings must block save without hiding the form.
+- Successful save must re-fetch current config from the backend and re-base the form.
+- Do not add a bespoke recovery workflow for hard load failures.
+
+### Acceptance criteria
+
+- `useBackendSettings.ts` owns initial load, save submission, re-fetch after save, and error clearing rules.
+- The hook consumes `backendConfigurationService.ts` only; no direct transport calls or backend globals are introduced.
+- Hard load failures map to a top-level failure state.
+- Partial-load warnings set a blocked-save state while keeping editable data visible.
+- Save submission uses the smallest safe write payload generated by the mapper.
+- Successful save clears stale save errors, shows success feedback, re-fetches config, and re-bases the form from the fresh payload.
+- Save failures preserve current input state and map to persistent user-safe inline feedback.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None unless implementation reveals a real transport contract issue.
+
+Frontend tests:
+
+1. Initial load enters `isInitialLoading` and resolves into editable state on success.
+2. Initial hard load failure sets `loadError`, prevents save, and exposes the top-level failure state.
+3. Successful read with backend `loadError` sets `partialLoadError` and `isSaveBlocked` while keeping form data available.
+4. Save submission sets `isSaving`, clears stale save error, and calls the mapper/service correctly.
+5. Successful save triggers `message.success`, re-fetches backend config, and re-bases the form from the returned payload.
+6. Domain save failures (`{ success: false, error }`) map to persistent save error state.
+7. Transport/runtime failures map to the shared user-safe error path and keep current form values intact.
+8. API key branch logic behaves correctly for stored-key and no-key states.
+9. Hook state resets appropriately after a successful reload/save.
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/features/settings/backend/useBackendSettings.spec.ts src/frontend/src/services/backendConfigurationService.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Section 4 — Backend settings panel UI and accessibility
+
+### Objective
+
+- Build the presentational backend settings panel with sectioned Ant Design cards, clear labels, correct field bindings, and accessible failure/success feedback.
+
+### Constraints
+
+- Keep the panel declarative and drive behaviour from the hook.
+- Use the agreed Ant Design components and built-in features before adding custom behaviour.
+- Use a top-level `Alert` for hard initial load failure and inline `Alert` components for partial-load/save failures.
+- Use `scrollToFirstError={{ focus: true }}` and preserve visible labels and semantic grouping.
+- Keep save as the only user action in this iteration; do not add reset/reload controls.
+
+### Acceptance criteria
+
+- `BackendSettingsPanel.tsx` renders the agreed cards/sections and field set from the layout plan.
+- Ant Design `Form` is vertical, named, and configured to focus/scroll to the first invalid field on submit failure.
+- The API key input behaves as a replacement-only field with stored-key helper text.
+- `jsonDbBackupOnInitialise` binds through `valuePropName="checked"`.
+- Hard load failures render a top-level `Alert`.
+- Partial-load warnings and save failures render persistent inline `Alert` feedback.
+- Save button loading/disabled state follows the hook state model.
+- Success feedback uses `App.useApp()`/`message.success` within the provided Ant Design `App` context.
+- The panel remains accessible with visible labels, semantic section grouping, and keyboard-friendly form behaviour.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+1. Component renders skeleton during initial load.
+2. Component renders top-level `Alert` for hard load failure.
+3. Component renders inline warning for partial-load `loadError`.
+4. Component renders all planned fields/cards with visible labels.
+5. Save button is disabled when `isSaveBlocked` or `isSaving` is true.
+6. Save button shows loading while save is in flight.
+7. Validation errors are rendered inline and associated with the correct fields.
+8. Submit failure focuses or scrolls to the first invalid field.
+9. API key helper text changes correctly based on `hasStoredApiKey`.
+10. Boolean and numeric fields bind correctly to Ant Design form state.
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/features/settings/backend/BackendSettingsPanel.spec.tsx`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Section 5 — End-to-end-visible behaviour and cross-layer tests
+
+### Objective
+
+- Add comprehensive automated coverage for the new backend settings feature using the repo’s Vitest/Playwright split and existing service/API test locations.
+
+### Constraints
+
+- Follow the authoritative Vitest vs Playwright split from `docs/developer/frontend/frontend-testing.md`.
+- Keep transport/service assertions in `src/frontend/src/services/backendConfigurationService.spec.ts`.
+- Keep backend configuration transport assertions in `tests/api/backendConfigApi.test.js`.
+- Every user-visible interaction must have Playwright coverage.
+- Prefer extending existing test helpers over copying setup logic.
+
+### Acceptance criteria
+
+- Frontend unit/component tests cover validation, mapping, hook state transitions, rendering, accessibility attributes, and error mapping.
+- Playwright covers the visible user journey through Settings → Backend settings, including validation, save, blocked-save state, keyboard interaction, and success/failure feedback.
+- Transport-layer tests remain separated by responsibility between frontend service specs and backend API specs.
+- New tests use behaviour-based names rather than action-plan section labels.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. `tests/api/backendConfigApi.test.js` still verifies the backend configuration transport contract relied on by the frontend.
+2. `tests/api/apiHandler.test.js` is updated only if dispatcher-level contract coverage must change.
+
+Frontend tests:
+
+1. `backendConfigurationService.spec.ts` continues to verify `callApi` usage and request/response validation boundaries.
+2. `BackendSettingsPanel.spec.tsx` covers visible rendering outcomes and accessibility structure.
+3. `useBackendSettings.spec.ts` covers invisible state transitions and orchestration.
+4. Playwright covers:
+   - navigation to Settings and the Backend settings tab
+   - initial skeleton state
+   - hard load failure top-level `Alert`
+   - keyboard-only data entry
+   - inline validation and first-invalid-field focus
+   - blocked save when partial-load warning exists
+   - API key retention with existing stored key
+   - API key requirement when no stored key exists
+   - successful save followed by visible refresh from backend data
+   - visible save failure feedback
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/services/backendConfigurationService.spec.ts src/frontend/src/features/settings/backend/useBackendSettings.spec.ts src/frontend/src/features/settings/backend/BackendSettingsPanel.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/settings-backend.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Regression and contract hardening
+
+### Objective
+
+- Verify the completed backend settings feature against transport contracts, lint/type-check standards, coverage requirements, and visible browser behaviour before considering the work complete.
+
+### Constraints
+
+- Prefer focused test runs before broader validation.
+- Keep transport coverage separated by layer responsibility.
+- Ensure frontend unit/component coverage remains at or above the repository threshold.
+
+### Acceptance criteria
+
+- Touched frontend service, hook, component, and e2e suites pass.
+- Any touched backend configuration transport suites pass.
+- Frontend lint, type-check, and coverage checks pass.
+- No direct-backend-call regressions are introduced in frontend code.
+
+### Required test cases/checks
+
+1. Run touched frontend service/unit/component suites.
+2. Run touched Playwright backend settings scenarios.
+3. Run `tests/api/backendConfigApi.test.js` if transport-facing behaviour changes.
+4. Run `npm run frontend:lint`.
+5. Run `npm exec tsc -- -b src/frontend/tsconfig.json`.
+6. Run `npm run frontend:test:coverage`.
+7. Run broader validation commands if section-level runs expose coupling.
+
+### Section checks
+
+- `npm run frontend:test -- src/frontend/src/services/backendConfigurationService.spec.ts src/frontend/src/features/settings/backend/useBackendSettings.spec.ts src/frontend/src/features/settings/backend/BackendSettingsPanel.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/settings-backend.spec.ts`
+- `npm run frontend:test:coverage`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+- `npm test -- tests/api/backendConfigApi.test.js`
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Documentation and rollout notes
+
+### Objective
+
+- Keep implementation-facing documentation aligned with the completed feature and record any genuine deviations discovered during development.
+
+### Constraints
+
+- Only modify documents relevant to the touched areas.
+- Do not backfill the implementation-notes fields in this plan until sections are actually worked.
+
+### Acceptance criteria
+
+- `SETTINGS_PAGE_LAYOUT.md` still reflects the implemented behaviour, or is updated if implementation uncovers a justified deviation.
+- Frontend agent guidance remains accurate if implementation confirms or refines transport/error-handling rules.
+- Any implementation caveats discovered during delivery are recorded in the relevant section notes of this plan.
+- No redundant new docs are added if existing docs already cover the implemented behaviour.
+
+### Required checks
+
+1. Verify the implemented feature still matches the agreed layout and constraint document.
+2. Verify transport/error-handling docs remain accurate for any new shared abstractions.
+3. Confirm implementation-notes/deviation fields are updated by the implementing agent as work progresses.
+
+### Implementation notes / deviations / follow-up
+
+---
+
+## Suggested implementation order
+
+1. Section 1 (frontend entry wiring and shell prerequisites)
+2. Section 2 (form contract, validation, and mapping)
+3. Section 3 (hook orchestration and state model)
+4. Section 4 (backend settings panel UI and accessibility)
+5. Section 5 (end-to-end-visible behaviour and cross-layer tests)
+6. Regression and contract hardening
+7. Documentation and rollout notes

--- a/SETTINGS_PAGE_LAYOUT.md
+++ b/SETTINGS_PAGE_LAYOUT.md
@@ -13,7 +13,13 @@ The goal is to replace the current placeholder backend settings tab with a prope
 3. Use Ant Design components rather than recreating legacy modal patterns.
 4. Keep async orchestration in a feature hook, not in `SettingsPage`.
 5. Validate in the frontend with Zod and again in the backend via the existing configuration manager.
-6. Prefer a single visible form with clear sections over nested tabs, to avoid hidden-field validation problems.
+6. Prefer a single visible form with clear sections over nested tabs to avoid hidden-field validation problems.
+
+## Constraints
+
+1. Do not define a bespoke recovery path for configuration load failures in this iteration.
+2. Allow `callApi(...)` to use its existing retry and exponential backoff behaviour; if configuration loading still fails after that, fail fast and surface the failure clearly for developer debugging.
+3. Use a top-level `Alert` as the default failure state for this settings page rather than introducing a richer recovery flow for now.
 
 ## Proposed component tree
 
@@ -40,10 +46,12 @@ SettingsPage
                 │   ├── JSON DB backup on initialise
                 │   └── JSON DB root folder ID
                 └── FormActions
-                    ├── Save button
-                    └── Optional reset/reload button
+                    └── Save button
+```
 
-Proposed frontend file structure
+## Proposed frontend file structure
+
+```text
 src/frontend/src/
   features/
     settings/
@@ -55,459 +63,506 @@ src/frontend/src/
         backendSettingsForm.zod.ts
         backendSettingsFormMapper.ts
         backendSettingsFields.ts
-Notes
-SettingsPage.tsx should remain a composition layer only.
+```
+
+### Notes
 
-BackendSettingsPanel.tsx should focus on rendering.
+- `SettingsPage.tsx` should remain a composition layer only.
+- `BackendSettingsPanel.tsx` should focus on rendering.
+- `useBackendSettings.ts` should own:
+  - loading current config
+  - preparing form initial values
+  - mapping form values to the write payload
+  - calling `src/frontend/src/services/backendConfigurationService.ts`, which in turn uses `callApi('getBackendConfig')` and `callApi('setBackendConfig', parsedInput)` through the shared `apiHandler` transport rather than calling backend globals directly
+  - handling success and error feedback
+- `backendSettingsForm.zod.ts` should be the canonical frontend validation schema.
+- Ant Design `App.useApp()` requires an `App` provider in the root shell, so the implementation should add that wrapper before the settings feature uses context-aware `message` or `notification`.
+
+### Suggested hook state matrix
 
-useBackendSettings.ts should own:
+Use a small explicit state model in `useBackendSettings.ts` so the React flow stays idiomatic and testable:
+
+- `isInitialLoading`
+  - `true` while the first `getBackendConfig()` request is in flight
+  - renders the initial `Skeleton` state rather than the editable form
+- `loadError`
+  - stores the current blocking load failure message when the initial read fails completely
+  - renders a top-level `Alert`
+- `partialLoadError`
+  - stores backend `loadError` warnings when the payload is present but incomplete
+  - keeps the form visible but blocks saving
+- `isSaveBlocked`
+  - derived from `partialLoadError !== null || loadError !== null`
+  - disables submit affordances while keeping failure visible
+- `isSaving`
+  - `true` only while `setBackendConfig()` is in flight
+  - drives Ant Design loading/disabled affordances rather than custom spinners
+- `saveError`
+  - stores the latest save failure after transport/domain error mapping
+  - renders as persistent inline feedback until the next successful save or reload
+- `hasStoredApiKey`
+  - derived from the read payload and used only for API key UX/validation branching
 
-loading current config
+Suggested transitions:
 
-preparing form initial values
+1. `isInitialLoading` → success: form becomes editable.
+2. `isInitialLoading` → hard failure: show top-level `Alert`, hide or disable the form, fail fast.
+3. successful read with backend `loadError`: show warning `Alert`, render the form, set `isSaveBlocked=true`.
+4. save submit: set `isSaving=true`, clear stale save error, keep load errors intact.
+5. successful save: show `message.success`, then re-fetch current config from the backend and rebase the form from the fresh payload.
+6. failed save: set `saveError`, keep the current form values visible, and clear `isSaving`.
 
-mapping form values to write payload
+## Ant Design components to use
 
-calling getBackendConfig() and setBackendConfig()
+### 1. [Form](https://ant.design/components/form/)
 
-handling success and error feedback
+Use `Form` as the primary interaction container.
 
-backendSettingsForm.zod.ts should be the canonical frontend validation schema.
+**Why**
 
-Ant Design components to use
-1. Form
-Use Form as the primary interaction container.
+- central field registration
+- inline validation feedback
+- submit handling
+- form-wide disabled/loading state
+- strong compatibility with Ant Design inputs
 
-Why
-central field registration
+**Planned usage**
 
-inline validation feedback
+- `Form.useForm()`
+- `name`
+- `layout="vertical"`
+- `onFinish`
+- `onFinishFailed`
+- `requiredMark`
+- `scrollToFirstError={{ focus: true }}`
 
-submit handling
+### 2. [Card](https://ant.design/components/card/)
 
-form-wide disabled/loading state
+Use `Card` for visual section grouping.
 
-strong compatibility with Ant Design inputs
+**Planned grouping**
 
-Planned usage
-Form.useForm()
+- outer page card or panel wrapper
+- inner cards for:
+  - Backend
+  - Advanced
+  - Database
 
-layout="vertical"
+**Why**
 
-onFinish
+- cleaner than nested tabs
+- keeps all fields visible during validation
+- simpler page scanning
 
-onFinishFailed
+### 3. [Input.Password](https://ant.design/components/input/)
 
-requiredMark
+Use `Input.Password` for `apiKey`.
 
-2. Card
-Use Card for visual section grouping.
+**Why**
 
-Planned grouping
-outer page card or panel wrapper
+- communicates sensitivity clearly
+- appropriate for a secret-like value
+- avoids showing the existing value in plain text
 
-inner cards for:
+**Behaviour**
 
-Backend
+- Never prefill with the masked backend value.
+- If a key already exists:
+  - leave the field blank
+  - show helper text or a placeholder indicating a stored key exists
+- If the field is left blank when a key already exists:
+  - omit `apiKey` from the save payload
+- If no key exists:
+  - require a non-empty API key
 
-Advanced
+### 4. [Input](https://ant.design/components/input/)
 
-Database
+Use `Input` for plain string fields:
 
-Why
-cleaner than nested tabs
+- `backendUrl`
+- `jsonDbMasterIndexKey`
+- `jsonDbRootFolderId`
 
-keeps all fields visible during validation
+**Why**
 
-simpler page scanning
+- single-line text entry
+- straightforward integration with `Form.Item`
+- suitable for custom schema validation
 
-3. Input.Password
-Use for apiKey.
+### 5. [InputNumber](https://ant.design/components/input-number/)
 
-Why
-communicates sensitivity clearly
+Use `InputNumber` for bounded integer fields:
 
-appropriate for a secret-like value
+- `backendAssessorBatchSize`
+- `slidesFetchBatchSize`
+- `daysUntilAuthRevoke`
+- `jsonDbLockTimeoutMs`
 
-avoids showing the existing value in plain text
+**Why**
 
-Behaviour
-never prefill with the masked backend value
+- correct numeric affordance
+- built-in min/max UI hints
+- easier to use than free text for numeric configuration
 
-if a key already exists:
+**Planned props**
 
-leave the field blank
+- `precision={0}`
+- `min`
+- `max`
+- full-width styling where needed
 
-show helper text or placeholder indicating a stored key exists
+**Validation note**
 
-if the field is left blank when a key already exists:
+Do not rely on `InputNumber` alone for validation. Final validation still belongs in the Zod schema and backend configuration manager.
 
-omit apiKey from the save payload
+### 6. [Select](https://ant.design/components/select/)
 
-if no key exists:
+Use `Select` for `jsonDbLogLevel`.
 
-require a non-empty API key
+**Options**
 
-4. Input
-Use for plain string fields:
+- `DEBUG`
+- `INFO`
+- `WARN`
+- `ERROR`
 
-backendUrl
+**Why**
 
-jsonDbMasterIndexKey
+- fixed set of values
+- prevents typo-based invalid input
+- mirrors backend-supported values
 
-jsonDbRootFolderId
+### 7. [Switch](https://ant.design/components/switch/)
 
-Why
-single-line text entry
+Use `Switch` for boolean settings:
 
-straightforward integration with Form.Item
+- `jsonDbBackupOnInitialise`
 
-suitable for custom schema validation
+**Important form binding detail**
 
-5. InputNumber
-Use for bounded integer fields:
-
-backendAssessorBatchSize
-
-slidesFetchBatchSize
-
-daysUntilAuthRevoke
-
-jsonDbLockTimeoutMs
-
-Why
-correct numeric affordance
-
-built-in min/max UI hints
-
-easier to use than free text for numeric configuration
-
-Planned props
-precision={0}
-
-min
-
-max
-
-full width styling where needed
-
-Validation note
-Do not rely on InputNumber alone for validation. Final validation still belongs in the Zod schema and backend configuration manager.
-
-6. Select
-Use for jsonDbLogLevel.
-
-Options
-DEBUG
-
-INFO
-
-WARN
-
-ERROR
-
-Why
-fixed set of values
-
-prevents typo-based invalid input
-
-mirrors backend-supported values
-
-7. Switch
-Use for boolean settings:
-
-jsonDbBackupOnInitialise
-
-optionally revokeAuthTriggerSet if that remains editable in the new UI
-
-Important form binding detail
 Use:
 
+```tsx
 <Form.Item name="jsonDbBackupOnInitialise" valuePropName="checked">
-Why
-Switch binds on checked, not value.
+```
 
-8. Alert
-Use Alert for persistent inline messages.
+**Why**
 
-Planned uses
-top-of-form warning when loadError is returned from getBackendConfig()
+`Switch` binds on `checked`, not `value`.
 
-save failure summaries that need to remain visible while the user corrects issues
+### 8. [Alert](https://ant.design/components/alert/)
 
-optional informational note about API key behaviour
+Use `Alert` for persistent inline messages.
 
-Types
-warning for partial-load issues
+**Planned uses**
 
-error for save problems
+- top-of-form warning when `loadError` is returned from the `backendConfigurationService.getBackendConfig()` read path
+- save failure summaries that need to remain visible while the user corrects issues
+- optional informational note about API key behaviour
 
-info for guidance copy if needed
+**Types**
 
-9. App.useApp() with message and notification
-Use context-aware Ant Design feedback APIs.
+- `warning` for partial-load issues
+- `error` for save problems
+- `info` for guidance copy if needed
 
-message
+### 9. [App](https://ant.design/components/app/) with [message](https://ant.design/components/message/) and [notification](https://ant.design/components/notification/)
+
+Use context-aware Ant Design feedback APIs via `App.useApp()`.
+
+**`message`**
+
 Use for short, direct-action feedback:
 
-successful save
+- successful save
+- possibly simple save failure
 
-possibly simple save failure
+**`notification`**
 
-notification
 Use only when failure details are richer and need more space.
 
-Why
+**Why**
+
 These APIs respect app context and theme, and fit the repo’s feedback guidance better than static calls.
 
-10. Button
+### 10. [Button](https://ant.design/components/button/)
+
 Use:
 
-primary Save button
+- primary Save button
 
-optional secondary Reset or Reload button
+**Planned behaviour**
 
-Planned behaviour
-htmlType="submit" for Save
+- `htmlType="submit"` for Save
+- loading while save is in progress
 
-loading while save is in progress
+### 11. [Skeleton](https://ant.design/components/skeleton/)
 
-11. Skeleton
-Use for first-load placeholder rendering before the config payload is available.
+Use `Skeleton` for first-load placeholder rendering before the config payload is available.
 
-Why
-more natural for page-load UX than a blocking spinner
+**Why**
 
-shows users the intended page structure immediately
+- more natural for page-load UX than a blocking spinner
+- shows users the intended page structure immediately
 
-12. Space, Row, Col, and/or Flex
+### 12. Layout helpers: [Space](https://ant.design/components/space/), [Grid (`Row` / `Col`)](https://ant.design/components/grid/), and/or [Flex](https://ant.design/components/flex/)
+
 Use these layout helpers for spacing and responsive form arrangement.
 
-Planned layout approach
-two columns for wider screens where appropriate
+**Planned layout approach**
 
-stacked layout on narrower screens
+- two columns for wider screens where appropriate
+- stacked layout on narrower screens
+- action row aligned consistently beneath the section cards
 
-action row aligned consistently beneath the section cards
+## Field-to-component mapping
 
-Field-to-component mapping
-Setting field	Component	Notes
-apiKey	Input.Password	blank value with masked helper text if already stored
-backendUrl	Input	strict custom HTTPS validation
-backendAssessorBatchSize	InputNumber	integer 1–500
-slidesFetchBatchSize	InputNumber	integer 1–100
-daysUntilAuthRevoke	InputNumber	integer 1–365
-jsonDbMasterIndexKey	Input	required non-empty
-jsonDbLockTimeoutMs	InputNumber	integer 1000–600000
-jsonDbLogLevel	Select	enum value
-jsonDbBackupOnInitialise	Switch	checked binding
-jsonDbRootFolderId	Input	optional, validate only when populated
-Validation model
-Frontend validation source of truth
+| Setting field              | Component        | Notes                                                 |
+| -------------------------- | ---------------- | ----------------------------------------------------- |
+| `apiKey`                   | `Input.Password` | Blank value with masked helper text if already stored |
+| `backendUrl`               | `Input`          | Match existing backend HTTPS validation rules         |
+| `backendAssessorBatchSize` | `InputNumber`    | Integer `1–500`                                       |
+| `slidesFetchBatchSize`     | `InputNumber`    | Integer `1–100`                                       |
+| `daysUntilAuthRevoke`      | `InputNumber`    | Integer `1–365`                                       |
+| `jsonDbMasterIndexKey`     | `Input`          | Required non-empty                                    |
+| `jsonDbLockTimeoutMs`      | `InputNumber`    | Integer `1000–600000`                                 |
+| `jsonDbLogLevel`           | `Select`         | Enum value                                            |
+| `jsonDbBackupOnInitialise` | `Switch`         | `checked` binding                                     |
+| `jsonDbRootFolderId`       | `Input`          | Optional; validate only when populated                |
+
+`revokeAuthTriggerSet` should be removed from the UI entirely. It is a backend operational flag managed by initialisation routines rather than a user-facing setting.
+
+## Validation model
+
+### Frontend validation source of truth
+
 Create a dedicated adjacent schema file:
 
+```text
 src/frontend/src/features/settings/backend/backendSettingsForm.zod.ts
-The frontend form schema should enforce at least the following:
+```
 
-backendUrl
+The frontend form schema should enforce at least the following.
 
-required
+#### `backendUrl`
 
-trimmed
+- required
+- trimmed
+- HTTPS only
+- no whitespace
+- no localhost
+- no IPv4 literal host
+- hostname must be structurally valid
 
-HTTPS only
+#### `backendAssessorBatchSize`
 
-no whitespace
+- integer between `1` and `500`
 
-no localhost
+#### `slidesFetchBatchSize`
 
-no IPv4 literal host
+- integer between `1` and `100`
 
-hostname must be structurally valid
+#### `daysUntilAuthRevoke`
 
-backendAssessorBatchSize
+- integer between `1` and `365`
 
-integer between 1 and 500
+#### `jsonDbMasterIndexKey`
 
-slidesFetchBatchSize
+- required non-empty string
 
-integer between 1 and 100
+#### `jsonDbLockTimeoutMs`
 
-daysUntilAuthRevoke
+- integer between `1000` and `600000`
 
-integer between 1 and 365
+#### `jsonDbLogLevel`
 
-jsonDbMasterIndexKey
+- one of `DEBUG`, `INFO`, `WARN`, `ERROR`
 
-required non-empty string
+#### `jsonDbRootFolderId`
 
-jsonDbLockTimeoutMs
+- optional
+- must match the expected Drive identifier format when supplied
 
-integer between 1000 and 600000
+#### `apiKey`
 
-jsonDbLogLevel
+- required only when no backend key already exists
 
-one of DEBUG, INFO, WARN, ERROR
+### Consistency recommendations for the validation layers
 
-jsonDbRootFolderId
+Keep the three validation layers aligned but distinct:
 
-optional
+1. `backendConfiguration.zod.ts` should remain the transport schema for the backend configuration read/write payload shape.
+2. `backendSettingsForm.zod.ts` should own user-input validation, normalisation, and form-specific rules such as conditional API key requirements.
+3. The backend `ConfigurationManager` remains the final authority for persisted configuration validation.
 
-must match expected Drive identifier format when supplied
+To keep these layers as consistent as possible:
 
-apiKey
+- reuse the same field names and enum values across all layers
+- mirror backend numeric limits exactly in the form schema
+- mirror the backend URL rules exactly rather than introducing different frontend-only URL semantics
+- keep form-only concerns, such as `hasApiKey`-driven conditional requirements, out of the transport schema
+- keep transport-only concerns, such as masked read payloads and write result envelopes, out of the form schema
+- prefer shared frontend error contracts and shared transport/domain mapping utilities where the behaviour is generic
+- add a backend-settings-specific error mapper only if this feature introduces genuinely unique error semantics that would make a shared mapper noisy or misleading
+- add mapper tests that prove form values translate cleanly into `BackendConfigWriteInput`
 
-required only when no backend key already exists
+### Validation strategy
 
-Validation strategy
 Validation should happen in three layers:
 
-Ant Design field integration and inline error rendering
+1. Ant Design field integration and inline error rendering.
+2. Zod schema validation in the frontend feature layer.
+3. Existing backend configuration validation in the configuration manager.
 
-Zod schema validation in the frontend feature layer
+## Data flow
 
-Existing backend configuration validation in the configuration manager
+### Read flow
 
-Data flow
-Read flow
-BackendSettingsPanel mounts
+1. `BackendSettingsPanel` mounts.
+2. `useBackendSettings` calls `backendConfigurationService.getBackendConfig()`.
+3. The response is parsed through the existing frontend service schema.
+4. That service reads through `callApi('getBackendConfig')`, which routes via the shared frontend `apiHandler` transport path.
+5. If the request fails completely after `callApi(...)` retry/backoff, the hook fails fast and renders a top-level `Alert`.
+6. If the request succeeds, the hook maps the backend payload into form initial values.
+7. Backend `loadError`, if present in an otherwise valid payload, is rendered as an inline warning `Alert`.
+8. If backend `loadError` is present, saving is blocked until a future successful reload clears that condition.
 
-useBackendSettings calls getBackendConfig()
+### Write flow
 
-response is parsed through the existing frontend service schema
+1. The user edits fields.
+2. The user clicks Save.
+3. If the latest load produced `loadError`, the hook throws an error and the UI keeps the form in a blocked state with a persistent inline `Alert`.
+4. Form values are normalised and validated against the dedicated settings Zod schema.
+5. The hook maps values to `BackendConfigWriteInput`.
+6. `backendConfigurationService.setBackendConfig()` is called.
+7. That service writes through `callApi('setBackendConfig', parsedInput)`, which routes via the shared frontend `apiHandler` transport path.
+8. Success uses `message.success`.
+9. After a successful save, the hook immediately re-fetches the current config from the backend and re-bases the form from that fresh payload.
+10. Failure throws an error from the hook and displays it as an inline `Alert`. `notification.error` should be used only if extra asynchronous context is genuinely needed.
 
-hook maps backend payload into form initial values
+## API key handling rules
 
-loadError, if present, is rendered as an inline Alert
-
-Write flow
-user edits fields
-
-user clicks Save
-
-form values are normalised and validated against the dedicated settings Zod schema
-
-hook maps values to BackendConfigWriteInput
-
-setBackendConfig() is called
-
-success uses message.success
-
-failure uses inline Alert and, if needed, notification.error
-
-API key handling rules
 The API key field needs special handling.
 
-Read
-do not populate the input with the masked backend value
+### Read
 
-use hasApiKey to determine whether a stored key exists
+- do not populate the input with the masked backend value
+- use `hasApiKey` to determine whether a stored key exists
+- show masked state only as explanatory helper text or placeholder
 
-show masked state only as explanatory helper text or placeholder
+### Write
 
-Write
-if the user enters a value, send it as the new API key
+- if the user enters a value, send it as the new API key
+- if the user leaves the field blank and a stored key exists, omit `apiKey`
+- explicit API key clearing is out of scope for this UI; support replacement or retention only
 
-if the user leaves the field blank and a stored key exists, omit apiKey
+## Error and feedback behaviour
 
-if explicit clearing remains supported, handle that deliberately rather than accidentally
+### Persistent inline feedback
 
-Error and feedback behaviour
-Persistent inline feedback
-Use Alert for:
+Use `Alert` for:
 
-partial configuration load warnings
+- partial configuration load warnings
+- non-field save failures
+- any guidance the user may need while editing
 
-non-field save failures
+### Default load failure state
 
-any guidance the user may need while editing
+Use a top-level `Alert` as the default hard-failure state when the initial configuration read fails completely. Do not add a bespoke recovery workflow in this iteration; allow the failure to surface clearly after the shared `callApi(...)` retry path is exhausted.
 
-Transient feedback
-Use message.success for successful saves.
+### Transient feedback
 
-Logging
+Use `message.success` for successful saves.
+
+### Logging
+
 Keep raw technical details out of user-facing copy. Any developer diagnostics should remain in frontend logging utilities and should not expose secrets.
 
-Why not nested tabs inside Backend settings
+### Error mapping recommendation
+
+- transport or runtime failures should throw from the hook and be mapped to user-safe inline error copy in the component
+- backend `{ success: false, error }` save responses should also be treated as failures and surfaced through the same inline error path
+- technical details such as request identifiers or backend error codes should stay in logs rather than the rendered UI
+- because the feature uses visible inline feedback, the error state should persist until the next successful load or save clears it
+
+## Why not nested tabs inside Backend settings?
+
 The legacy modal used tabs partly because it lived in a constrained dialog.
 
 For the new page:
 
-nested tabs would add complexity
+- nested tabs would add complexity
+- they would reintroduce hidden-field validation problems
+- cards and vertical sections provide a simpler, clearer layout
+- the page already has a top-level tab system
 
-they would reintroduce hidden-field validation problems
+## Accessibility and usability expectations
 
-cards and vertical sections provide a simpler, clearer layout
+- every field must have a visible label
+- validation errors should be inline and linked to the correct field
+- the first invalid field should be focused or scrolled into view on submit failure
+- the save action should expose a visible loading state
+- section boundaries should be visually and semantically clear
 
-the page already has a top-level tab system
+## Testing expectations
 
-Accessibility and usability expectations
-every field must have a visible label
-
-validation errors should be inline and linked to the correct field
-
-the first invalid field should be focused or scrolled into view on submit failure
-
-the save action should expose a visible loading state
-
-section boundaries should be visually and semantically clear
-
-Testing expectations
 The new backend settings page introduces visible interactions, so both test layers are needed.
 
-Vitest + Testing Library
+### Vitest + Testing Library
+
 Cover:
 
-initial load state
+- initial load state
+- hard load failure rendering as a top-level `Alert`
+- blocked save state when `loadError` is present
+- field rendering from backend data
+- API key masking behaviour
+- API key required state when no stored key exists
+- API key omission when a stored key exists and the field is left blank
+- payload mapping
+- validation logic
+- full hook state transitions (`isInitialLoading`, `loadError`, `partialLoadError`, `isSaveBlocked`, `isSaving`, `saveError`)
+- transport error mapping
+- backend save failure mapping
+- successful save followed by config re-fetch and form rebase
+- save success/failure state handling
+- top-level load error vs inline partial-load warning rendering
+- first-invalid-field focus behaviour on submit failure
+- error clearing behaviour after successful reload/save
 
-field rendering from backend data
+### Playwright
 
-API key masking behaviour
-
-payload mapping
-
-validation logic
-
-save success/failure state handling
-
-Playwright
 Cover:
 
-navigating to Settings
+- navigating to Settings
+- selecting Backend settings
+- seeing the initial skeleton state before config is ready
+- seeing a top-level `Alert` when the initial config read fails
+- editing fields
+- seeing inline validation
+- keyboard-only entry and submission flow across the form
+- focus moving to the first invalid field after a failed submit
+- seeing save blocked when the page is in a partial-load error state
+- leaving the API key blank when an existing key is present and still saving successfully
+- seeing validation failure when no stored API key exists and the field is left blank
+- saving successfully
+- seeing the form refresh from the backend after a successful save
+- seeing save failure feedback when appropriate
 
-selecting Backend settings
+## Summary
 
-editing fields
-
-seeing inline validation
-
-saving successfully
-
-seeing save failure feedback when appropriate
-
-Summary
 The recommended implementation is a sectioned Ant Design page-based form using:
 
-Form
-
-Card
-
-Input.Password
-
-Input
-
-InputNumber
-
-Select
-
-Switch
-
-Alert
-
-Button
-
-Skeleton
-
-App.useApp() with message and optionally notification
+- `Form`
+- `Card`
+- `Input.Password`
+- `Input`
+- `InputNumber`
+- `Select`
+- `Switch`
+- `Alert`
+- `Button`
+- `Skeleton`
+- `App.useApp()` with `message` and, optionally, `notification`
 
 This keeps the implementation simple, accessible, and aligned with both the active frontend architecture and the legacy configuration feature set.

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -46,7 +46,9 @@ Root scripts execute frontend tasks via `npm --prefix src/frontend ...`.
 
 ### 4.1 Required API transport pattern
 
-- Route backend calls through `src/frontend/src/services/apiService.ts` (`callApi`) and avoid direct `google.script.run.<method>` calls in feature code.
+- **Hard rule:** all frontend-to-backend calls must be routed through `src/frontend/src/services/apiService.ts` (`callApi`).
+- Never call backend API methods directly from frontend feature code, components, hooks, or services via `google.script.run`, backend globals, or any other transport shortcut.
+- Wrap backend methods in a frontend service module that owns request/response validation and calls `callApi(...)`.
 - Keep method names aligned with backend `API_METHODS` in `src/backend/z_Api/apiConstants.js`.
 - Treat backend responses as envelopes handled by `callApi`; feature services should consume typed `data` results only.
 - Keep retry behaviour centralised in `callApi`; do not add per-feature retry loops for rate-limit handling.
@@ -58,6 +60,8 @@ Root scripts execute frontend tasks via `npm --prefix src/frontend ...`.
 - Fail loudly in development; do not hide failures behind broad catch-and-ignore logic.
 - When implementing or refactoring frontend logging/error handling, read `docs/developer/frontend/frontend-logging-and-error-handling.md` first and treat it as the single source of truth.
 - Keep this AGENTS file as a signpost only; do not duplicate detailed logging policy here.
+- Default hard-failure UI state should be a top-level Ant Design `Alert` unless a stronger user experience case is explicitly documented for a feature.
+- Prefer shared frontend error contracts and mapping utilities; add feature-specific error mapping only when a feature has genuinely unique error semantics.
 - Never implement or fall back to defaults unless explicitly instructed to do so.
 - Keep component state and side effects predictable and testable.
 


### PR DESCRIPTION
### Motivation

- Provide a TDD-first, step-by-step delivery plan for implementing the new Backend settings feature and its frontend wiring.
- Clarify the Settings page layout, field/component mapping, validation strategy, and UX/error feedback expectations to avoid ambiguity during implementation.
- Enforce frontend integration patterns and failure-mode conventions so feature code consistently routes backend calls through the shared API surface and surfaces hard failures predictably.

### Description

- Add `ACTION_PLAN.md` containing a sectioned TDD delivery plan for the Backend settings feature including scope, constraints, acceptance criteria, suggested file structure, and per-section test/validation commands.
- Update `SETTINGS_PAGE_LAYOUT.md` to refine the component tree, Ant Design component usage, field-to-component mapping, detailed validation rules, hook state matrix, API key handling rules, error/feedback behaviour, accessibility expectations, and test coverage guidance.
- Update `src/frontend/AGENTS.md` to make the `callApi(...)` routing a hard rule, to ban direct backend globals from feature code, and to specify default hard-failure UI behaviour and error-mapping preferences.
- Remove `revokeAuthTriggerSet` from the proposed UI surface and add explicit guidance to keep orchestration in hooks and transport calls in `backendConfigurationService.ts`.

### Testing

- No automated tests were executed as part of this documentation/plan change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb7a4d172c83299285cd627db509ec)