### PR TITLE
Move Classes CRUD into Settings-page Classes tab; add cohort keys and tab layout docs

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -6,7 +6,7 @@
 
 - Implement the Classes CRUD feature in the **Classes** tab on the top-level `SettingsPage`.
 - Replace the current placeholder Classes-tab content in `src/frontend/src/pages/SettingsPage.tsx` with a real feature entry for CRUD-only class management.
-- Use `CLASSROOM_TAB_LAYOUT_AND_MODALS.md` as the UI-layout and modal-state companion document for implementation details that sit below the product/data-contract level.
+- Use `CLASSES_TAB_LAYOUT_AND_MODALS.md` as the UI-layout and modal-state companion document for implementation details that sit below the product/data-contract level.
 - Update backend reference-data models, controllers, and API handlers so cohorts and year groups use stable keys.
 - Update `ABClass` transport and persistence contracts so class metadata stores `cohortKey` and `yearGroupKey` rather than mutable display names.
 - Add the required frontend services, Zod schemas, React Query definitions, view-model mapping, page UI, modal workflows, and automated test coverage.

--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -4,18 +4,21 @@
 
 ### Scope
 
-- Implement the Classes CRUD feature on the top-level `ClassesPage`.
-- Replace the current placeholder `src/frontend/src/pages/ClassesPage.tsx` with a real feature entry for CRUD-only class management.
+- Implement the Classes CRUD feature in the **Classes** tab on the top-level `SettingsPage`.
+- Replace the current placeholder Classes-tab content in `src/frontend/src/pages/SettingsPage.tsx` with a real feature entry for CRUD-only class management.
+- Use `CLASSROOM_TAB_LAYOUT_AND_MODALS.md` as the UI-layout and modal-state companion document for implementation details that sit below the product/data-contract level.
 - Update backend reference-data models, controllers, and API handlers so cohorts and year groups use stable keys.
 - Update `ABClass` transport and persistence contracts so class metadata stores `cohortKey` and `yearGroupKey` rather than mutable display names.
 - Add the required frontend services, Zod schemas, React Query definitions, view-model mapping, page UI, modal workflows, and automated test coverage.
-- Update shared prefetch behaviour so `cohorts` and `yearGroups` warm at startup alongside `classPartials`, while `googleClassrooms` remains a Classes-page entry prefetch.
+- Update shared prefetch behaviour so `cohorts` and `yearGroups` warm at startup alongside `classPartials`, while `googleClassrooms` remains a Classes-tab entry prefetch.
 - Add backend validation to prevent `active` updates from creating missing classes and to block deletion of in-use cohort or year-group records.
+- Add `startYear` and `startMonth` to the cohort model so cohort-year calculations remain possible after moving to stable keys.
+- Update the plan and rollout notes to record that some assessment-workflow paths depend on the current numeric `ABClass.yearGroup` behaviour and will require follow-on refactor work outside this delivery.
 
 ### Out of scope
 
-- Class analysis features on the Classes page.
-- Assessment-run controls on the Classes page.
+- Class analysis features on the Settings-page Classes tab.
+- Assessment-run controls on the Settings-page Classes tab.
 - Inline editing inside the table.
 - Dedicated bulk backend endpoints in this delivery.
 - Manual Google Classroom refresh controls in this delivery.
@@ -23,12 +26,14 @@
 
 ### Assumptions
 
-1. `cohort` and `yearGroup` will move to stable-key reference-data records, and the canonical `ABClass` metadata fields will become `cohortKey` and `yearGroupKey`.
-2. `googleClassrooms` remains a narrow page-entry dataset returning active Classroom rows only; it does not become a startup warm-up dataset in this delivery.
-3. Frontend shared server-state continues to use React Query with shared query-key helpers and transport access routed through `callApi(...)` only.
-4. The current `apiHandler` envelope remains the transport contract; changed payload shapes should be introduced through existing allowlisted methods unless implementation proves a new method is required.
-5. All user-visible interactions introduced by this feature require Playwright coverage in addition to appropriate Vitest coverage.
-6. This feature can be implemented as a blank-slate contract without compatibility or backfill work.
+1. Rollout uses a one-off destructive reset of existing persisted data, so the new code may treat the key-based reference-data and `ABClass` contracts as blank-slate shapes without compatibility or backfill logic.
+2. All cohort and year-group records are keyed records. Cohort keys and year-group keys are generated as UUIDs on create and remain immutable on rename.
+3. Cohorts add `startYear` and `startMonth` as part of the v1 stable-key contract.
+4. `googleClassrooms` remains a narrow page-entry dataset returning active Classroom rows only; the backend API surface already exists and this delivery adds the missing frontend service/query integration.
+5. Frontend shared server-state continues to use React Query with shared query-key helpers and transport access routed through `callApi(...)` only.
+6. The current `apiHandler` envelope remains the transport contract; changed payload shapes should be introduced through existing allowlisted methods unless implementation proves a new method is required.
+7. All user-visible interactions introduced by this feature require Playwright coverage in addition to appropriate Vitest coverage.
+8. Some assessment-workflow paths currently depend on `ABClass.yearGroup` as a numeric academic-year field; that downstream refactor is out of scope for this delivery and must be recorded in follow-up documentation.
 
 ---
 
@@ -41,7 +46,7 @@
 - Avoid defensive guards that hide wiring issues.
 - Keep changes minimal, localised, and consistent with repository conventions.
 - Use British English in comments and documentation.
-- Keep `ClassesPage.tsx` as a composition layer; do not move feature orchestration into page-level shell components.
+- Keep `SettingsPage.tsx` as a composition layer; do not move feature orchestration into page-level shell components.
 - Route all frontend-to-backend calls through `callApi(...)`; never call backend globals or `google.script.run` directly from feature code.
 - Use Zod for new or updated frontend validation logic and derive TypeScript types from schemas.
 - When shared server-state is introduced or changed, use shared query-key helpers and update canonical React Query documentation if policy changes.
@@ -80,6 +85,9 @@ For each section below:
 - Preserve current cohort active-state semantics while introducing keys.
 - Do not silently repurpose existing name fields to carry keys; keep key and display-name responsibilities explicit.
 - Treat the new key-based reference-data shape as the only supported contract for this delivery.
+- Generate UUID keys on create and keep them immutable on rename.
+- All CRUD request shapes must identify target reference-data records by `key`, not by mutable display name.
+- Cohorts must include `startYear` and `startMonth`, with defaults applied from the agreed academic-year rule.
 
 ### Acceptance criteria
 
@@ -87,30 +95,36 @@ For each section below:
 - Backend and frontend code can rely on the blank-slate key-based contract without compatibility fallbacks.
 - Backend and frontend schemas agree on the new reference-data shapes.
 - The changed contract is reflected in the relevant canonical docs or queued explicitly in the documentation section.
+- Cohort records expose `key`, `name`, `active`, `startYear`, and `startMonth`.
+- Year-group records expose `key` and `name`.
+- CRUD request and response shapes for reference data are fully keyed.
 
 ### Required test cases (Red first)
 
 Backend model tests:
 
-1. Cohort model serialises and deserialises `{ key, name, active }` correctly.
+1. Cohort model serialises and deserialises `{ key, name, active, startYear, startMonth }` correctly.
 2. Year-group model serialises and deserialises `{ key, name }` correctly.
 3. Cohort and year-group constructors reject missing or malformed keys.
+4. Cohort defaulting sets `startMonth` to September and derives `startYear` from the current month/year using the agreed academic-year rule.
 
 Backend controller tests:
 
 1. Reference-data list methods return keys and names in the expected plain-object shape.
 2. Create and update paths preserve key integrity and duplicate protection rules.
-3. None unless implementation introduces a normalisation helper for unrelated contract-shaping reasons.
+3. Create and update paths for cohorts preserve `startYear` and `startMonth` rules.
 
 API layer tests:
 
 1. `getCohorts`, `createCohort`, `updateCohort`, `getYearGroups`, `createYearGroup`, and `updateYearGroup` expose the new key-bearing payloads.
 2. Invalid reference-data payloads surface `INVALID_REQUEST` envelopes through the API layer when applicable.
+3. Keyed update and delete request shapes are validated at the API boundary.
 
 Frontend tests:
 
 1. Updated Zod schemas accept valid key-bearing cohort and year-group payloads.
 2. Updated frontend service contracts reject malformed key-bearing payloads.
+3. Updated frontend schemas enforce the keyed CRUD request shapes.
 
 ### Section checks
 
@@ -203,6 +217,7 @@ Frontend tests:
 - Keep API-layer methods thin; put behavioural rules in controllers and/or dedicated validation helpers.
 - Do not allow `active` updates to create missing classes.
 - Delete guards for cohorts and year groups must be backend-authoritative.
+- Use `abclass_partials` as the preferred source for in-use reference-data checks unless implementation proves it insufficient.
 
 ### Acceptance criteria
 
@@ -272,6 +287,9 @@ Frontend tests:
 - Shared query helpers exist for `googleClassrooms`, `cohorts`, `yearGroups`, and `classPartials` as needed.
 - Startup warm-up can fetch `classPartials`, `cohorts`, and `yearGroups`.
 - Cohort and year-group mutations invalidate and refresh the relevant shared queries.
+- The warm-up client is considered warmed only when all three startup-prefetched datasets succeed.
+- Startup warm-up does not add extra retry loops beyond the existing `apiHandler` retry behaviour.
+- If any startup-prefetched dataset fails, the feature surfaces a fail-fast/loud top-level alert rather than silently continuing with a partially warmed state.
 
 ### Required test cases (Red first)
 
@@ -294,6 +312,8 @@ Frontend tests:
 3. Shared query helpers expose the correct query keys and query functions for `googleClassrooms`.
 4. Startup warm-up orchestration fetches `classPartials`, `cohorts`, and `yearGroups` after authorisation.
 5. Cohort and year-group mutation flows invalidate the correct shared queries.
+6. The warm-up marker is set only after all three startup-prefetched datasets resolve successfully.
+7. A failed startup-prefetch path surfaces the expected fail-fast/loud alert state without additional retry orchestration.
 
 ### Section checks
 
@@ -313,22 +333,22 @@ Frontend tests:
 
 ---
 
-## Section 5 — Classes-page entry and merged view-model orchestration
+## Section 5 — Settings-page Classes-tab entry and merged view-model orchestration
 
 ### Objective
 
-- Replace the placeholder Classes page with a real feature entry that loads the shared datasets and builds the merged row view model.
+- Replace the placeholder Settings-page Classes-tab content with a real feature entry that loads the shared datasets and builds the merged row view model.
 
 ### Constraints
 
-- Keep `ClassesPage.tsx` thin and move orchestration into a feature hook or view-model helper.
+- Keep `SettingsPage.tsx` thin and move orchestration into a feature hook or view-model helper.
 - The merged row model must represent `active`, `inactive`, `notCreated`, and `orphaned` rows.
 - Sorting defaults must follow the agreed order.
 - This section must remain CRUD-only; do not add analysis or assessment-run behaviour.
 
 ### Acceptance criteria
 
-- The Classes page renders a real feature entry component.
+- The Settings-page Classes tab renders a real feature entry component.
 - The merged row view model correctly combines Google Classroom rows, stored `ABClass` partials, and reference-data lookups.
 - Default sort order is active, inactive, not created, then orphaned.
 - The page exposes the required loading and partial-load state needed for later UI sections.
@@ -349,7 +369,7 @@ API layer tests:
 
 Frontend tests:
 
-1. `ClassesPage` renders the Classes management feature entry.
+1. `SettingsPage` renders the Classes-tab management feature entry.
 2. The merged view-model helper derives the correct status for active, inactive, not-created, and orphaned rows.
 3. The merged view-model helper resolves cohort and year-group names from keys.
 4. The default sort order is applied correctly.
@@ -357,7 +377,7 @@ Frontend tests:
 
 ### Section checks
 
-- `npm run frontend:test -- src/pages/ClassesPage.spec.tsx src/features/classes/*.spec.ts src/features/classes/**/*.spec.tsx`
+- `npm run frontend:test -- src/pages/SettingsPage.spec.tsx src/features/classes/*.spec.ts src/features/classes/**/*.spec.tsx`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
@@ -409,11 +429,21 @@ API layer tests:
 
 Frontend tests:
 
-1. Table renders the required columns and row content for each status.
-2. Selection state updates correctly when rows are toggled.
-3. Ineligible rows or actions surface the correct disabled states or tooltips.
-4. Orphaned rows show the correct warning affordance.
-5. Playwright covers the visible table render, sorting, and selection behaviour.
+Vitest:
+
+1. Table renders the required columns and row content for active, inactive, `notCreated`, and orphaned rows.
+2. Table loading state renders with shell structure intact during initial Google Classroom entry fetch.
+3. Selection state updates correctly when rows are toggled from no selection to mixed and fully eligible selections.
+4. Ineligible rows or actions surface the correct disabled states or tooltips, including deletion-only orphaned rows.
+5. Summary-card counts and selection-summary text update correctly for mixed row-state datasets.
+
+Playwright:
+
+1. User opens the Settings page, switches to the Classes tab, and sees the default sorted table with summary and toolbar cards.
+2. User sees the no-selection state with the bulk-action trigger disabled and the selection summary reset.
+3. User selects eligible and ineligible rows and sees the correct enabled, disabled, and tooltip-backed bulk affordances.
+4. User sees the first-run `notCreated` rendering and the orphaned warning affordance in the live table.
+5. User sees the no-active-classrooms empty state without losing the management launchers.
 
 ### Section checks
 
@@ -470,11 +500,22 @@ API layer tests:
 
 Frontend tests:
 
-1. Bulk create modal validates required inputs and dispatches one mutation per selected row.
-2. Bulk delete confirmation text is correct and destructive flow works.
-3. Bulk active-state modal or action blocks ineligible selections.
-4. Partial failures keep failed rows selected and show summary feedback.
-5. Playwright covers the visible create, delete, and active-state user journeys.
+Vitest:
+
+1. Bulk create modal covers opening, ready, validation-error, submitting, partial-success, and success-close states.
+2. Bulk create validates required cohort and year-group inputs, applies the default `courseLength` of `1`, and dispatches one mutation per selected row.
+3. Bulk delete confirmation copy states that both full and partial stored class records are removed.
+4. Bulk delete workflow covers ready, submitting, partial-success, and submission-failure summary mapping.
+5. Bulk active-state action blocks ineligible selections before open and maps submitting and partial-success outcomes correctly.
+6. Partial failures keep failed rows selected and drive the top-level mutation summary state expected by the tab.
+
+Playwright:
+
+1. User selects `notCreated` rows, opens Bulk create, sees active-cohort-only options, validates required fields, and completes a successful create flow.
+2. User triggers a bulk-create partial failure and sees failed rows remain selected with warning feedback after close.
+3. User opens Bulk delete, sees the destructive copy, confirms, and receives success or partial-failure summary feedback.
+4. User attempts an ineligible bulk active/inactive action and sees the blocked-before-open explanation.
+5. User completes an eligible bulk active or inactive confirmation flow and sees the tab-level summary update after the modal closes.
 
 ### Section checks
 
@@ -531,12 +572,25 @@ API layer tests:
 
 Frontend tests:
 
-1. Bulk cohort modal offers only active cohorts and updates selected rows correctly.
-2. Bulk year-group modal uses key-based options correctly.
-3. Cohort management modal handles create, edit, delete, and active-state transitions.
-4. Year-group management modal handles create, edit, and delete.
-5. Blocked deletes surface the correct feedback.
-6. Playwright covers the visible reference-data and bulk-metadata flows.
+Vitest:
+
+1. Bulk cohort modal covers ready, validation-error, submitting, and partial-success states and offers only active cohorts.
+2. Bulk year-group modal covers ready, validation-error, submitting, and partial-success states with key-based options and payloads.
+3. Manage cohorts modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
+4. Create/Edit cohort modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
+5. Delete cohort confirmation covers ready, blocked, submitting, success-close, and submission-failure states, including in-use delete messaging.
+6. Manage year groups modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
+7. Create/Edit year group modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
+8. Delete year group confirmation covers ready, blocked, submitting, success-close, and submission-failure states.
+
+Playwright:
+
+1. User opens Bulk set cohort, sees active cohorts only, submits a valid change, and receives summary feedback.
+2. User opens Bulk set year group, submits a valid change, and sees the updated year-group value reflected in the table.
+3. User opens Manage cohorts, exercises empty or ready states as applicable, then completes create, edit, active-state change, and delete flows.
+4. User attempts to delete an in-use cohort and sees the blocked state clearly before the modal closes.
+5. User opens Manage year groups and completes create, edit, and delete flows.
+6. User attempts to delete an in-use year group and sees the blocked state clearly before the modal closes.
 
 ### Section checks
 
@@ -592,11 +646,21 @@ API layer tests:
 
 Frontend tests:
 
-1. Blocking load failure state renders correctly.
-2. Partial-load warning state renders correctly while leaving usable data visible.
-3. Empty states render correctly for the agreed scenarios.
-4. Mutation summary alerts render the correct counts and persistence behaviour.
-5. Playwright covers the main visible failure and empty-state journeys.
+Vitest:
+
+1. Alert stack renders no-alert, blocking startup-prefetch failure, blocking Google Classroom entry failure, partial-load warning, and mutation-summary states in severity order.
+2. Summary card covers initial loading, ready-with-data, ready-with-zero-values, and blocked suppression behaviour.
+3. Toolbar card covers no-selection, mixed eligible/ineligible selection, mutation-in-progress, and ready states.
+4. Table empty-state and failure-state rendering matches the agreed no-active-classrooms, first-run, partial-load, and blocking-failure rules.
+5. Mutation summary alerts render the correct counts, severity, persistence behaviour, and replacement rules.
+
+Playwright:
+
+1. User encounters a startup-prefetch failure and sees the blocking top-level alert with normal interaction disabled.
+2. User encounters a Google Classroom entry failure and sees the blocking error rather than an empty state.
+3. User encounters a partial-load warning and still sees usable summary, toolbar, and table content.
+4. User encounters the no-active-classrooms empty state and still has access to cohort and year-group management launchers.
+5. User completes a mutation that yields success or partial-failure feedback and sees the alert-stack summary persist clearly after modal close.
 
 ### Section checks
 
@@ -681,6 +745,8 @@ Frontend tests:
 - API docs reflect any changed request and response payloads.
 - React Query/prefetch docs reflect the new startup warm-up and invalidation behaviour.
 - Any contract caveats or deferred follow-up items are documented.
+- Documentation records that rollout assumed a one-off destructive reset of existing persisted data.
+- Documentation records the deferred assessment-workflow refactor required by the `yearGroup` contract change.
 
 ### Required checks
 
@@ -707,7 +773,7 @@ Frontend tests:
 2. Section 2 — `ABClass` contract update and partial-shape refresh
 3. Section 3 — `ABClass` mutation validation hardening
 4. Section 4 — Frontend service, schema, and shared-query groundwork
-5. Section 5 — Classes-page entry and merged view-model orchestration
+5. Section 5 — Settings-page Classes-tab entry and merged view-model orchestration
 6. Section 6 — Main table rendering, selection, and status affordances
 7. Section 7 — Bulk create, delete, and active-state workflows
 8. Section 8 — Bulk cohort/year-group updates and reference-data management modals

--- a/CLASSES_TAB_LAYOUT_AND_MODALS.md
+++ b/CLASSES_TAB_LAYOUT_AND_MODALS.md
@@ -1,4 +1,4 @@
-# Classroom Tab Layout and Modals
+# Classes Tab Layout and Modals
 
 ## Purpose
 
@@ -331,7 +331,7 @@ Classes tab
 2. Use `Modal.confirm` only for simple destructive confirmation where no extra fields are required.
 3. Keep one primary modal open at a time unless a secondary create/edit/delete modal is explicitly nested from a management modal.
 4. When a secondary modal closes successfully, return focus to the invoking button inside the parent modal.
-5. Use `destroyOnHidden` only when resetting state is desirable; otherwise keep parent modal state stable during child modal flows.
+5. Use `destroyOnHidden` only when resetting state is desirable; otherwise keep parent modal state stable during child modal flows. In the current Ant Design Modal docs this is the supported prop, while `destroyOnClose` is shown as deprecated.
 6. Surface final mutation summaries in the top-level alert stack after the modal closes.
 
 ## Modal state vocabulary

--- a/CLASSROOM_TAB_LAYOUT_AND_MODALS.md
+++ b/CLASSROOM_TAB_LAYOUT_AND_MODALS.md
@@ -1,0 +1,691 @@
+# Classroom Tab Layout and Modals
+
+## Purpose
+
+This document defines the explicit layout, component hierarchy, modal flows, and user-visible states for the **Classes** tab inside `SettingsPage`.
+
+Use it alongside:
+
+- `SPEC.md`
+- `ACTION_PLAN.md`
+- `SETTINGS_PAGE_LAYOUT.md`
+- `docs/developer/frontend/frontend-testing.md`
+- `docs/developer/frontend/frontend-shell-navigation-and-motion.md`
+
+This document is intentionally UI-focused. It does not replace the data-contract decisions in the spec or the implementation sequencing in the action plan.
+
+## Scope of this document
+
+This document covers:
+
+1. the tab hierarchy inside `SettingsPage`
+2. the major screen regions inside the Classes tab
+3. the Ant Design components to use for each region and modal
+4. the user-visible states of the tab
+5. the user-visible states of each modal workflow
+6. the preferred hierarchy for secondary and tertiary modal flows
+
+This document does **not** redefine backend contracts, data shapes, or rollout assumptions already covered in `SPEC.md` and `ACTION_PLAN.md`.
+
+## Design principles
+
+1. Keep `SettingsPage.tsx` as a composition layer only.
+2. Keep the Classes feature inside the existing **Classes** tab; do not add a new top-level route for this work.
+3. Use one visible CRUD table rather than nested inner tabs.
+4. Use modal-driven workflows for create, bulk-edit, and reference-data management.
+5. Use top-level `Alert` components for blocking and partial-load failures.
+6. Prefer built-in Ant Design behaviours before creating bespoke interaction patterns.
+7. Keep the tab readable in reduced-motion mode and avoid decorative motion that obscures status changes.
+8. Keep the most important statuses visible without forcing the user to open a modal.
+
+## Ant Design references consulted
+
+The component choices below are aligned to the official Ant Design documentation for:
+
+- [Tabs](https://ant.design/components/tabs)
+- [Table](https://ant.design/components/table)
+- [Modal](https://ant.design/components/modal)
+- [Form](https://ant.design/components/form)
+- [Select](https://ant.design/components/select)
+- [InputNumber](https://ant.design/components/input-number)
+- [Empty](https://ant.design/components/empty)
+- [Tooltip](https://ant.design/components/tooltip)
+
+## Tab hierarchy
+
+```text
+SettingsPage
+└── TabbedPageSection
+    ├── Classes tab
+    │   └── ClassesManagementPanel
+    │       ├── ClassesTabAlertStack
+    │       ├── ClassesTabSummaryCard
+    │       ├── ClassesToolbarCard
+    │       │   ├── BulkActionsDropdown
+    │       │   ├── ManageCohortsButton
+    │       │   ├── ManageYearGroupsButton
+    │       │   └── SelectionSummary
+    │       └── ClassesTableCard
+    │           └── ClassesTable
+    └── Backend settings tab
+        └── BackendSettingsPanel
+```
+
+## No nested tabs inside the Classes tab
+
+The Classes tab should **not** introduce another Ant Design `Tabs` layer inside the tab content.
+
+Rationale:
+
+- the Settings page already provides the primary tab switcher
+- the feature is centred on one table and a toolbar
+- nested tabs would hide bulk-action context and selection state
+- modals are a better fit for secondary workflows such as cohort and year-group management
+
+## Classes tab outer layout
+
+## Recommended page skeleton
+
+```text
+ClassesManagementPanel
+└── Flex / Space (vertical)
+    ├── Alert stack
+    ├── Summary card
+    ├── Toolbar card
+    └── Table card
+```
+
+## Recommended top-level Ant Design components
+
+### 1. `Card`
+
+Use `Card` for the main visible regions:
+
+- summary card
+- toolbar card
+- table card
+
+Reason:
+
+- gives clear visual separation without extra tab layers
+- aligns with the existing Settings page design language
+- keeps error and empty states contained and readable
+
+### 2. `Flex` or `Space`
+
+Use a vertical `Flex` or `Space` layout for the main stacking of cards and alerts.
+
+Reason:
+
+- simple, declarative spacing
+- avoids ad-hoc margin stacking
+- keeps the tab responsive without inventing a bespoke layout system
+
+### 3. `Alert`
+
+Use a dedicated alert stack at the top of the tab for:
+
+- blocking startup-prefetch failures
+- Google Classroom load failure on tab entry
+- partial-load warnings
+- mutation summary feedback
+
+Reason:
+
+- the spec and frontend error-handling rules already favour top-level `Alert`
+- makes failure states visible before the user reaches the table
+
+## Classes tab region-by-region design
+
+## 1. Alert stack
+
+### Components
+
+- `Alert`
+- `Space` or `Flex` for vertical stacking
+
+### States
+
+1. **No alerts**
+   - render nothing in this region
+2. **Blocking startup-prefetch failure**
+   - show one error `Alert`
+   - table and toolbar should not present an interactive ready state
+3. **Blocking Google Classroom fetch failure**
+   - show one error `Alert`
+   - keep any already-cached shared lookup data out of view unless the page has a deliberate degraded mode
+4. **Partial-load warning**
+   - show one warning `Alert`
+   - keep usable table data visible
+5. **Mutation summary**
+   - show success or warning `Alert`
+   - partial success remains visible until the user dismisses it or the next mutation replaces it
+
+### Notes
+
+- The alert stack should preserve order by severity: blocking errors first, warnings second, mutation summaries last.
+- Do not bury destructive-operation feedback inside a modal after the modal closes; surface the result here.
+
+## 2. Summary card
+
+### Components
+
+- `Card`
+- `Statistic` for compact counts
+- `Flex` for responsive layout
+- `Badge` or `Tag` only if a textual status cue is needed beside a statistic
+
+### Content
+
+Show compact, glanceable counts such as:
+
+- total visible rows
+- active rows
+- inactive rows
+- not-created rows
+- orphaned rows
+- selected rows
+
+### States
+
+1. **Initial loading**
+   - render `Skeleton` blocks inside the summary card
+2. **Ready with data**
+   - render statistics
+3. **Ready with no active classrooms**
+   - render zero-value statistics rather than hiding the card entirely
+4. **Blocking failure**
+   - optional: suppress the card if the whole tab is blocked
+
+## 3. Toolbar card
+
+### Components
+
+- `Card`
+- `Flex` for row layout and wrapping
+- `Dropdown` for bulk actions
+- `Button` for modal launchers
+- `Badge` or plain text for selection count
+- `Tooltip` for disabled action explanations
+
+### Recommended structure
+
+```text
+Toolbar card
+├── Left cluster
+│   ├── Bulk actions button/dropdown
+│   ├── Manage cohorts button
+│   └── Manage year groups button
+└── Right cluster
+    └── Selection summary text/badge
+```
+
+### Bulk actions menu
+
+Use `Dropdown` plus a primary `Button` or split-button trigger.
+
+Menu items:
+
+- Create selected classes
+- Delete selected classes
+- Set selected classes active
+- Set selected classes inactive
+- Set cohort
+- Set year group
+
+### States
+
+1. **No selection**
+   - bulk action trigger disabled
+   - tooltip explains that at least one eligible row must be selected
+2. **Mixed eligible/ineligible selection**
+   - openable trigger allowed only if the chosen action can still be validated pre-open
+   - ineligible actions disabled with tooltip explanation
+3. **Mutation in progress**
+   - disable bulk trigger and modal launchers
+4. **Ready state**
+   - all launchers available subject to row-selection rules
+
+## 4. Table card
+
+### Components
+
+- `Card`
+- `Table`
+- `Badge` for row status
+- `Tooltip` for warnings and disabled actions
+- `Empty` for empty states
+- `Skeleton` or table `loading`
+
+### Core `Table` features to use
+
+- `rowKey="classId"`
+- `rowSelection`
+- explicit `columns`
+- `pagination` with sensible defaults for the expected row count
+- `locale.emptyText` for custom empty-state content
+- `scroll.x` if column width demands it
+
+### Recommended columns
+
+1. selection checkbox
+2. status
+3. class name
+4. cohort
+5. course length
+6. year group
+7. active flag
+8. row-level actions (only if needed after the bulk-first flow is stable)
+
+`classId` should remain the `rowKey` and an internal identifier for actions, but it does not need a visible column. `class owner` and `teachers` should stay out of the table because they are backend-managed Google Classroom metadata and are only populated after the stored `ABClass` exists.
+
+### Status presentation
+
+Use `Badge` for the four row statuses:
+
+- active
+- inactive
+- not created
+- orphaned
+
+Use `Tooltip` for the orphaned explanation and any disabled state explanation.
+
+### Table states
+
+1. **Initial load in progress**
+   - render table `loading`
+   - keep columns visible if practical
+2. **No active Google Classrooms**
+   - render `Empty` with explanatory description
+   - keep toolbar visible but non-destructive actions disabled
+3. **First run**
+   - render all active classrooms as `notCreated`
+4. **Ready with mixed statuses**
+   - render the merged table normally
+5. **Partial-load warning**
+   - keep table visible
+   - show warning `Alert` above the card
+6. **Blocking failure**
+   - do not present the table as an interactive ready state
+
+## Modal hierarchy
+
+```text
+Classes tab
+├── BulkCreateClassesModal
+├── BulkDeleteClassesConfirmModal
+├── BulkSetActiveStateConfirmModal
+├── BulkSetCohortModal
+├── BulkSetYearGroupModal
+├── ManageCohortsModal
+│   ├── CreateOrEditCohortModal
+│   └── DeleteCohortConfirmModal
+└── ManageYearGroupsModal
+    ├── CreateOrEditYearGroupModal
+    └── DeleteYearGroupConfirmModal
+```
+
+## General modal rules
+
+1. Use Ant Design `Modal` for all form-driven workflows.
+2. Use `Modal.confirm` only for simple destructive confirmation where no extra fields are required.
+3. Keep one primary modal open at a time unless a secondary create/edit/delete modal is explicitly nested from a management modal.
+4. When a secondary modal closes successfully, return focus to the invoking button inside the parent modal.
+5. Use `destroyOnHidden` only when resetting state is desirable; otherwise keep parent modal state stable during child modal flows.
+6. Surface final mutation summaries in the top-level alert stack after the modal closes.
+
+## Modal state vocabulary
+
+Each modal should explicitly support these states where relevant:
+
+- **closed**
+- **opening**
+- **ready**
+- **validation error**
+- **submitting**
+- **success-close**
+- **submission failure**
+- **partial success** (bulk flows only)
+- **blocked** (delete or edit disallowed)
+
+## Bulk create classes modal
+
+### Purpose
+
+Create missing `ABClass` records for selected `notCreated` rows.
+
+### Components
+
+- `Modal`
+- `Form`
+- `Select` for cohort
+- `Select` for year group
+- `InputNumber` for course length
+- `Alert` for validation or bulk-result warnings inside the modal only while it remains open
+
+### Fields
+
+- cohort
+- year group
+- course length
+
+### States
+
+1. **opening**
+   - selected-row count known
+   - reference-data options may still be resolving
+2. **ready**
+   - form enabled
+   - cohort options limited to active cohorts
+3. **validation error**
+   - use `Form.Item` help/status, not a bespoke error renderer
+4. **submitting**
+   - OK button loading
+   - form disabled
+5. **partial success**
+   - modal may either remain open to show failures or close and let the tab-level summary alert carry the result
+   - failed rows remain selected
+6. **success-close**
+   - close modal
+   - update top-level summary alert
+
+## Bulk delete classes confirmation modal
+
+### Purpose
+
+Delete active, inactive, or orphaned `ABClass` rows.
+
+### Components
+
+- `Modal.confirm` or standard `Modal`
+- `Alert` inside the body only if there is a destructive-operation warning that must not be missed
+- optional `List` for selected class names if the selection is small enough to be readable
+
+### Required copy
+
+Must state that the action deletes:
+
+- the full stored `ABClass` record
+- the partial stored class-summary/index row
+
+### States
+
+1. **ready**
+   - confirmation copy visible
+2. **submitting**
+   - confirm button loading/disabled
+3. **partial success**
+   - close modal and show summary `Alert` in the tab
+4. **submission failure**
+   - keep modal open only if the error is actionable in-place; otherwise close and show the alert stack result
+
+## Bulk set active/inactive confirmation modal
+
+### Purpose
+
+Apply a status change to eligible existing rows.
+
+### Components
+
+- `Modal.confirm` for simple confirmation
+- optional `Alert` if the current selection contains rows that were filtered out before open
+
+### States
+
+1. **blocked before open**
+   - do not open modal if the current selection includes ineligible rows
+   - explain via `Tooltip`
+2. **ready**
+   - confirmation text includes target state and affected count
+3. **submitting**
+   - confirm button loading
+4. **partial success**
+   - close modal and surface summary at tab level
+
+## Bulk set cohort modal
+
+### Purpose
+
+Apply one cohort to multiple eligible existing rows.
+
+### Components
+
+- `Modal`
+- `Form`
+- `Select`
+- `Alert` for blocked or warning copy where needed
+
+### States
+
+1. **ready**
+   - active cohorts only in `Select`
+2. **validation error**
+   - missing selection or stale option
+3. **submitting**
+   - form disabled, OK button loading
+4. **partial success**
+   - same summary pattern as other bulk workflows
+
+## Bulk set year group modal
+
+### Purpose
+
+Apply one year group to multiple eligible existing rows.
+
+### Components
+
+- `Modal`
+- `Form`
+- `Select`
+
+### States
+
+1. **ready**
+2. **validation error**
+3. **submitting**
+4. **partial success**
+
+## Manage cohorts modal
+
+### Purpose
+
+Provide CRUD management for cohort reference data without leaving the Classes tab.
+
+### Components
+
+- `Modal`
+- inner `Table` for cohort records
+- `Button` for create
+- row action buttons for edit/delete
+- `Switch` or status `Badge` for active state visibility
+- `Empty` when no cohorts exist
+- `Alert` for blocked delete or stale-data warnings
+
+### Recommended columns
+
+- name
+- start year
+- start month
+- active
+- actions
+
+### States
+
+1. **opening/list loading**
+   - show `Skeleton` or table `loading`
+2. **empty**
+   - show `Empty` plus a primary create button
+3. **ready**
+   - render table of cohorts
+4. **mutation in progress**
+   - disable conflicting row actions
+5. **list reload warning**
+   - show warning `Alert` inside modal while keeping current rows visible
+
+### Child modal flows
+
+#### Create/Edit cohort modal
+
+Components:
+
+- `Modal`
+- `Form`
+- `Input` for name
+- `InputNumber` or `Select` for start month
+- `InputNumber` for start year
+- `Switch` for active
+
+States:
+
+- opening
+- ready
+- validation error
+- submitting
+- success-close
+- submission failure
+
+#### Delete cohort confirmation modal
+
+Components:
+
+- `Modal.confirm` or standard `Modal`
+- `Alert` when delete is blocked because the cohort is in use
+
+States:
+
+- ready
+- blocked (in use)
+- submitting
+- success-close
+- submission failure
+
+## Manage year groups modal
+
+### Purpose
+
+Provide CRUD management for year-group reference data without leaving the Classes tab.
+
+### Components
+
+- `Modal`
+- inner `Table`
+- `Button` for create
+- row action buttons for edit/delete
+- `Empty`
+- `Alert` for blocked delete or reload warnings
+
+### Recommended columns
+
+- name
+- actions
+
+### States
+
+1. **opening/list loading**
+2. **empty**
+3. **ready**
+4. **mutation in progress**
+5. **list reload warning**
+
+### Child modal flows
+
+#### Create/Edit year group modal
+
+Components:
+
+- `Modal`
+- `Form`
+- `Input` for name
+
+States:
+
+- opening
+- ready
+- validation error
+- submitting
+- success-close
+- submission failure
+
+#### Delete year group confirmation modal
+
+Components:
+
+- `Modal.confirm` or standard `Modal`
+- `Alert` when delete is blocked because the year group is in use
+
+States:
+
+- ready
+- blocked
+- submitting
+- success-close
+- submission failure
+
+## Preferred tab-state matrix
+
+| State                            | Visible UI                        | Primary components                                 | Interaction rule                             |
+| -------------------------------- | --------------------------------- | -------------------------------------------------- | -------------------------------------------- |
+| Startup prefetch loading         | summary skeleton + disabled shell | `Skeleton`, disabled `Button`, empty `Card` shells | do not allow bulk actions                    |
+| Startup prefetch failure         | blocking error                    | `Alert`                                            | fail fast and block normal interaction       |
+| Google Classroom entry load      | table loading                     | `Table.loading`                                    | keep shell stable while tab-entry fetch runs |
+| Google Classroom entry failure   | blocking error                    | `Alert`                                            | do not masquerade as empty state             |
+| No active classrooms             | empty state                       | `Empty`                                            | keep management launchers visible            |
+| Ready, no selection              | normal table                      | `Table`, `Dropdown`, `Button`                      | bulk trigger disabled                        |
+| Ready, with selection            | normal table + selection summary  | `Badge`/text summary                               | enable only eligible actions                 |
+| Mutation in progress             | ready state with disabled actions | loading `Button` / `Modal` buttons                 | prevent double-submit                        |
+| Mutation summary success         | summary feedback                  | success `Alert`                                    | keep table visible                           |
+| Mutation summary partial failure | warning feedback                  | warning `Alert`                                    | failed rows remain selected                  |
+
+## Accessibility and usability requirements
+
+1. Every modal must have a specific title describing the action, not a generic “Manage” label.
+2. Disabled bulk actions should expose the reason through `Tooltip` text where practical.
+3. Orphaned warnings must not rely on icon-only communication.
+4. The first actionable field in each form modal should receive focus on open.
+5. Destructive confirmations must name the record count or the specific record where practical.
+6. Row selection changes should remain visible after partial failures.
+7. The tab must remain readable without animation when reduced motion is enabled.
+
+## Testing implications
+
+Per `docs/developer/frontend/frontend-testing.md`, every new user-visible interaction here will require Playwright coverage in addition to suitable Vitest coverage.
+
+### Required Vitest coverage by state group
+
+Vitest should cover the invisible behaviour that drives every explicit state in this document:
+
+- alert-stack ordering and mapping for no-alert, blocking failure, warning, and mutation-summary states
+- summary-card derivation for loading, ready-with-data, ready-with-zero-values, and blocked suppression states
+- toolbar action-eligibility logic for no-selection, mixed-selection, ready, and mutation-in-progress states
+- table-column configuration, row-status derivation, selection rules, and empty-state mapping
+- modal state transitions for opening, ready, validation error, submitting, success-close, submission failure, partial success, and blocked flows
+- reference-data management modal list-state mapping for loading, empty, ready, mutation-in-progress, and reload-warning states
+- summary and error mapping that keeps failed rows selected after partial-success batch operations
+
+### Required Playwright journeys by visible state group
+
+Playwright should cover the visible browser flows that correspond to those same states:
+
+1. open the Settings page, switch to the Classes tab, and confirm the default ready state
+2. observe startup-prefetch failure, Google Classroom entry failure, partial-load warning, and no-active-classrooms empty states
+3. verify no-selection, mixed-selection, and ready-with-selection toolbar states, including tooltip-backed disabled actions
+4. verify table rendering for active, inactive, `notCreated`, and orphaned rows
+5. open and complete Bulk create, Bulk delete, and Bulk set active/inactive flows, including partial-failure feedback where applicable
+6. open and complete Bulk set cohort and Bulk set year-group flows
+7. open Manage cohorts and Manage year groups, then exercise create, edit, delete, active-state, and blocked-delete flows
+8. verify mutation-summary success and partial-failure alerts persist at tab level after modal close
+
+### Suggested spec organisation
+
+Keep the frontend suites split by testing responsibility:
+
+- Vitest: feature hook, view-model, table, toolbar, alert-stack, and modal component or helper specs under `src/frontend/src/features/classes/**`
+- Playwright: visible Classes-tab journeys in `src/frontend/e2e-tests/classes-crud.spec.ts` with test names grouped by ready, error, empty, bulk-action, and reference-data-management flows
+
+## Open decisions intentionally left to implementation
+
+1. whether the management modals use inner `Table` components or `List` for very small datasets
+2. whether the destructive bulk-confirm flows use standard `Modal` or `Modal.confirm`
+3. whether partial-failure bulk flows keep the modal open briefly or always close immediately and rely solely on the top-level alert stack
+
+These may be refined during implementation, but the overall hierarchy and state model above should remain stable.

--- a/SPEC.md
+++ b/SPEC.md
@@ -161,7 +161,7 @@ The UI table should resolve keys to human-readable names by joining:
 
 The composition root for this feature should live under `SettingsPage` in the **Classes** tab rather than on the top-level `ClassesPage` shell route.
 
-For the detailed tab layout, modal hierarchy, component selection, and state design, use `CLASSROOM_TAB_LAYOUT_AND_MODALS.md` alongside this spec.
+For the detailed tab layout, modal hierarchy, component selection, and state design, use `CLASSES_TAB_LAYOUT_AND_MODALS.md` alongside this spec.
 
 Proposed high-level tree:
 
@@ -230,8 +230,6 @@ The backend `getGoogleClassrooms` API surface already exists. Add the missing fr
 
 - `queryKeys.googleClassrooms()`
 - `getGoogleClassroomsQueryOptions()`
-
-Add a dedicated frontend service and adjacent Zod schema for `getGoogleClassrooms`.
 
 ## Core merged view model
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@ Draft v1.2 — refined after the second review pass.
 
 This document defines the intended behaviour for the Classes CRUD surface.
 
-The top-level Classes page will be used to:
+The Classes CRUD feature will live in the **Classes** tab within the top-level **Settings** page and will be used to:
 
 - list active Google Classrooms alongside persisted `ABClass` records
 - show which Google Classrooms do and do not yet have corresponding `ABClass` records
@@ -19,7 +19,7 @@ This page is **not** intended to host class analysis or assessment-run controls 
 
 ## Agreed product decisions
 
-1. The top-level **Classes** page is the correct home for this feature.
+1. The **Classes** tab in the top-level **Settings** page is the correct home for this feature.
 2. This page is for **CRUD operations on `ABClass` entities only**.
 3. Orphaned `ABClass` records should remain visible on the same page and should support **deletion only**.
 4. The page should use a **single table** with status as a visible column.
@@ -96,6 +96,8 @@ If `ABClass` stores a stable key instead:
   key: string;
   name: string;
   active: boolean;
+  startYear: number;
+  startMonth: number;
 }
 ```
 
@@ -157,22 +159,26 @@ The UI table should resolve keys to human-readable names by joining:
 
 ## Page architecture
 
-The top-level `ClassesPage` should become the composition root for this feature.
+The composition root for this feature should live under `SettingsPage` in the **Classes** tab rather than on the top-level `ClassesPage` shell route.
+
+For the detailed tab layout, modal hierarchy, component selection, and state design, use `CLASSROOM_TAB_LAYOUT_AND_MODALS.md` alongside this spec.
 
 Proposed high-level tree:
 
 ```text
-ClassesPage
-└── ClassesManagementPage
-    ├── PageHeader / summary
-    ├── Alert region (load, partial-load, mutation summary)
-    ├── ClassesToolbar
-    │   ├── Bulk actions trigger
-    │   ├── Secondary modal launchers
-    │   │   ├── Manage cohorts
-    │   │   └── Manage year groups
-    │   └── Selection summary
-    └── ClassesTable
+SettingsPage
+└── TabbedPageSection
+    └── Classes tab
+        └── ClassesManagementPanel
+            ├── PageHeader / summary
+            ├── Alert region (load, partial-load, mutation summary)
+            ├── ClassesToolbar
+            │   ├── Bulk actions trigger
+            │   ├── Secondary modal launchers
+            │   │   ├── Manage cohorts
+            │   │   └── Manage year groups
+            │   └── Selection summary
+            └── ClassesTable
 ```
 
 ### Out of scope for this page
@@ -187,7 +193,7 @@ The first implementation slice must not add:
 
 ## Required datasets
 
-The Classes page depends on four shared datasets:
+The Settings-page **Classes** tab depends on four shared datasets:
 
 - `classPartials`
 - `googleClassrooms`
@@ -204,11 +210,11 @@ Startup warm-up should prefetch:
 - `cohorts`
 - `yearGroups`
 
-These datasets should be treated as shared lookup data because they will be reused for joins, filters, and query composition beyond the Classes page.
+These datasets should be treated as shared lookup data because they will be reused for joins, filters, and query composition beyond the Classes tab.
 
-### Classes-page entry
+### Classes-tab entry
 
-When the Classes page is opened, prefetch:
+When the Classes tab is opened, prefetch:
 
 - `googleClassrooms`
 
@@ -220,7 +226,7 @@ No dedicated manual refresh control is required in v1.
 
 ## Query additions
 
-Add a shared query key and query options for Google Classrooms:
+The backend `getGoogleClassrooms` API surface already exists. Add the missing frontend service, adjacent Zod schema, shared query key, and shared query options for Google Classrooms:
 
 - `queryKeys.googleClassrooms()`
 - `getGoogleClassroomsQueryOptions()`
@@ -279,6 +285,8 @@ This is the first-run case.
 - persisted `ABClass` partial exists
 - class is not present in the active Google Classroom list
 
+For v1, this status means **not present in the active Google Classroom list** only. It is not yet a definitive signal that the Classroom was deleted or archived. Future work may widen the Classroom dataset to include archived classes so this label can become more precise.
+
 ## Sort order
 
 Default table sort order should be:
@@ -313,13 +321,12 @@ Recommended Ant Design components:
 1. checkbox selection column
 2. status column
 3. `className`
-4. `classId`
-5. cohort
-6. `courseLength`
-7. year group
-8. `classOwner`
-9. `teachers`
-10. `active`
+4. cohort
+5. `courseLength`
+6. year group
+7. `active`
+
+`classId` should remain available to the feature as the row key and hidden identifier, but it does not need a visible table column in the Classes-tab UI. `classOwner` and `teachers` should not be displayed in the table because they are backend-managed Google Classroom metadata and are populated only after the stored `ABClass` exists.
 
 ## Rendering rules
 
@@ -330,8 +337,6 @@ For rows without persisted `ABClass` data, unavailable fields should render as `
 - cohort
 - course length
 - year group
-- class owner
-- teachers
 - active
 
 ### Active and inactive rows
@@ -445,7 +450,7 @@ For all bulk actions:
 
 ## Reference-data management specification
 
-Reference-data management should be launched from secondary modals on the Classes page.
+Reference-data management should be launched from secondary modals in the Settings-page **Classes** tab.
 
 ## Cohort management modal
 
@@ -487,6 +492,24 @@ As with cohorts, backend validation is authoritative.
 
 Update the cohort and year-group models and transport contracts so they expose stable keys.
 
+Key requirements:
+
+- generate UUID keys on create
+- keys are immutable on rename
+- all cohort and year-group records are keyed; no unkeyed records are supported in the v1 contract
+- CRUD request and response shapes should identify records by `key`, not mutable display names
+
+For cohorts, also add:
+
+- `startYear: number`
+- `startMonth: number`
+
+Defaulting rules for cohorts:
+
+- `startMonth` defaults to `9` (September)
+- `startYear` defaults to the current calendar year when the current month is September or later
+- `startYear` defaults to the previous calendar year when the current month is earlier than September
+
 ## 2. Update `ABClass` metadata to store keys
 
 Update the `ABClass` domain model and transport contracts to use:
@@ -495,6 +518,8 @@ Update the `ABClass` domain model and transport contracts to use:
 - `yearGroupKey`
 
 rather than mutable display names.
+
+This spec assumes a one-off destructive reset of existing data before rollout, so no compatibility or backfill layer is required in production code for the old name-based contract.
 
 ## 3. Strengthen `updateABClass` validation for `active`
 
@@ -514,6 +539,8 @@ Add backend validation so:
 
 - `deleteCohort` fails if any persisted `ABClass` uses that cohort key
 - `deleteYearGroup` fails if any persisted `ABClass` uses that year-group key
+
+The preferred implementation source for these in-use checks is the `abclass_partials` registry, because it already exists as the lightweight index of persisted class metadata.
 
 ## 5. Partial-response shaping
 
@@ -559,14 +586,17 @@ The implementation plan should be organised around the following broad workstrea
 ## 1. Contract design
 
 - confirm the final blank-slate transport contract for `cohortKey` and `yearGroupKey`
+- record explicitly that rollout depends on a one-off destructive reset of existing persisted data
 - ensure later sections can rely on the key-based contract without compatibility fallbacks
 - identify every backend and frontend consumer that must adopt the new key-based contract
+- record that parts of the assessment workflow currently depend on `ABClass.yearGroup` as a numeric academic-year field and will require follow-on refactor work outside this v1 delivery
 
 ## 2. Reference-data model and API updates
 
-- add stable keys to cohort and year-group records
-- update create, edit, list, and delete handlers to expose keys
+- add stable UUID keys to cohort and year-group records
+- update create, edit, list, and delete handlers to expose keys and use keyed CRUD payloads
 - preserve existing active-state behaviour for cohorts
+- add `startYear` and `startMonth` to cohorts, including the defaulting rules above
 - add delete guards for in-use cohort and year-group keys
 
 ## 3. `ABClass` domain and API updates
@@ -585,7 +615,7 @@ The implementation plan should be organised around the following broad workstrea
 ## 5. Frontend service and schema work
 
 - add or update Zod schemas for key-based cohort and year-group payloads
-- add the frontend `googleClassrooms` service wrapper
+- add the frontend `googleClassrooms` service wrapper for the existing backend API surface
 - update service contracts for any changed `ABClass`, cohort, or year-group payloads
 - keep all transport calls routed through `callApi(...)`
 
@@ -596,9 +626,9 @@ The implementation plan should be organised around the following broad workstrea
 - add invalidation and forced refresh behaviour for cohort and year-group mutations
 - update any canonical React Query documentation that changes as a result
 
-## 7. Classes-page feature implementation
+## 7. Settings-page Classes-tab feature implementation
 
-- replace the current placeholder `ClassesPage` with a real feature entry component
+- replace the current placeholder Classes-tab content in `SettingsPage` with a real feature entry component
 - build the merged row view model for active, inactive, not-created, and orphaned rows
 - implement default status sorting and row selection
 - render the main Ant Design table and status affordances
@@ -638,7 +668,7 @@ The implementation plan should be organised around the following broad workstrea
 
 ## Blocking load failure
 
-If the Classes page cannot load essential datasets, show a top-level `Alert`.
+If the Settings-page Classes tab cannot load any essential startup-prefetched dataset (`classPartials`, `cohorts`, or `yearGroups`), show a top-level `Alert` and fail fast/loudly rather than silently continuing with a partially warmed client state.
 
 ## Partial-load failure
 
@@ -652,7 +682,7 @@ If one dataset fails but others succeed:
 
 ### No active Google Classrooms
 
-Show `Empty` state for the table.
+Show `Empty` state for the table only when the Google Classroom fetch succeeds and returns zero active classes. A fetch failure must surface as an error state rather than being treated as an empty result.
 
 ### First run: no `ABClass` records yet
 
@@ -683,7 +713,7 @@ After successful mutations, refresh the relevant queries:
 
 Include in v1:
 
-- Classes-page ownership for this feature
+- Settings-page **Classes** tab ownership for this feature
 - a single CRUD-focused table
 - status column with default sort order
 - merged active, inactive, not-created, and orphaned rows
@@ -694,7 +724,7 @@ Include in v1:
 - `ABClass` storage of cohort and year-group keys
 - backend validation to prevent `active` updates creating missing classes
 - backend validation to prevent deleting in-use cohorts and year groups
-- Google Classrooms view-entry prefetch on Classes-page entry
+- Google Classrooms view-entry prefetch on Classes-tab entry
 
 Defer from v1:
 
@@ -704,3 +734,4 @@ Defer from v1:
 - class analysis features on this page
 - assessment-run controls on this page
 - broader assignment workflows
+- fetching all Google Classrooms, including archived classes, to refine orphaned-row labelling


### PR DESCRIPTION
### Motivation

- Re-home the Classes CRUD feature from a standalone top-level page into the **Classes** tab inside `SettingsPage` to align UI navigation and settings surface location.
- Introduce stable-key reference-data for cohorts and year-groups and add cohort contract fields so display-name mutations do not require bulk rewrites of `ABClass` records.
- Provide a prescriptive UI-layout and modal-state companion document to standardise component choices, modal hierarchies, and required test journeys for the Classes tab.

### Description

- Updated `ACTION_PLAN.md` to move the feature entry to the `SettingsPage` Classes tab, to require UUID `key` usage for cohorts/year-groups, and to add `startYear` and `startMonth` to the cohort contract including defaulting rules and a note that rollout assumes a one-off destructive reset of persisted data.
- Added a new `CLASSROOM_TAB_LAYOUT_AND_MODALS.md` file that defines the full Classes-tab component hierarchy, Ant Design component recommendations, modal flows, accessibility rules, required Vitest and Playwright coverage, and state matrices for the tab and all modals.
- Updated `SPEC.md` to reflect the Settings-page Classes-tab ownership, to record the keyed cohort/year-group shapes and cohort defaulting rules, to prefer `abclass_partials` for in-use checks, and to document the deferred assessment-workflow refactor required by the `yearGroup` contract change.
- Adjusted prefetch/warm-up and shared-query guidance so `cohorts` and `yearGroups` are warmed at startup with `classPartials`, while `googleClassrooms` becomes a view-entry prefetch for the Classes tab, and added fail-fast guidance for partially warmed startup failures.

### Testing

- This PR contains documentation and plan/spec changes only and did not modify runtime code or tests, so no automated unit/e2e tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be89cfbe008329a51c3562a947ecb0)