### PR TITLE
Add shared google.script.run apiHandler test harness and migrate frontend tests

### DIFF
--- a/.github/agents/Testing.agent.md
+++ b/.github/agents/Testing.agent.md
@@ -34,6 +34,7 @@ Choose test strategy by component.
 - Browser E2E tests: Playwright (`npm run frontend:test:e2e`) in `src/frontend/e2e-tests/**/*.spec.ts`. You must run them for any new or changed user-visible interaction or browser integration flow. If Chromium or its system dependencies are missing, install them with `npm --prefix src/frontend exec -- playwright install --with-deps chromium`, then rerun `npm run frontend:test:e2e` until it passes.
 - Environment: JSDOM for unit tests, real browser automation for E2E.
 - Prefer behaviour-focused assertions over implementation details.
+- When mocking `google.script.run.apiHandler`, reuse `src/frontend/src/test/googleScriptRunHarness.ts`. Use `createGoogleScriptRunApiHandlerMock(...)` in Vitest and `googleScriptRunApiHandlerFactorySource` for Playwright init scripts; do not add new shared-mutable runner mocks.
 
 ### Builder (`scripts/builder`)
 - Framework: Vitest (`npm run builder:test`), Node environment.

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -176,9 +176,19 @@ Use shared helpers to keep fixtures and mocks consistent and avoid duplicate tes
 **Important:** for frontend logging assertions, spy on browser console endpoints (`console.debug/info/warn/error`) rather than reading implementation-specific globals.
 
 - Frontend runtime setup helper: `src/frontend/src/test/setup.ts` (Testing Library + jest-dom integration).
+- Frontend `apiHandler` mock helper: `src/frontend/src/test/googleScriptRunHarness.ts`.
 - Builder JsonDb source fixture helpers: `scripts/builder/src/test/jsondb-source-test-helpers.ts` (shared by JsonDb source builder specs to build release archives, create path fixtures, and write release files/manifests).
 
 When adding test scenarios, prefer extending an existing helper before copying setup logic into each spec.
+
+### Mandatory `apiHandler` mock rule
+
+When a frontend test needs to mock `google.script.run.apiHandler`, you must use the shared helper in `src/frontend/src/test/googleScriptRunHarness.ts`.
+
+- **Vitest / jsdom tests:** use `createGoogleScriptRunApiHandlerMock(...)`.
+- **Playwright browser init scripts:** inline `googleScriptRunApiHandlerFactorySource` inside `page.addInitScript(...)`.
+
+Do not introduce new ad-hoc `google.script.run` mocks that mutate one shared runner object or store handlers on shared mutable state. Each mocked call must model GAS-style per-call callback isolation so overlapping requests cannot overwrite one another's success or failure handlers.
 
 ## Current Structure
 

--- a/src/frontend/e2e-tests/app.spec.ts
+++ b/src/frontend/e2e-tests/app.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { pageExpectations } from '../src/test/pageExpectations';
+import { googleScriptRunApiHandlerFactorySource } from '../src/test/googleScriptRunHarness';
 
 const appBreadcrumbBaseLabel = 'AssessmentBot Frontend';
 const breadcrumbNavigationName = 'Breadcrumb';
@@ -15,6 +16,20 @@ const collapseNavigationButtonLabel = 'Collapse navigation';
 const expandNavigationButtonLabel = 'Expand navigation';
 const settingsLabel = 'Settings';
 const navigationMenuLabels = ['Dashboard', 'Classes', 'Assignments', settingsLabel];
+const backendSettingsFixture = {
+  backendAssessorBatchSize: 30,
+  apiKey: '****cdef',
+  hasApiKey: true,
+  backendUrl: 'https://backend.example.com',
+  revokeAuthTriggerSet: false,
+  daysUntilAuthRevoke: 60,
+  slidesFetchBatchSize: 20,
+  jsonDbMasterIndexKey: 'master-index',
+  jsonDbLockTimeoutMs: 15_000,
+  jsonDbLogLevel: 'INFO',
+  jsonDbBackupOnInitialise: true,
+  jsonDbRootFolderId: 'folder-1234',
+};
 
 /**
  * Returns the rendered breadcrumb locator.
@@ -68,23 +83,35 @@ async function getHeaderBackgroundColour(page: Page) {
  * @param {Page} page - The Playwright page under test.
  */
 async function mockPendingGoogleScriptRun(page: Page) {
-  await page.addInitScript(() => {
-    const run = {
-      withSuccessHandler() {
-        return run;
-      },
-      withFailureHandler() {
-        return run;
-      },
-      apiHandler() {},
-    };
+  await page.addInitScript(`
+    (() => {
+      const createGoogleScriptRunApiHandlerMock = ${googleScriptRunApiHandlerFactorySource};
+      const backendSettingsFixture = ${JSON.stringify(backendSettingsFixture)};
 
-    (globalThis as { google?: unknown }).google = {
-      script: {
-        run,
-      },
-    };
-  });
+      globalThis.google = {
+        script: {
+          run: createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+            if (request?.method === 'getBackendConfig') {
+              callbacks.successHandler?.({
+                ok: true,
+                requestId: 'req-backend-config',
+                data: backendSettingsFixture,
+              });
+              return;
+            }
+
+            if (request?.method === 'getABClassPartials') {
+              callbacks.successHandler?.({
+                ok: true,
+                requestId: 'req-class-partials',
+                data: [],
+              });
+            }
+          }),
+        },
+      };
+    })();
+  `);
 }
 
 test.describe('app shell', () => {

--- a/src/frontend/e2e-tests/auth-status.spec.ts
+++ b/src/frontend/e2e-tests/auth-status.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { googleScriptRunApiHandlerFactorySource } from '../src/test/googleScriptRunHarness';
 
 type AuthServiceMockScenario =
   | {
@@ -25,77 +26,55 @@ type AuthServiceMockScenario =
  * @returns {Promise<void>} A promise that resolves once the init script is installed.
  */
 async function mockGoogleScriptRun(page: Page, scenario: AuthServiceMockScenario) {
-  await page.addInitScript((mockScenario: AuthServiceMockScenario) => {
-    const delayMs = mockScenario.delayMs ?? 0;
+  await page.addInitScript(
+    `
+      (() => {
+        const createGoogleScriptRunApiHandlerMock = ${googleScriptRunApiHandlerFactorySource};
+        const mockScenario = ${JSON.stringify(scenario)};
+        const delayMs = mockScenario.delayMs ?? 0;
 
-    /**
-     * Dispatches a mocked apiHandler response based on the selected scenario.
-     *
-    * @param {{ successHandler: ((response: unknown) => void) | undefined; failureHandler: ((error: unknown) => void) | undefined; }} run - The mocked `google.script.run` surface.
-    * @param {((response: unknown) => void) | undefined} run.successHandler - The currently registered success callback.
-    * @param {((error: unknown) => void) | undefined} run.failureHandler - The currently registered failure callback.
-    * @param {AuthServiceMockScenario} scenario - The selected mock scenario.
-     */
-    function dispatchScenarioResponse(
-      run: {
-        successHandler: ((response: unknown) => void) | undefined;
-        failureHandler: ((error: unknown) => void) | undefined;
-      },
-      scenario: AuthServiceMockScenario
-    ) {
-      if (scenario.kind === 'success') {
-        run.successHandler?.({
-          ok: true,
-          requestId: 'req-e2e-success',
-          data: scenario.result,
-        });
-        return;
-      }
-
-      if (scenario.kind === 'apiFailure') {
-        run.successHandler?.({
-          ok: false,
-          requestId: 'req-e2e-failure',
-          error: {
-            code: 'INTERNAL_ERROR',
-            message: scenario.message,
-          },
-        });
-        return;
-      }
-
-      run.failureHandler?.(new Error(scenario.message));
-    }
-
-    const run = {
-      successHandler: undefined as ((response: unknown) => void) | undefined,
-      failureHandler: undefined as ((error: unknown) => void) | undefined,
-      withSuccessHandler(handler: (response: unknown) => void) {
-        this.successHandler = handler;
-        return this;
-      },
-      withFailureHandler(handler: (error: unknown) => void) {
-        this.failureHandler = handler;
-        return this;
-      },
-      apiHandler(request: unknown) {
-        setTimeout(() => {
-          if (typeof (request as { method?: unknown })?.method !== 'string') {
-            this.failureHandler?.(new Error('Invalid transport request payload.'));
+        function dispatchScenarioResponse(callbacks, activeScenario) {
+          if (activeScenario.kind === 'success') {
+            callbacks.successHandler?.({
+              ok: true,
+              requestId: 'req-e2e-success',
+              data: activeScenario.result,
+            });
             return;
           }
 
-          dispatchScenarioResponse(this, mockScenario);
-        }, delayMs);
-      },
-    };
+          if (activeScenario.kind === 'apiFailure') {
+            callbacks.successHandler?.({
+              ok: false,
+              requestId: 'req-e2e-failure',
+              error: {
+                code: 'INTERNAL_ERROR',
+                message: activeScenario.message,
+              },
+            });
+            return;
+          }
 
-    globalThis.google = {
-      script: {
-        run,
-      },
-    };
-  }, scenario);
+          callbacks.failureHandler?.(new Error(activeScenario.message));
+        }
+
+        globalThis.google = {
+          script: {
+            run: createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+              setTimeout(() => {
+                if (typeof request?.method !== 'string') {
+                  callbacks.failureHandler?.(new Error('Invalid transport request payload.'));
+                  return;
+                }
+
+                dispatchScenarioResponse(callbacks, mockScenario);
+              }, delayMs);
+            }),
+          },
+        };
+      })();
+    `
+  );
 }
 
 test.describe('auth status flow', () => {

--- a/src/frontend/e2e-tests/settings-backend.spec.ts
+++ b/src/frontend/e2e-tests/settings-backend.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import type { BackendConfig, BackendConfigWriteResult } from '../src/services/backendConfiguration.zod';
+import { googleScriptRunApiHandlerFactorySource } from '../src/test/googleScriptRunHarness';
 
 type BackendApiResponseScenario = Readonly<
   | {
@@ -93,6 +94,7 @@ const refreshedWriteResult = {
 async function mockBackendSettingsRuntime(page: Page, scenario: BackendSettingsRuntimeScenario) {
   await page.addInitScript(`
     (() => {
+      const createGoogleScriptRunApiHandlerMock = ${googleScriptRunApiHandlerFactorySource};
       const mockScenario = ${JSON.stringify(scenario)};
       const callCounts = {
         getBackendConfig: 0,
@@ -149,7 +151,7 @@ async function mockBackendSettingsRuntime(page: Page, scenario: BackendSettingsR
         return false;
       }
 
-      function handleBackendSettingsResponse(method, responseIndex, handler) {
+      function handleBackendSettingsResponse(method, responseIndex, callbacks) {
         const responseQueue = responseQueues[method];
         const response = responseQueue[responseIndex];
 
@@ -159,15 +161,13 @@ async function mockBackendSettingsRuntime(page: Page, scenario: BackendSettingsR
 
         setTimeout(() => {
           if (response.kind === 'transportFailure') {
-            if (handler.failureHandler !== undefined) {
-              handler.failureHandler(new Error(response.message));
-            }
+            callbacks.failureHandler?.(new Error(response.message));
             return;
           }
 
           if (response.kind === 'failureEnvelope') {
             sendFailureEnvelope(
-              handler.successHandler,
+              callbacks.successHandler,
               \`req-\${method}-\${responseIndex}\`,
               response.code ?? 'INTERNAL_ERROR',
               response.message
@@ -175,44 +175,30 @@ async function mockBackendSettingsRuntime(page: Page, scenario: BackendSettingsR
             return;
           }
 
-          sendSuccess(handler.successHandler, response.data, \`req-\${method}-\${responseIndex}\`);
+          sendSuccess(callbacks.successHandler, response.data, \`req-\${method}-\${responseIndex}\`);
         }, response.delayMs ?? 0);
       }
 
-      const run = {
-        successHandler: undefined,
-        failureHandler: undefined,
-        withSuccessHandler(handler) {
-          this.successHandler = handler;
-          return this;
-        },
-        withFailureHandler(handler) {
-          this.failureHandler = handler;
-          return this;
-        },
-        apiHandler(request) {
-          if (!isBackendSettingsTransportRequest(request)) {
-            if (this.failureHandler !== undefined) {
-              this.failureHandler(new Error('Invalid transport request payload.'));
-            }
-            return;
-          }
+      const run = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+        if (!isBackendSettingsTransportRequest(request)) {
+          callbacks.failureHandler?.(new Error('Invalid transport request payload.'));
+          return;
+        }
 
-          const method = request.method;
+        const method = request.method;
 
-          if (handleStaticMethod(method, this.successHandler)) {
-            return;
-          }
+        if (handleStaticMethod(method, callbacks.successHandler)) {
+          return;
+        }
 
-          if (method !== 'getBackendConfig' && method !== 'setBackendConfig') {
-            return;
-          }
+        if (method !== 'getBackendConfig' && method !== 'setBackendConfig') {
+          return;
+        }
 
-          const responseIndex = callCounts[method];
-          callCounts[method] = responseIndex + 1;
-          handleBackendSettingsResponse(method, responseIndex, this);
-        },
-      };
+        const responseIndex = callCounts[method];
+        callCounts[method] = responseIndex + 1;
+        handleBackendSettingsResponse(method, responseIndex, callbacks);
+      });
 
       globalThis.google = {
         script: {

--- a/src/frontend/src/App.spec.tsx
+++ b/src/frontend/src/App.spec.tsx
@@ -14,6 +14,7 @@ import {
   navigationItems,
   type AppNavigationKey,
 } from './navigation/appNavigation';
+import { createGoogleScriptRunApiHandlerMock } from './test/googleScriptRunHarness';
 
 const checkingAuthorisationStatusText = 'Checking authorisation status...';
 const applicationTitleText = appBreadcrumbBaseLabel;
@@ -76,50 +77,40 @@ function dispatchMockTransportResponse(
  * @returns {{ getCallCount(method: string): number }} A transport harness that exposes per-method call counts.
  */
 function installApiHandlerMock(responsesByMethod: ApiMethodResponseMap) {
-  let successHandler: ((payload: unknown) => void) | undefined;
-  let failureHandler: ((error: unknown) => void) | undefined;
   const methodCallCounts = new Map<string, number>();
 
-  const runMock = {
-    withSuccessHandler(handler: (payload: unknown) => void) {
-      successHandler = handler;
-      return runMock;
-    },
-    withFailureHandler(handler: (error: unknown) => void) {
-      failureHandler = handler;
-      return runMock;
-    },
-    apiHandler(request: unknown) {
-      const method = (request as { method?: unknown })?.method;
+  const runMock = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+    const { failureHandler, successHandler } = callbacks;
 
-      if (typeof method !== 'string') {
-        dispatchMockTransportResponse(
-          { transportFailure: new Error('Invalid transport request payload.') },
-          failureHandler,
-          successHandler
-        );
-        return;
-      }
+    const method = (request as { method?: unknown })?.method;
 
-      methodCallCounts.set(method, (methodCallCounts.get(method) ?? 0) + 1);
-      const response = responsesByMethod[method];
+    if (typeof method !== 'string') {
+      dispatchMockTransportResponse(
+        { transportFailure: new Error('Invalid transport request payload.') },
+        failureHandler,
+        successHandler
+      );
+      return;
+    }
 
-      if (response === undefined) {
-        dispatchMockTransportResponse(
-          { transportFailure: new Error(`No mocked response configured for method: ${method}`) },
-          failureHandler,
-          successHandler
-        );
-        return;
-      }
+    methodCallCounts.set(method, (methodCallCounts.get(method) ?? 0) + 1);
+    const response = responsesByMethod[method];
 
-      if (response === 'pending') {
-        return;
-      }
+    if (response === undefined) {
+      dispatchMockTransportResponse(
+        { transportFailure: new Error(`No mocked response configured for method: ${method}`) },
+        failureHandler,
+        successHandler
+      );
+      return;
+    }
 
-      dispatchMockTransportResponse(response, failureHandler, successHandler);
-    },
-  };
+    if (response === 'pending') {
+      return;
+    }
+
+    dispatchMockTransportResponse(response, failureHandler, successHandler);
+  });
 
   (globalThis as { google?: unknown }).google = {
     script: {

--- a/src/frontend/src/services/apiService.spec.ts
+++ b/src/frontend/src/services/apiService.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createGoogleScriptRunApiHandlerMock, type GoogleScriptRunApiHandler } from '../test/googleScriptRunHarness';
 
 type ApiSuccessEnvelope<TData> = {
     ok: true;
@@ -18,15 +19,9 @@ type ApiErrorEnvelope = {
     meta?: Record<string, unknown>;
 };
 
-type GoogleScriptRunWithApiHandler = {
-    withSuccessHandler: (handler: (response: unknown) => void) => GoogleScriptRunWithApiHandler;
-    withFailureHandler: (handler: (error: unknown) => void) => GoogleScriptRunWithApiHandler;
-    apiHandler: (request: unknown) => void;
-};
-
 type GoogleScript = {
     script?: {
-        run?: GoogleScriptRunWithApiHandler;
+        run?: GoogleScriptRunApiHandler;
     };
 };
 
@@ -50,6 +45,20 @@ function clearGoogle(): void {
     delete (globalThis as Record<string, unknown>).google;
 }
 
+/**
+ * Creates a mock runner shape that exposes handler registration but omits `apiHandler`.
+ *
+ * @returns {GoogleScriptRunApiHandler} The runner-like shape for missing-apiHandler tests.
+ */
+function createRunnerWithoutApiHandler(): GoogleScriptRunApiHandler {
+    return {
+        ...createGoogleScriptRunApiHandlerMock(() => {
+            return;
+        }),
+        apiHandler: undefined as unknown as (request: unknown) => void,
+    };
+}
+
 const apiServiceModulePath: string = './apiService';
 
 /**
@@ -71,6 +80,7 @@ type RunnerHarnessResponse =
 
 const SECOND_ATTEMPT_CALL_COUNT = 2;
 const MAX_ATTEMPTS = 4;
+const CONCURRENT_ALPHA_DELAY_MS = 20;
 
 /**
  * Builds a retriable RATE_LIMITED envelope for retry-path tests.
@@ -90,57 +100,27 @@ function makeRateLimitedEnvelope(requestId: string): ApiErrorEnvelope {
  * Creates a controllable `google.script.run` harness for unit tests.
  *
  * @param {RunnerHarnessResponse} response - The response shape to replay through the harness.
- * @returns {{ runner: GoogleScriptRunWithApiHandler; apiHandlerSpy: ReturnType<typeof vi.fn>; }} The runner harness and its spy.
+ * @returns {{ runner: GoogleScriptRunApiHandler; apiHandlerSpy: ReturnType<typeof vi.fn>; }} The runner harness and its spy.
  */
 function createGoogleScriptRunHarness(response: RunnerHarnessResponse): {
-    runner: GoogleScriptRunWithApiHandler;
+    runner: GoogleScriptRunApiHandler;
     apiHandlerSpy: ReturnType<typeof vi.fn>;
 } {
-    let successHandler: ((value: unknown) => void) | undefined;
-    let failureHandler: ((error: unknown) => void) | undefined;
-
     const apiHandlerSpy = vi.fn();
 
-    const runner: GoogleScriptRunWithApiHandler = {
-        /**
-         * Registers the success callback for the harness.
-         *
-         * @param {(responseValue: unknown) => void} handler - The success callback.
-         * @returns {GoogleScriptRunWithApiHandler} The harness runner.
-         */
-        withSuccessHandler(handler: (responseValue: unknown) => void) {
-            successHandler = handler;
-            return runner;
-        },
-        /**
-         * Registers the failure callback for the harness.
-         *
-         * @param {(error: unknown) => void} handler - The failure callback.
-         * @returns {GoogleScriptRunWithApiHandler} The harness runner.
-         */
-        withFailureHandler(handler: (error: unknown) => void) {
-            failureHandler = handler;
-            return runner;
-        },
-        /**
-         * Dispatches the request into the harness spy.
-         *
-         * @param {unknown} request - The request payload to dispatch.
-         * @returns {void} Nothing.
-         */
-        apiHandler(request: unknown) {
-            apiHandlerSpy(request);
+    const runner = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+        apiHandlerSpy(request);
 
-            queueMicrotask(() => {
-                if (response.kind === 'success') {
-                    successHandler?.(response.payload);
-                    return;
-                }
+        queueMicrotask(() => {
+            if (response.kind === 'success') {
+                callbacks.successHandler?.(response.payload);
+                return;
+            }
 
-                failureHandler?.(response.payload);
-            });
-        },
-    };
+            callbacks.failureHandler?.(response.payload);
+        });
+    });
+
     return {
         runner,
         apiHandlerSpy,
@@ -195,15 +175,7 @@ describe('apiService.callApi', () => {
 
         setGoogle({
             script: {
-                run: {
-                    withSuccessHandler() {
-                        return this as GoogleScriptRunWithApiHandler;
-                    },
-                    withFailureHandler() {
-                        return this as GoogleScriptRunWithApiHandler;
-                    },
-                    apiHandler: undefined as unknown as (request: unknown) => void,
-                },
+                run: createRunnerWithoutApiHandler(),
             },
         });
 
@@ -313,6 +285,55 @@ describe('apiService.callApi', () => {
             },
         });
     });
+
+    it('keeps concurrent responses bound to the correct request handlers', async () => {
+        const callApi = await loadCallApi();
+
+        const alphaEnvelope: ApiSuccessEnvelope<{ label: string }> = {
+            ok: true,
+            requestId: 'req-concurrent-alpha',
+            data: { label: 'alpha' },
+        };
+        const betaEnvelope: ApiSuccessEnvelope<{ label: string }> = {
+            ok: true,
+            requestId: 'req-concurrent-beta',
+            data: { label: 'beta' },
+        };
+
+        const runner = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+            const method = (request as { method?: unknown })?.method;
+
+            if (method === 'loadAlpha') {
+                setTimeout(() => {
+                    callbacks.successHandler?.(alphaEnvelope);
+                }, CONCURRENT_ALPHA_DELAY_MS);
+                return;
+            }
+
+            if (method === 'loadBeta') {
+                setTimeout(() => {
+                    callbacks.successHandler?.(betaEnvelope);
+                }, 0);
+                return;
+            }
+
+            callbacks.failureHandler?.(new Error(`Unexpected method: ${String(method)}`));
+        });
+
+        setGoogle({
+            script: {
+                run: runner,
+            },
+        });
+
+        const alphaPromise = callApi<{ label: string }>('loadAlpha');
+        const betaPromise = callApi<{ label: string }>('loadBeta');
+
+        await expect(Promise.all([alphaPromise, betaPromise])).resolves.toEqual([
+            { label: 'alpha' },
+            { label: 'beta' },
+        ]);
+    });
 });
 
 // ── Helpers for retry policy tests ───────────────────────────────────────────
@@ -323,42 +344,30 @@ describe('apiService.callApi', () => {
  * repeated if the sequence is exhausted.
  *
  * @param {RunnerHarnessResponse[]} responses - The ordered responses to replay.
- * @returns {{ runner: GoogleScriptRunWithApiHandler; apiHandlerSpy: ReturnType<typeof vi.fn>; }} The sequential harness and its spy.
+ * @returns {{ runner: GoogleScriptRunApiHandler; apiHandlerSpy: ReturnType<typeof vi.fn>; }} The sequential harness and its spy.
  */
 function createSequentialHarness(responses: RunnerHarnessResponse[]): {
-    runner: GoogleScriptRunWithApiHandler;
+    runner: GoogleScriptRunApiHandler;
     apiHandlerSpy: ReturnType<typeof vi.fn>;
 } {
     let callCount = 0;
-    let successHandler: ((value: unknown) => void) | undefined;
-    let failureHandler: ((error: unknown) => void) | undefined;
 
     const apiHandlerSpy = vi.fn();
 
-    const runner: GoogleScriptRunWithApiHandler = {
-        withSuccessHandler(handler: (responseValue: unknown) => void) {
-            successHandler = handler;
-            return runner;
-        },
-        withFailureHandler(handler: (error: unknown) => void) {
-            failureHandler = handler;
-            return runner;
-        },
-        apiHandler(request: unknown) {
-            apiHandlerSpy(request);
+    const runner = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
+        apiHandlerSpy(request);
 
-            const response = responses[Math.min(callCount, responses.length - 1)];
-            callCount++;
+        const response = responses[Math.min(callCount, responses.length - 1)];
+        callCount++;
 
-            queueMicrotask(() => {
-                if (response.kind === 'success') {
-                    successHandler?.(response.payload);
-                    return;
-                }
-                failureHandler?.(response.payload);
-            });
-        },
-    };
+        queueMicrotask(() => {
+            if (response.kind === 'success') {
+                callbacks.successHandler?.(response.payload);
+                return;
+            }
+            callbacks.failureHandler?.(response.payload);
+        });
+    });
 
     return { runner, apiHandlerSpy };
 }

--- a/src/frontend/src/services/apiService.spec.ts
+++ b/src/frontend/src/services/apiService.spec.ts
@@ -21,8 +21,12 @@ type ApiErrorEnvelope = {
 
 type GoogleScript = {
     script?: {
-        run?: GoogleScriptRunApiHandler;
+        run?: unknown;
     };
+};
+
+type GoogleScriptRunWithoutApiHandler = Omit<GoogleScriptRunApiHandler, 'apiHandler'> & {
+    apiHandler: undefined;
 };
 
 type CallApi = <TResponse>(method: string, parameters?: unknown) => Promise<TResponse>;
@@ -48,14 +52,14 @@ function clearGoogle(): void {
 /**
  * Creates a mock runner shape that exposes handler registration but omits `apiHandler`.
  *
- * @returns {GoogleScriptRunApiHandler} The runner-like shape for missing-apiHandler tests.
+ * @returns {GoogleScriptRunWithoutApiHandler} The runner-like shape for missing-apiHandler tests.
  */
-function createRunnerWithoutApiHandler(): GoogleScriptRunApiHandler {
+function createRunnerWithoutApiHandler(): GoogleScriptRunWithoutApiHandler {
     return {
         ...createGoogleScriptRunApiHandlerMock(() => {
             return;
         }),
-        apiHandler: undefined as unknown as (request: unknown) => void,
+        apiHandler: undefined,
     };
 }
 
@@ -80,8 +84,6 @@ type RunnerHarnessResponse =
 
 const SECOND_ATTEMPT_CALL_COUNT = 2;
 const MAX_ATTEMPTS = 4;
-const CONCURRENT_ALPHA_DELAY_MS = 20;
-
 /**
  * Builds a retriable RATE_LIMITED envelope for retry-path tests.
  *
@@ -300,20 +302,23 @@ describe('apiService.callApi', () => {
             data: { label: 'beta' },
         };
 
+        let releaseAlphaResponse: (() => void) | undefined;
+        let releaseBetaResponse: (() => void) | undefined;
+
         const runner = createGoogleScriptRunApiHandlerMock((request, callbacks) => {
             const method = (request as { method?: unknown })?.method;
 
             if (method === 'loadAlpha') {
-                setTimeout(() => {
+                releaseAlphaResponse = () => {
                     callbacks.successHandler?.(alphaEnvelope);
-                }, CONCURRENT_ALPHA_DELAY_MS);
+                };
                 return;
             }
 
             if (method === 'loadBeta') {
-                setTimeout(() => {
+                releaseBetaResponse = () => {
                     callbacks.successHandler?.(betaEnvelope);
-                }, 0);
+                };
                 return;
             }
 
@@ -328,6 +333,13 @@ describe('apiService.callApi', () => {
 
         const alphaPromise = callApi<{ label: string }>('loadAlpha');
         const betaPromise = callApi<{ label: string }>('loadBeta');
+
+        if (releaseAlphaResponse === undefined || releaseBetaResponse === undefined) {
+            throw new Error('Expected both concurrent responses to be registered before release.');
+        }
+
+        releaseBetaResponse();
+        releaseAlphaResponse();
 
         await expect(Promise.all([alphaPromise, betaPromise])).resolves.toEqual([
             { label: 'alpha' },

--- a/src/frontend/src/test/google-script-run-harness-factory.d.ts
+++ b/src/frontend/src/test/google-script-run-harness-factory.d.ts
@@ -1,0 +1,21 @@
+export type GoogleScriptRunApiHandlerFactoryCallbacks = Readonly<{
+  successHandler: ((response: unknown) => void) | undefined;
+  failureHandler: ((error: unknown) => void) | undefined;
+}>;
+
+export type GoogleScriptRunApiHandlerFactoryRunner = {
+  withSuccessHandler: (
+    handler: (response: unknown) => void
+  ) => GoogleScriptRunApiHandlerFactoryRunner;
+  withFailureHandler: (
+    handler: (error: unknown) => void
+  ) => GoogleScriptRunApiHandlerFactoryRunner;
+  apiHandler: (request: unknown) => void;
+};
+
+export function createGoogleScriptRunApiHandlerMock(
+  invokeRequest: (
+    request: unknown,
+    callbacks: GoogleScriptRunApiHandlerFactoryCallbacks
+  ) => void
+): GoogleScriptRunApiHandlerFactoryRunner;

--- a/src/frontend/src/test/google-script-run-harness-factory.js
+++ b/src/frontend/src/test/google-script-run-harness-factory.js
@@ -1,0 +1,38 @@
+/**
+ * Creates a `google.script.run.apiHandler` mock with per-call callback isolation.
+ *
+ * Each chained `withSuccessHandler(...).withFailureHandler(...).apiHandler(...)` call
+ * receives a fresh runner instance so overlapping requests cannot overwrite one
+ * another's handlers.
+ *
+ * @param {(request: unknown, callbacks: { successHandler: ((response: unknown) => void) | undefined; failureHandler: ((error: unknown) => void) | undefined; }) => void} invokeRequest
+ * The request callback to execute when `apiHandler` is invoked.
+ * @returns {{ withSuccessHandler: (handler: (response: unknown) => void) => unknown; withFailureHandler: (handler: (error: unknown) => void) => unknown; apiHandler: (request: unknown) => void; }} The mocked runner.
+ */
+export function createGoogleScriptRunApiHandlerMock(invokeRequest) {
+  return createRunner();
+
+  /**
+   * Creates a runner snapshot with the currently registered handlers.
+   *
+   * @param {((response: unknown) => void) | undefined} successHandler The current success handler.
+   * @param {((error: unknown) => void) | undefined} failureHandler The current failure handler.
+   * @returns {{ withSuccessHandler: (handler: (response: unknown) => void) => unknown; withFailureHandler: (handler: (error: unknown) => void) => unknown; apiHandler: (request: unknown) => void; }} The runner snapshot.
+   */
+  function createRunner(successHandler, failureHandler) {
+    return {
+      withSuccessHandler(nextSuccessHandler) {
+        return createRunner(nextSuccessHandler, failureHandler);
+      },
+      withFailureHandler(nextFailureHandler) {
+        return createRunner(successHandler, nextFailureHandler);
+      },
+      apiHandler(request) {
+        invokeRequest(request, {
+          successHandler,
+          failureHandler,
+        });
+      },
+    };
+  }
+}

--- a/src/frontend/src/test/googleScriptRunHarness.ts
+++ b/src/frontend/src/test/googleScriptRunHarness.ts
@@ -1,0 +1,79 @@
+export type GoogleScriptRunApiHandler = {
+  withSuccessHandler: (
+    handler: (response: unknown) => void
+  ) => GoogleScriptRunApiHandler;
+  withFailureHandler: (handler: (error: unknown) => void) => GoogleScriptRunApiHandler;
+  apiHandler: (request: unknown) => void;
+};
+
+export type GoogleScriptRunApiHandlerCallbacks = Readonly<{
+  successHandler: ((response: unknown) => void) | undefined;
+  failureHandler: ((error: unknown) => void) | undefined;
+}>;
+
+/**
+ * Creates a `google.script.run.apiHandler` mock with per-call callback isolation.
+ *
+ * Each chained `withSuccessHandler(...).withFailureHandler(...).apiHandler(...)` call
+ * receives a fresh runner instance so overlapping requests cannot overwrite one
+ * another's handlers.
+ *
+ * @param {(request: unknown, callbacks: GoogleScriptRunApiHandlerCallbacks) => void} invokeRequest
+ * The request callback to execute when `apiHandler` is invoked.
+ * @returns {GoogleScriptRunApiHandler} The mocked runner.
+ */
+export function createGoogleScriptRunApiHandlerMock(
+  invokeRequest: (request: unknown, callbacks: GoogleScriptRunApiHandlerCallbacks) => void
+): GoogleScriptRunApiHandler {
+  return createRunner();
+
+  /**
+   * Creates a runner snapshot with the currently registered handlers.
+   *
+   * @param {((response: unknown) => void) | undefined} successHandler The current success handler.
+   * @param {((error: unknown) => void) | undefined} failureHandler The current failure handler.
+   * @returns {GoogleScriptRunApiHandler} The runner snapshot.
+   */
+  function createRunner(
+    successHandler?: (response: unknown) => void,
+    failureHandler?: (error: unknown) => void
+  ): GoogleScriptRunApiHandler {
+    return {
+      withSuccessHandler(nextSuccessHandler: (response: unknown) => void) {
+        return createRunner(nextSuccessHandler, failureHandler);
+      },
+      withFailureHandler(nextFailureHandler: (error: unknown) => void) {
+        return createRunner(successHandler, nextFailureHandler);
+      },
+      apiHandler(request: unknown) {
+        invokeRequest(request, {
+          successHandler,
+          failureHandler,
+        });
+      },
+    };
+  }
+}
+
+export const googleScriptRunApiHandlerFactorySource = String.raw`
+function createGoogleScriptRunApiHandlerMock(invokeRequest) {
+  return createRunner();
+
+  function createRunner(successHandler, failureHandler) {
+    return {
+      withSuccessHandler(nextSuccessHandler) {
+        return createRunner(nextSuccessHandler, failureHandler);
+      },
+      withFailureHandler(nextFailureHandler) {
+        return createRunner(successHandler, nextFailureHandler);
+      },
+      apiHandler(request) {
+        invokeRequest(request, {
+          successHandler,
+          failureHandler,
+        });
+      },
+    };
+  }
+}
+`;

--- a/src/frontend/src/test/googleScriptRunHarness.ts
+++ b/src/frontend/src/test/googleScriptRunHarness.ts
@@ -1,3 +1,5 @@
+import { createGoogleScriptRunApiHandlerMock as createGoogleScriptRunApiHandlerImplementation } from './google-script-run-harness-factory.js';
+
 export type GoogleScriptRunApiHandler = {
   withSuccessHandler: (
     handler: (response: unknown) => void
@@ -25,55 +27,8 @@ export type GoogleScriptRunApiHandlerCallbacks = Readonly<{
 export function createGoogleScriptRunApiHandlerMock(
   invokeRequest: (request: unknown, callbacks: GoogleScriptRunApiHandlerCallbacks) => void
 ): GoogleScriptRunApiHandler {
-  return createRunner();
-
-  /**
-   * Creates a runner snapshot with the currently registered handlers.
-   *
-   * @param {((response: unknown) => void) | undefined} successHandler The current success handler.
-   * @param {((error: unknown) => void) | undefined} failureHandler The current failure handler.
-   * @returns {GoogleScriptRunApiHandler} The runner snapshot.
-   */
-  function createRunner(
-    successHandler?: (response: unknown) => void,
-    failureHandler?: (error: unknown) => void
-  ): GoogleScriptRunApiHandler {
-    return {
-      withSuccessHandler(nextSuccessHandler: (response: unknown) => void) {
-        return createRunner(nextSuccessHandler, failureHandler);
-      },
-      withFailureHandler(nextFailureHandler: (error: unknown) => void) {
-        return createRunner(successHandler, nextFailureHandler);
-      },
-      apiHandler(request: unknown) {
-        invokeRequest(request, {
-          successHandler,
-          failureHandler,
-        });
-      },
-    };
-  }
+  return createGoogleScriptRunApiHandlerImplementation(invokeRequest) as GoogleScriptRunApiHandler;
 }
 
-export const googleScriptRunApiHandlerFactorySource = String.raw`
-function createGoogleScriptRunApiHandlerMock(invokeRequest) {
-  return createRunner();
-
-  function createRunner(successHandler, failureHandler) {
-    return {
-      withSuccessHandler(nextSuccessHandler) {
-        return createRunner(nextSuccessHandler, failureHandler);
-      },
-      withFailureHandler(nextFailureHandler) {
-        return createRunner(successHandler, nextFailureHandler);
-      },
-      apiHandler(request) {
-        invokeRequest(request, {
-          successHandler,
-          failureHandler,
-        });
-      },
-    };
-  }
-}
-`;
+export const googleScriptRunApiHandlerFactorySource =
+  createGoogleScriptRunApiHandlerImplementation.toString();


### PR DESCRIPTION
### Motivation

- Provide a deterministic, per-call-isolated mock for `google.script.run.apiHandler` to avoid shared-mutable runner issues in tests.
- Standardise how Vitest and Playwright tests mock GAS transport so overlapping requests cannot overwrite each other's handlers.
- Update docs and agent guidance so test authors reuse the shared helper rather than adding ad-hoc mocks.

### Description

- Added a new test harness `src/frontend/src/test/googleScriptRunHarness.ts` that exports `createGoogleScriptRunApiHandlerMock`, `GoogleScriptRunApiHandler` types, and `googleScriptRunApiHandlerFactorySource` for Playwright `addInitScript` usage.
- Migrated multiple tests to the harness: Playwright E2E specs (`src/frontend/e2e-tests/*.spec.ts`) now use the factory source and a `backendSettingsFixture`, and many unit tests (`src/frontend/src/*.spec.tsx`, `src/frontend/src/services/*.spec.ts`) use the harness instead of ad-hoc runner implementations.
- Replaced inline/duplicated `google.script.run` mocks with calls to `createGoogleScriptRunApiHandlerMock` to ensure per-call callback isolation and clearer intent.
- Updated documentation and agent guidance in `.github/agents/Testing.agent.md` and `docs/developer/frontend/frontend-testing.md` to mandate using the shared `apiHandler` mock helper for Vitest and Playwright and to show recommended usage patterns.
- Added a targeted unit test (`keeps concurrent responses bound to the correct request handlers`) to validate concurrent-response binding behaviour.

### Testing

- Ran frontend unit tests via `npm run frontend:test` (Vitest) for the modified specs and they passed.
- Ran Playwright E2E tests via `npm run frontend:test:e2e` for the updated scenarios and they passed.
- Verified coverage with `npm run frontend:test:coverage` and met the configured thresholds for the frontend suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2dcceb18832998f01e44da1872e4)