### PR TITLE
Extract backend validation utils, centralize Zod schemas, and update tests/ESLint

### DIFF
--- a/src/frontend/e2e-tests/settings-backend.spec.ts
+++ b/src/frontend/e2e-tests/settings-backend.spec.ts
@@ -41,7 +41,7 @@ const partialLoadWarning = 'apiKey: REDACTED';
 const backendSettingsLoadFailureCopy = 'Unable to load backend settings right now.';
 const backendSettingsSaveFailureCopy = 'Configuration save failed.';
 const backendSettingsSavedCopy = 'Backend settings saved.';
-const backendSettingsInitialDelayMs = 150;
+const backendSettingsInitialDelayMs = 1000;
 const backendSettingsSaveDelayMs = 150;
 const apiKeyValidationMessage =
   'API Key must be a valid string of alphanumeric characters and hyphens, without leading/trailing hyphens or consecutive hyphens.';

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -140,6 +140,17 @@ export default defineConfig([
     },
   },
   {
+    files: [
+      'src/features/settings/backend/backendSettingsForm.zod.ts',
+      'src/services/backendConfiguration.zod.ts',
+      'src/services/backendConfigurationValidation.ts',
+    ],
+    rules: {
+      '@typescript-eslint/no-magic-numbers': 'error',
+      'unicorn/prevent-abbreviations': 'error',
+    },
+  },
+  {
     files: ['src/**/*.{spec,test}.{ts,tsx}'],
     rules: {
       ...unicodeSecurityRules,

--- a/src/frontend/src/App.spec.tsx
+++ b/src/frontend/src/App.spec.tsx
@@ -494,7 +494,9 @@ describe('App', () => {
       throw new Error('Expected main.tsx to render the application tree.');
     }
 
-    render(<>{renderedTree}</>);
+    await act(async () => {
+      render(<>{renderedTree}</>);
+    });
 
     expect(screen.getByTestId('config-provider')).toHaveAttribute('data-algorithm', 'light');
 
@@ -645,7 +647,7 @@ describe('App', () => {
   it('does not start class-partials warm-up while auth is unresolved', async () => {
     const transport = installPendingApiHandlerMock();
 
-    renderApp();
+    await renderPendingApp();
 
     expect(screen.getByText(checkingAuthorisationStatusText)).toBeInTheDocument();
     expect(transport.getCallCount(classPartialsMethodName)).toBe(0);

--- a/src/frontend/src/features/settings/backend/BackendSettingsPanel.spec.tsx
+++ b/src/frontend/src/features/settings/backend/BackendSettingsPanel.spec.tsx
@@ -31,6 +31,7 @@ const backendSettingsHookState = {
 const { useBackendSettingsMock } = vi.hoisted(() => ({
   useBackendSettingsMock: vi.fn(),
 }));
+const slowPanelInteractionTimeoutMs = 30_000;
 
 vi.mock('./useBackendSettings', () => ({
   useBackendSettings: useBackendSettingsMock,
@@ -122,7 +123,7 @@ describe('BackendSettingsPanel', () => {
 
     expect(screen.getByRole('alert')).toHaveTextContent('apiKey: REDACTED');
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-  });
+  }, slowPanelInteractionTimeoutMs);
 
   it('renders the planned section cards and visible field labels', () => {
     useBackendSettingsMock.mockImplementation(() => ({
@@ -244,7 +245,7 @@ describe('BackendSettingsPanel', () => {
     await waitFor(() => {
       expect(getField('API key')).toHaveFocus();
     });
-  });
+  }, slowPanelInteractionTimeoutMs);
 
   it('shows stored-key helper text when an API key already exists', () => {
     useBackendSettingsMock.mockImplementation(() => ({

--- a/src/frontend/src/features/settings/backend/backendSettingsForm.zod.ts
+++ b/src/frontend/src/features/settings/backend/backendSettingsForm.zod.ts
@@ -1,82 +1,44 @@
 import { z } from 'zod';
+import {
+  backendApiKeyValidationMessage,
+  isBackendApiKeyToken,
+  isDriveFolderId,
+} from '../../../services/backendConfigurationValidation';
 
-const BackendAssessorBatchSizeSchema = z.number().int().min(1).max(500);
-const SlidesFetchBatchSizeSchema = z.number().int().min(1).max(100);
-const DaysUntilAuthRevokeSchema = z.number().int().min(1).max(365);
-const JsonDbLockTimeoutMsSchema = z.number().int().min(10 ** 3).max(6 * 10 ** 5);
-const JsonDbLogLevelValues = ['DEBUG', 'INFO', 'WARN', 'ERROR'] as const;
-const JsonDbLogLevelSchema = z
-    .string()
-    .trim()
-    .transform((value) => value.toUpperCase())
-    .pipe(z.enum(JsonDbLogLevelValues));
-
-/**
- * Determines whether a character is ASCII alphanumeric.
- *
- * @param {string} character The character to inspect.
- * @returns {boolean} True when the character is alphanumeric.
- */
-const isAlphaNumericCharacter = (character: string): boolean => {
-    const characterCode = character.codePointAt(0);
-    return (
-        characterCode !== undefined &&
-        ((characterCode >= 48 && characterCode <= 57) ||
-            (characterCode >= 65 && characterCode <= 90) ||
-            (characterCode >= 97 && characterCode <= 122))
-    );
-};
-
-/**
- * Determines whether a value matches the backend API key token contract.
- *
- * @param {string} value The candidate API key.
- * @returns {boolean} True when the value is a valid token.
- */
-const isBackendApiKeyToken = (value: string): boolean => {
-    if (value === '') {
-        return false;
-    }
-
-    const tokenSegments = value.split('-');
-    if (tokenSegments.some((segment) => segment.length === 0)) {
-        return false;
-    }
-
-    return tokenSegments.every((segment) => {
-        for (const character of segment) {
-            if (!isAlphaNumericCharacter(character)) {
-                return false;
-            }
-        }
-
-        return true;
-    });
-};
-
-/**
- * Determines whether a string matches the backend Drive folder identifier contract.
- *
- * @param {string} value The candidate folder identifier.
- * @returns {boolean} True when the identifier shape is valid.
- */
-const isDriveFolderId = (value: string): boolean => {
-    if (value.length < 10) {
-        return false;
-    }
-
-    for (const character of value) {
-        if (
-            !isAlphaNumericCharacter(character) &&
-            character !== '_' &&
-            character !== '-'
-        ) {
-            return false;
-        }
-    }
-
-    return true;
-};
+const backendAssessorBatchSizeMinimum = 1;
+const backendAssessorBatchSizeMaximum = 500;
+const slidesFetchBatchSizeMinimum = 1;
+const slidesFetchBatchSizeMaximum = 100;
+const daysUntilAuthRevokeMinimum = 1;
+const daysUntilAuthRevokeMaximum = 365;
+const millisecondsPerSecond = 1000;
+const maximumJsonDatabaseLockTimeoutSeconds = 600;
+const backendAssessorBatchSizeSchema = z
+  .number()
+  .int()
+  .min(backendAssessorBatchSizeMinimum)
+  .max(backendAssessorBatchSizeMaximum);
+const slidesFetchBatchSizeSchema = z
+  .number()
+  .int()
+  .min(slidesFetchBatchSizeMinimum)
+  .max(slidesFetchBatchSizeMaximum);
+const daysUntilAuthRevokeSchema = z
+  .number()
+  .int()
+  .min(daysUntilAuthRevokeMinimum)
+  .max(daysUntilAuthRevokeMaximum);
+const jsonDatabaseLockTimeoutMsSchema = z
+  .number()
+  .int()
+  .min(millisecondsPerSecond)
+  .max(maximumJsonDatabaseLockTimeoutSeconds * millisecondsPerSecond);
+const jsonDatabaseLogLevelValues = ['DEBUG', 'INFO', 'WARN', 'ERROR'] as const;
+const jsonDatabaseLogLevelSchema = z
+  .string()
+  .trim()
+  .transform((value) => value.toUpperCase())
+  .pipe(z.enum(jsonDatabaseLogLevelValues));
 
 /**
  * Canonical frontend validation schema for the backend settings form.
@@ -88,49 +50,47 @@ const isDriveFolderId = (value: string): boolean => {
  * separately.
  */
 export const BackendSettingsFormSchema = z
-    .object({
-        hasApiKey: z.boolean(),
-        apiKey: z.string().trim(),
-        backendUrl: z.string().trim().pipe(z.url()),
-        backendAssessorBatchSize: BackendAssessorBatchSizeSchema,
-        slidesFetchBatchSize: SlidesFetchBatchSizeSchema,
-        daysUntilAuthRevoke: DaysUntilAuthRevokeSchema,
-        jsonDbMasterIndexKey: z.string().trim().min(1),
-        jsonDbLockTimeoutMs: JsonDbLockTimeoutMsSchema,
-        jsonDbLogLevel: JsonDbLogLevelSchema,
-        jsonDbBackupOnInitialise: z.boolean(),
-        jsonDbRootFolderId: z
-            .string()
-            .trim()
-            .optional()
-            .transform((value) => value ?? '')
-            .refine((value) => value === '' || isDriveFolderId(value), {
-                message:
-                    'JSON DB Root Folder ID must match the backend Drive folder identifier contract.',
-            }),
-    })
-    .superRefine((value, context) => {
-        if (value.hasApiKey) {
-            if (value.apiKey !== '' && !isBackendApiKeyToken(value.apiKey)) {
-                context.addIssue({
-                    code: 'custom',
-                    path: ['apiKey'],
-                    message:
-                        'API Key must be a valid string of alphanumeric characters and hyphens, without leading/trailing hyphens or consecutive hyphens.',
-                });
-            }
-            return;
-        }
+  .object({
+    hasApiKey: z.boolean(),
+    apiKey: z.string().trim(),
+    backendUrl: z.string().trim().pipe(z.url()),
+    backendAssessorBatchSize: backendAssessorBatchSizeSchema,
+    slidesFetchBatchSize: slidesFetchBatchSizeSchema,
+    daysUntilAuthRevoke: daysUntilAuthRevokeSchema,
+    jsonDbMasterIndexKey: z.string().trim().min(1),
+    jsonDbLockTimeoutMs: jsonDatabaseLockTimeoutMsSchema,
+    jsonDbLogLevel: jsonDatabaseLogLevelSchema,
+    jsonDbBackupOnInitialise: z.boolean(),
+    jsonDbRootFolderId: z
+      .string()
+      .trim()
+      .optional()
+      .transform((value) => value ?? '')
+      .refine((value) => value === '' || isDriveFolderId(value), {
+        message:
+          'JSON DB Root Folder ID must match the backend Drive folder identifier contract.',
+      }),
+  })
+  .superRefine((value, context) => {
+    if (value.hasApiKey) {
+      if (value.apiKey !== '' && !isBackendApiKeyToken(value.apiKey)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['apiKey'],
+          message: backendApiKeyValidationMessage,
+        });
+      }
+      return;
+    }
 
-        if (value.apiKey === '' || !isBackendApiKeyToken(value.apiKey)) {
-            context.addIssue({
-                code: 'custom',
-                path: ['apiKey'],
-                message:
-                    'API Key must be a valid string of alphanumeric characters and hyphens, without leading/trailing hyphens or consecutive hyphens.',
-            });
-        }
-    })
-    .strict();
+    if (value.apiKey === '' || !isBackendApiKeyToken(value.apiKey)) {
+      context.addIssue({
+        code: 'custom',
+        path: ['apiKey'],
+        message: backendApiKeyValidationMessage,
+      });
+    }
+  })
+  .strict();
 
 export type BackendSettingsForm = z.infer<typeof BackendSettingsFormSchema>;

--- a/src/frontend/src/services/backendConfiguration.zod.ts
+++ b/src/frontend/src/services/backendConfiguration.zod.ts
@@ -1,70 +1,21 @@
 import { z } from 'zod';
+import {
+  backendApiKeyValidationMessage,
+  isBackendApiKeyToken,
+  isMaskedBackendApiKeyValue,
+} from './backendConfigurationValidation';
 
 const IntegerSchema = z.number().int();
 const NonEmptyStringSchema = z.string();
 const BackendUrlSchema = z.union([z.url(), z.literal('')]);
 
-/**
- * Determines whether a character is ASCII alphanumeric.
- *
- * @param {string} character The character to inspect.
- * @returns {boolean} True when the character is alphanumeric.
- */
-const isAlphaNumericCharacter = (character: string): boolean => {
-    const characterCode = character.codePointAt(0);
-    return (
-        characterCode !== undefined &&
-        ((characterCode >= 48 && characterCode <= 57) ||
-            (characterCode >= 65 && characterCode <= 90) ||
-            (characterCode >= 97 && characterCode <= 122))
-    );
-};
-
-/**
- * Determines whether a value matches the backend API key token contract.
- *
- * @param {string} value The candidate API key.
- * @returns {boolean} True when the value is a valid token.
- */
-const isBackendApiKeyToken = (value: string): boolean => {
-    if (value === '') {
-        return false;
-    }
-
-    const tokenSegments = value.split('-');
-    if (tokenSegments.some((segment) => segment.length === 0)) {
-        return false;
-    }
-
-    return tokenSegments.every((segment) => {
-        for (const character of segment) {
-            if (!isAlphaNumericCharacter(character)) {
-                return false;
-            }
-        }
-
-        return true;
-    });
-};
-
-/**
- * Determines whether a masked API key value matches the read contract.
- *
- * @param {string} value The candidate masked API key.
- * @returns {boolean} True when the value is an accepted mask.
- */
-const isMaskedApiKeyValue = (value: string): boolean => {
-    return value === '' || value === '****' || (value.startsWith('****') && value.length === 8);
-};
-
 const BackendApiKeyWriteSchema = z.string().refine(
-    (value) => isBackendApiKeyToken(value),
-    {
-        message:
-            'API Key must be a valid string of alphanumeric characters and hyphens, without leading/trailing hyphens or consecutive hyphens.',
-    }
+  (value) => isBackendApiKeyToken(value),
+  {
+    message: backendApiKeyValidationMessage,
+  }
 );
-const MaskedApiKeySchema = z.string().refine(isMaskedApiKeyValue);
+const MaskedApiKeySchema = z.string().refine(isMaskedBackendApiKeyValue);
 
 /**
  * Transport schema for backend configuration reads.
@@ -75,22 +26,22 @@ const MaskedApiKeySchema = z.string().refine(isMaskedApiKeyValue);
  * entire query.
  */
 export const BackendConfigSchema = z
-    .object({
-        backendAssessorBatchSize: IntegerSchema,
-        apiKey: MaskedApiKeySchema,
-        hasApiKey: z.boolean(),
-        backendUrl: BackendUrlSchema,
-        revokeAuthTriggerSet: z.boolean(),
-        daysUntilAuthRevoke: IntegerSchema,
-        slidesFetchBatchSize: IntegerSchema,
-        jsonDbMasterIndexKey: NonEmptyStringSchema,
-        jsonDbLockTimeoutMs: IntegerSchema,
-        jsonDbLogLevel: NonEmptyStringSchema,
-        jsonDbBackupOnInitialise: z.boolean(),
-        jsonDbRootFolderId: z.string(),
-        loadError: z.string().optional(),
-    })
-    .strict();
+  .object({
+    backendAssessorBatchSize: IntegerSchema,
+    apiKey: MaskedApiKeySchema,
+    hasApiKey: z.boolean(),
+    backendUrl: BackendUrlSchema,
+    revokeAuthTriggerSet: z.boolean(),
+    daysUntilAuthRevoke: IntegerSchema,
+    slidesFetchBatchSize: IntegerSchema,
+    jsonDbMasterIndexKey: NonEmptyStringSchema,
+    jsonDbLockTimeoutMs: IntegerSchema,
+    jsonDbLogLevel: NonEmptyStringSchema,
+    jsonDbBackupOnInitialise: z.boolean(),
+    jsonDbRootFolderId: z.string(),
+    loadError: z.string().optional(),
+  })
+  .strict();
 
 export type BackendConfig = z.infer<typeof BackendConfigSchema>;
 
@@ -102,19 +53,19 @@ export type BackendConfig = z.infer<typeof BackendConfigSchema>;
  * `hasApiKey`, `loadError`, and `revokeAuthTriggerSet` are intentionally excluded from writes.
  */
 export const BackendConfigWriteInputSchema = z
-    .object({
-        backendAssessorBatchSize: IntegerSchema.optional(),
-        apiKey: BackendApiKeyWriteSchema.optional(),
-        backendUrl: z.url().optional(),
-        daysUntilAuthRevoke: IntegerSchema.optional(),
-        slidesFetchBatchSize: IntegerSchema.optional(),
-        jsonDbMasterIndexKey: NonEmptyStringSchema.optional(),
-        jsonDbLockTimeoutMs: IntegerSchema.optional(),
-        jsonDbLogLevel: NonEmptyStringSchema.optional(),
-        jsonDbBackupOnInitialise: z.boolean().optional(),
-        jsonDbRootFolderId: z.string().optional(),
-    })
-    .strict();
+  .object({
+    backendAssessorBatchSize: IntegerSchema.optional(),
+    apiKey: BackendApiKeyWriteSchema.optional(),
+    backendUrl: z.url().optional(),
+    daysUntilAuthRevoke: IntegerSchema.optional(),
+    slidesFetchBatchSize: IntegerSchema.optional(),
+    jsonDbMasterIndexKey: NonEmptyStringSchema.optional(),
+    jsonDbLockTimeoutMs: IntegerSchema.optional(),
+    jsonDbLogLevel: NonEmptyStringSchema.optional(),
+    jsonDbBackupOnInitialise: z.boolean().optional(),
+    jsonDbRootFolderId: z.string().optional(),
+  })
+  .strict();
 
 export type BackendConfigWriteInput = z.infer<typeof BackendConfigWriteInputSchema>;
 
@@ -126,17 +77,17 @@ export type BackendConfigWriteInput = z.infer<typeof BackendConfigWriteInputSche
  * failures are still represented by the outer `callApi` error envelope rather than this union.
  */
 export const BackendConfigWriteResultSchema = z.union([
-    z
-        .object({
-            success: z.literal(true),
-        })
-        .strict(),
-    z
-        .object({
-            success: z.literal(false),
-            error: z.string(),
-        })
-        .strict(),
+  z
+    .object({
+      success: z.literal(true),
+    })
+    .strict(),
+  z
+    .object({
+      success: z.literal(false),
+      error: z.string(),
+    })
+    .strict(),
 ]);
 
 export type BackendConfigWriteResult = z.infer<typeof BackendConfigWriteResultSchema>;

--- a/src/frontend/src/services/backendConfigurationValidation.ts
+++ b/src/frontend/src/services/backendConfigurationValidation.ts
@@ -1,0 +1,92 @@
+const asciiDigitZeroCodePoint = 48;
+const asciiDigitNineCodePoint = 57;
+const asciiUppercaseLetterACodePoint = 65;
+const asciiUppercaseLetterZCodePoint = 90;
+const asciiLowercaseLetterACodePoint = 97;
+const asciiLowercaseLetterZCodePoint = 122;
+const minimumDriveFolderIdLength = 10;
+const maskedApiKeyPrefix = '****';
+const maskedApiKeyWithSuffixLength = 8;
+
+export const backendApiKeyValidationMessage =
+  'API Key must be a valid string of alphanumeric characters and hyphens, without leading/trailing hyphens or consecutive hyphens.';
+
+/**
+ * Determines whether a character is ASCII alphanumeric.
+ *
+ * @param {string} character The character to inspect.
+ * @returns {boolean} True when the character is alphanumeric.
+ */
+export function isAlphaNumericCharacter(character: string): boolean {
+  const characterCode = character.codePointAt(0);
+
+  return (
+    characterCode !== undefined &&
+    ((characterCode >= asciiDigitZeroCodePoint && characterCode <= asciiDigitNineCodePoint) ||
+      (characterCode >= asciiUppercaseLetterACodePoint &&
+        characterCode <= asciiUppercaseLetterZCodePoint) ||
+      (characterCode >= asciiLowercaseLetterACodePoint &&
+        characterCode <= asciiLowercaseLetterZCodePoint))
+  );
+}
+
+/**
+ * Determines whether a value matches the backend API key token contract.
+ *
+ * @param {string} value The candidate API key.
+ * @returns {boolean} True when the value is a valid token.
+ */
+export function isBackendApiKeyToken(value: string): boolean {
+  if (value === '') {
+    return false;
+  }
+
+  const tokenSegments = value.split('-');
+  if (tokenSegments.some((segment) => segment.length === 0)) {
+    return false;
+  }
+
+  return tokenSegments.every((segment) => {
+    for (const character of segment) {
+      if (!isAlphaNumericCharacter(character)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Determines whether a masked API key value matches the read contract.
+ *
+ * @param {string} value The candidate masked API key.
+ * @returns {boolean} True when the value is an accepted mask.
+ */
+export function isMaskedBackendApiKeyValue(value: string): boolean {
+  return (
+    value === '' ||
+    value === maskedApiKeyPrefix ||
+    (value.startsWith(maskedApiKeyPrefix) && value.length === maskedApiKeyWithSuffixLength)
+  );
+}
+
+/**
+ * Determines whether a string matches the backend Drive folder identifier contract.
+ *
+ * @param {string} value The candidate folder identifier.
+ * @returns {boolean} True when the identifier shape is valid.
+ */
+export function isDriveFolderId(value: string): boolean {
+  if (value.length < minimumDriveFolderIdLength) {
+    return false;
+  }
+
+  for (const character of value) {
+    if (!isAlphaNumericCharacter(character) && character !== '_' && character !== '-') {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Motivation
- Consolidate and reuse backend configuration/validation logic to avoid duplication and reduce chances of inconsistent validation messages.
- Make Zod schemas clearer by using named constants for numeric bounds and clearer schema identifiers.
- Tighten linting for newly-centralized validation files and adjust tests to account for timing/async rendering changes.

### Description
- Added `src/frontend/src/services/backendConfigurationValidation.ts` with shared validators and messages: `isAlphaNumericCharacter`, `isBackendApiKeyToken`, `isMaskedBackendApiKeyValue`, `isDriveFolderId`, and `backendApiKeyValidationMessage`.
- Updated `backendSettingsForm.zod.ts` to import and use the shared validators and to replace inline numeric literals with named constants and clearer schema names.
- Updated `backendConfiguration.zod.ts` to reuse the shared validators and messages and to replace the inline masked-api-key check with `isMaskedBackendApiKeyValue`.
- Added an ESLint override in `eslint.config.js` to enforce `@typescript-eslint/no-magic-numbers` and `unicorn/prevent-abbreviations` for the new/updated validation/schema files.
- Adjusted tests: increased an initial delay constant in `settings-backend.spec.ts`, wrapped a render in `act` and changed a render call to `await` in `App.spec.tsx`, and added longer interaction timeouts in `BackendSettingsPanel.spec.tsx` to stabilize slow panel interactions.

### Testing
- Ran frontend unit and component tests (spec files under `src/frontend/src` and `src/frontend/e2e-tests`) that were modified; all tests passed locally in the test run.
- Verified updated specs targeting backend settings and app rendering complete successfully after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc57068ae48329a3a366a4443ee477)