### PR TITLE
Docs: refine Classes CRUD plan and UI spec (bulk course-length, warm-up ownership, stable keys, test harness)

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -9,10 +9,12 @@
 - Use `CLASSES_TAB_LAYOUT_AND_MODALS.md` as the UI-layout and modal-state companion document for implementation details that sit below the product/data-contract level.
 - Update backend reference-data models, controllers, and API handlers so cohorts and year groups use stable keys.
 - Update `ABClass` transport and persistence contracts so class metadata stores `cohortKey` and `yearGroupKey` rather than mutable display names.
-- Add the required frontend services, Zod schemas, React Query definitions, view-model mapping, page UI, modal workflows, and automated test coverage.
-- Update shared prefetch behaviour so `cohorts` and `yearGroups` warm at startup alongside `classPartials`, while `googleClassrooms` remains a Classes-tab entry prefetch.
+- Add the required frontend services, Zod schemas, React Query definitions, view-model mapping, page UI, modal workflows, browser-test harness support, and automated test coverage.
+- Update shared prefetch behaviour so `cohorts` and `yearGroups` warm at startup alongside `classPartials` under the app-level auth/warm-up boundary, while `googleClassrooms` remains a Classes-tab entry prefetch.
 - Add backend validation to prevent `active` updates from creating missing classes and to block deletion of in-use cohort or year-group records.
 - Add `startYear` and `startMonth` to the cohort model so cohort-year calculations remain possible after moving to stable keys.
+- Add a bulk/single-row edit workflow for `courseLength` alongside the other class metadata actions.
+- Update class partial responses to return keys plus resolved cohort and year-group labels.
 - Update the plan and rollout notes to record that some assessment-workflow paths depend on the current numeric `ABClass.yearGroup` behaviour and will require follow-on refactor work outside this delivery.
 
 ### Out of scope
@@ -31,9 +33,14 @@
 3. Cohorts add `startYear` and `startMonth` as part of the v1 stable-key contract.
 4. `googleClassrooms` remains a narrow page-entry dataset returning active Classroom rows only; the backend API surface already exists and this delivery adds the missing frontend service/query integration.
 5. Frontend shared server-state continues to use React Query with shared query-key helpers and transport access routed through `callApi(...)` only.
-6. The current `apiHandler` envelope remains the transport contract; changed payload shapes should be introduced through existing allowlisted methods unless implementation proves a new method is required.
-7. All user-visible interactions introduced by this feature require Playwright coverage in addition to appropriate Vitest coverage.
-8. Some assessment-workflow paths currently depend on `ABClass.yearGroup` as a numeric academic-year field; that downstream refactor is out of scope for this delivery and must be recorded in follow-up documentation.
+6. The app-level auth/warm-up boundary owns startup readiness for `classPartials`, `cohorts`, and `yearGroups`.
+7. The current `apiHandler` envelope remains the transport contract; changed payload shapes should be introduced through existing allowlisted methods unless implementation proves a new method is required.
+8. Bulk actions are also the single-row edit path; selecting one row uses the same workflow and transport behaviour.
+9. Bulk requests dispatch one request per selected row in parallel, continue across the full selection, and report failures per row.
+10. Newly created classes default to `active=true`.
+11. Class partial responses return keys plus resolved cohort and year-group labels.
+12. All user-visible interactions introduced by this feature require Playwright coverage in addition to appropriate Vitest coverage.
+13. Some assessment-workflow paths currently depend on `ABClass.yearGroup` as a numeric academic-year field; that downstream refactor is out of scope for this delivery and must be recorded in follow-up documentation.
 
 ---
 
@@ -68,7 +75,7 @@ For each section below:
 - Backend tests: `npm test -- <target>`
 - Frontend unit tests: `npm run frontend:test -- <target>`
 - Frontend e2e tests: `npm run frontend:test:e2e -- <target>`
-- Frontend coverage: `npm run frontend:test:coverage`
+- Frontend coverage (run after Green for a completed slice or before sign-off, not as the default per-section check): `npm run frontend:test:coverage`
 - Frontend type-check: `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ---
@@ -161,7 +168,7 @@ Frontend tests:
 ### Acceptance criteria
 
 - `ABClass` serialisation and deserialisation use `cohortKey` and `yearGroupKey`.
-- `getABClassPartials` returns the updated shape without leaking storage metadata.
+- `getABClassPartials` returns the updated shape without leaking storage metadata and includes keys plus resolved cohort/year-group labels.
 - Backend API docs and data-shape docs are ready to reflect the changed class-partial contract.
 - Frontend service/schema code can parse the new partial shape.
 
@@ -170,7 +177,7 @@ Frontend tests:
 Backend model tests:
 
 1. `ABClass.toJSON()` emits `cohortKey` and `yearGroupKey`.
-2. `ABClass.toPartialJSON()` emits `cohortKey` and `yearGroupKey`.
+2. `ABClass.toPartialJSON()` emits `cohortKey`, `cohortName`, `yearGroupKey`, and `yearGroupName`.
 3. `ABClass.fromJSON()` reconstructs key-based metadata correctly.
 
 Backend controller tests:
@@ -184,8 +191,8 @@ API layer tests:
 
 Frontend tests:
 
-1. `classPartials` Zod schema accepts the new key-based partial shape.
-2. `classPartialsService` returns validated key-based partials.
+1. `classPartials` Zod schema accepts the new key-based partial shape with resolved labels.
+2. `classPartialsService` returns validated key-based partials with resolved labels.
 
 ### Section checks
 
@@ -221,7 +228,7 @@ Frontend tests:
 
 ### Acceptance criteria
 
-- `upsertABClass` accepts key-based metadata and rejects invalid keys.
+- `upsertABClass` accepts key-based metadata, rejects invalid keys, and defaults newly created classes to `active=true`.
 - `updateABClass` rejects `active` updates when the class does not already exist.
 - `deleteCohort` and `deleteYearGroup` fail when any stored `ABClass` still references the target key.
 - Failure cases map cleanly to transport errors without hidden fallback behaviour.
@@ -234,14 +241,14 @@ Backend model tests:
 
 Backend controller tests:
 
-1. `ABClassController.upsertABClass()` rejects unknown `cohortKey` or `yearGroupKey` values.
+1. `ABClassController.upsertABClass()` rejects unknown `cohortKey` or `yearGroupKey` values and defaults newly created classes to `active=true`.
 2. `ABClassController.updateABClass()` rejects `active` patches for missing classes.
 3. `ReferenceDataController.deleteCohort()` rejects deletion of an in-use cohort key.
 4. `ReferenceDataController.deleteYearGroup()` rejects deletion of an in-use year-group key.
 
 API layer tests:
 
-1. `upsertABClass` surfaces invalid key payloads as transport errors.
+1. `upsertABClass` surfaces invalid key payloads as transport errors and returns newly created rows as active by default.
 2. `updateABClass` surfaces invalid active-on-missing attempts as transport errors.
 3. `deleteCohort` and `deleteYearGroup` surface in-use deletion failures as transport errors.
 
@@ -268,28 +275,23 @@ Frontend tests:
 
 ---
 
-## Section 4 — Frontend service, schema, and shared-query groundwork
+## Section 4A — Frontend service and schema groundwork
 
 ### Objective
 
-- Add or update the frontend services, Zod schemas, React Query keys, and shared query definitions needed by the Classes CRUD feature.
+- Add or update the frontend service wrappers and Zod schemas needed by the Classes CRUD feature.
 
 ### Constraints
 
 - Keep all backend access inside service modules that use `callApi(...)`.
-- Define shared query keys through `queryKeys.ts` only.
 - Runtime validation must happen at the service boundary before data is cached.
-- Keep startup warm-up and invalidation logic aligned with the canonical React Query policy docs.
+- Limit this section to service/schema behaviour only; do not depend on app-level warm-up or page-shell UI state here.
 
 ### Acceptance criteria
 
 - A frontend `googleClassrooms` service and adjacent Zod schema exist.
-- Shared query helpers exist for `googleClassrooms`, `cohorts`, `yearGroups`, and `classPartials` as needed.
-- Startup warm-up can fetch `classPartials`, `cohorts`, and `yearGroups`.
-- Cohort and year-group mutations invalidate and refresh the relevant shared queries.
-- The warm-up client is considered warmed only when all three startup-prefetched datasets succeed.
-- Startup warm-up does not add extra retry loops beyond the existing `apiHandler` retry behaviour.
-- If any startup-prefetched dataset fails, the feature surfaces a fail-fast/loud top-level alert rather than silently continuing with a partially warmed state.
+- Updated frontend schemas and services support keyed cohorts, keyed year groups, and class partials with keys plus resolved labels.
+- Service contracts preserve the `callApi(...)` transport boundary.
 
 ### Required test cases (Red first)
 
@@ -309,21 +311,18 @@ Frontend tests:
 
 1. `googleClassrooms` Zod schema accepts valid rows and rejects malformed payloads.
 2. `googleClassroomsService` delegates to `callApi('getGoogleClassrooms')` and validates responses.
-3. Shared query helpers expose the correct query keys and query functions for `googleClassrooms`.
-4. Startup warm-up orchestration fetches `classPartials`, `cohorts`, and `yearGroups` after authorisation.
-5. Cohort and year-group mutation flows invalidate the correct shared queries.
-6. The warm-up marker is set only after all three startup-prefetched datasets resolve successfully.
-7. A failed startup-prefetch path surfaces the expected fail-fast/loud alert state without additional retry orchestration.
+3. Updated reference-data schemas accept keyed payloads and reject malformed key-bearing payloads.
+4. Updated class-partial schema accepts keys plus resolved labels and rejects malformed payloads.
 
 ### Section checks
 
-- `npm run frontend:test -- src/services/googleClassrooms*.spec.ts src/query/sharedQueries.query.spec.tsx src/features/auth/AppAuthGate*.spec.tsx`
+- `npm run frontend:test -- src/services/googleClassrooms.zod.spec.ts src/services/googleClassroomsService.spec.ts src/services/referenceData.zod.spec.ts src/services/classPartials.zod.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` where warm-up policy or invalidation choices differ from the previous baseline and would not be obvious from the final code.
+- Add `@remarks` where new service/schema behaviour would not be obvious from type names alone.
 
 ### Implementation notes / deviations / follow-up
 
@@ -333,25 +332,250 @@ Frontend tests:
 
 ---
 
-## Section 5 — Settings-page Classes-tab entry and merged view-model orchestration
+## Section 4B — Shared query keys and query-options groundwork
 
 ### Objective
 
-- Replace the placeholder Settings-page Classes-tab content with a real feature entry that loads the shared datasets and builds the merged row view model.
+- Add the shared query keys and query-option helpers needed by the Classes CRUD feature.
 
 ### Constraints
 
-- Keep `SettingsPage.tsx` thin and move orchestration into a feature hook or view-model helper.
-- The merged row model must represent `active`, `inactive`, `notCreated`, and `orphaned` rows.
-- Sorting defaults must follow the agreed order.
-- This section must remain CRUD-only; do not add analysis or assessment-run behaviour.
+- Define shared query keys through `queryKeys.ts` only.
+- Keep this section limited to query-key and query-option wiring.
+- Do not implement startup readiness ownership or UI failure states in this section.
+
+### Acceptance criteria
+
+- Shared query helpers exist for `googleClassrooms`, `cohorts`, `yearGroups`, and `classPartials` as needed.
+- Query helpers delegate to the validated service-layer functions introduced earlier.
+- The canonical React Query documentation is updated if the shared-query baseline changes in this section.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+1. Shared query helpers expose the correct query keys and query functions for `googleClassrooms`.
+2. Shared query helpers expose the correct query keys and query functions for `classPartials`, `cohorts`, and `yearGroups`.
+3. Shared query helper tests remain focused on query wiring rather than page-level readiness state.
+
+### Section checks
+
+- `npm run frontend:test -- src/query/queryKeys.spec.ts src/query/sharedQueries.query.spec.tsx`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` only if query-key naming or view-entry prefetch choices would otherwise be surprising.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 4C — App-level startup warm-up ownership and readiness contract
+
+### Objective
+
+- Implement the app-level warm-up ownership model for `classPartials`, `cohorts`, and `yearGroups` after authorisation.
+
+### Constraints
+
+- The app-level auth/warm-up boundary owns startup readiness.
+- Startup warm-up fetches `classPartials`, `cohorts`, and `yearGroups` after authorisation.
+- The warm-up client is considered ready only when all three startup-prefetched datasets succeed.
+- Keep this section limited to readiness ownership and query orchestration; do not require the full Classes-tab UI shell yet.
+- Startup warm-up does not add extra retry loops beyond the existing `apiHandler` retry behaviour.
+
+### Acceptance criteria
+
+- App-level warm-up orchestration fetches `classPartials`, `cohorts`, and `yearGroups` after authorisation.
+- The warm-up marker is set only after all three startup-prefetched datasets resolve successfully.
+- Startup readiness state is exposed in a way later Classes-tab sections can consume without duplicating warm-up logic.
+- A failed startup-prefetch path remains a warm-up failure state owned by the app-level boundary, ready for later UI sections to render as blocking.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+1. Startup warm-up orchestration fetches `classPartials`, `cohorts`, and `yearGroups` after authorisation.
+2. The warm-up marker is set only after all three startup-prefetched datasets resolve successfully.
+3. A failed startup-prefetch path leaves startup readiness unresolved and does not silently mark the app as warmed.
+4. Existing auth-state behaviour remains intact for unauthorised and transport-failure cases.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/auth/AppAuthGate.auth.spec.tsx src/query/sharedQueries.query.spec.tsx`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where startup readiness ownership or warm-up gating semantics differ from the previous baseline.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 4D — Shared-query invalidation and post-mutation refetch contract
+
+### Objective
+
+- Define and implement the shared-query invalidation contract for reference-data mutations and the default re-fetch-failure behaviour.
+
+### Constraints
+
+- Cohort and year-group mutations invalidate and refresh the relevant shared queries.
+- The default assumption is that stale table data should not remain visible if a required re-fetch fails.
+- If a mutation succeeds but the follow-up re-fetch fails, the UI contract must preserve the success result while also warning that the page must be refreshed to see the latest data.
+- Keep this section focused on contract and query behaviour; full page-level alert rendering lands later.
+
+### Acceptance criteria
+
+- Cohort and year-group mutation flows invalidate the correct shared queries.
+- The post-success re-fetch contract is documented and encoded so later UI sections can show: successful update, failed refresh, and refresh-the-page guidance.
+- Shared-query helpers expose the invalidation behaviour needed by later modal and table sections.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None unless the invalidation work uncovers a transport mismatch.
+
+Frontend tests:
+
+1. Cohort mutation flows invalidate the `cohorts` query.
+2. Year-group mutation flows invalidate the `yearGroups` query.
+3. The post-success re-fetch-failure contract is represented in the feature or helper state without silently treating stale data as valid current data.
+
+### Section checks
+
+- `npm run frontend:test -- src/query/sharedQueries.query.spec.tsx src/features/classes/queryInvalidation.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where re-fetch-failure handling or invalidation choices would otherwise be hard to infer.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 4E — Browser-test harness and transport-scenario fixtures
+
+### Objective
+
+- Establish the mocked browser-test fixtures needed to cover the visible Classes CRUD journeys deterministically.
+
+### Constraints
+
+- Follow the canonical frontend testing split: invisible behaviour in Vitest, visible behaviour in Playwright.
+- Use the shared `google.script.run.apiHandler` mock rule documented in the frontend testing guidance.
+- Keep this section focused on harness and scenario setup only.
+
+### Acceptance criteria
+
+- A shared Playwright scenario harness exists for the Classes CRUD feature.
+- Shared fixtures cover at least: ready state, startup warm-up failure, Google Classroom entry failure, no-active-classrooms empty state, and a representative partial-success batch outcome.
+- The harness allows later Playwright sections to focus on user-visible behaviour instead of duplicating transport mocking logic.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+1. Harness-level tests or smoke journeys prove the Playwright fixture layer can drive the major visible state groups deterministically.
+2. The mocked transport setup follows the shared frontend testing helper rules.
+
+### Section checks
+
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud.harness.spec.ts`
+- `npm run frontend:lint`
+
+### Optional `@remarks` JSDoc follow-through
+
+- None.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 5A — Settings-page Classes-tab feature shell
+
+### Objective
+
+- Replace the placeholder Settings-page Classes-tab content with a real feature shell that consumes app-level readiness and page-entry query state.
+
+### Constraints
+
+- Keep `SettingsPage.tsx` thin and move orchestration into a feature hook or feature entry component.
+- This section should not yet depend on the full merged table or modal workflows.
+- The shell must be able to consume the app-owned startup readiness state introduced earlier.
 
 ### Acceptance criteria
 
 - The Settings-page Classes tab renders a real feature entry component.
-- The merged row view model correctly combines Google Classroom rows, stored `ABClass` partials, and reference-data lookups.
-- Default sort order is active, inactive, not created, then orphaned.
-- The page exposes the required loading and partial-load state needed for later UI sections.
+- The feature shell consumes app-level startup readiness and page-entry Google Classroom query state.
+- The shell exposes only the minimal states needed for later table and alert sections.
 
 ### Required test cases (Red first)
 
@@ -370,20 +594,74 @@ API layer tests:
 Frontend tests:
 
 1. `SettingsPage` renders the Classes-tab management feature entry.
-2. The merged view-model helper derives the correct status for active, inactive, not-created, and orphaned rows.
-3. The merged view-model helper resolves cohort and year-group names from keys.
-4. The default sort order is applied correctly.
-5. The feature hook exposes the expected loading, error, and data states.
+2. The feature shell consumes the app-level warm-up state correctly.
+3. The feature shell exposes the expected ready/loading/failure state contract for later sections.
 
 ### Section checks
 
-- `npm run frontend:test -- src/pages/SettingsPage.spec.tsx src/features/classes/*.spec.ts src/features/classes/**/*.spec.tsx`
+- `npm run frontend:test -- src/pages/SettingsPage.spec.tsx src/features/classes/ClassesManagementPanel.spec.tsx src/features/classes/useClassesManagementShell.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` to the merged view-model helper or hook if status resolution, sorting precedence, or orphaned-row semantics are non-obvious.
+- Add `@remarks` if the shell exists mainly to preserve the Settings-page composition boundary and that would not be obvious from the final code.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 5B — Merged row view-model derivation and default sorting
+
+### Objective
+
+- Build the merged row view model that combines Google Classroom rows, class partials, and resolved reference-data labels.
+
+### Constraints
+
+- Keep row derivation and sorting in pure helpers where possible.
+- Class partials return keys plus resolved labels; the frontend should not need a second name-join just to render the baseline table.
+- Sorting defaults must follow the agreed order.
+
+### Acceptance criteria
+
+- The merged row view model correctly combines Google Classroom rows, stored `ABClass` partials, and resolved label data.
+- Default sort order is active, inactive, not created, then orphaned.
+- The view-model helper can be tested independently of the rendered page shell.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+1. The merged view-model helper derives the correct status for active, inactive, not-created, and orphaned rows.
+2. The merged view-model helper preserves keys and resolved labels for cohorts and year groups.
+3. The default sort order is applied correctly.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/classesManagementViewModel.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` to the view-model helper if status resolution or sort precedence is non-obvious.
 
 ### Implementation notes / deviations / follow-up
 
@@ -404,6 +682,8 @@ Frontend tests:
 - Use Ant Design table facilities such as `rowSelection` rather than bespoke checkbox wiring.
 - Keep cells declarative and move data shaping into view-model code.
 - Orphaned rows must be clearly identifiable and deletion-only.
+- Bulk actions are also the single-row edit path; there is no separate row-edit affordance in v1.
+- Selection should follow the common predictable path: after partial failure, only failed rows remain selected if still present; after delete or tab re-entry, selection resets to the currently visible eligible state.
 - Any user-visible interaction introduced here must receive Playwright coverage.
 
 ### Acceptance criteria
@@ -412,6 +692,7 @@ Frontend tests:
 - Not-created rows display unavailable fields as `—`.
 - Orphaned rows display a warning affordance with explanatory tooltip.
 - Row selection works correctly across eligible and ineligible states.
+- Selection reset and retention behaviour follows the documented defaults.
 
 ### Required test cases (Red first)
 
@@ -432,9 +713,9 @@ Frontend tests:
 Vitest:
 
 1. Table renders the required columns and row content for active, inactive, `notCreated`, and orphaned rows.
-2. Table loading state renders with shell structure intact during initial Google Classroom entry fetch.
-3. Selection state updates correctly when rows are toggled from no selection to mixed and fully eligible selections.
-4. Ineligible rows or actions surface the correct disabled states or tooltips, including deletion-only orphaned rows.
+2. Selection state updates correctly when rows are toggled from no selection to mixed and fully eligible selections.
+3. Ineligible rows or actions surface the correct disabled states or tooltips, including deletion-only orphaned rows.
+4. Selection reset and failed-row-retention rules behave as documented.
 5. Summary-card counts and selection-summary text update correctly for mixed row-state datasets.
 
 Playwright:
@@ -443,18 +724,17 @@ Playwright:
 2. User sees the no-selection state with the bulk-action trigger disabled and the selection summary reset.
 3. User selects eligible and ineligible rows and sees the correct enabled, disabled, and tooltip-backed bulk affordances.
 4. User sees the first-run `notCreated` rendering and the orphaned warning affordance in the live table.
-5. User sees the no-active-classrooms empty state without losing the management launchers.
 
 ### Section checks
 
-- `npm run frontend:test -- src/features/classes/**/*.spec.tsx`
-- `npm run frontend:test:e2e -- e2e-tests/classes-crud.spec.ts`
+- `npm run frontend:test -- src/features/classes/ClassesTable.spec.tsx src/features/classes/ClassesToolbar.spec.tsx src/features/classes/selectionState.spec.ts`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-table.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` to any table column factory or selection helper where status-specific affordances or disabled-state rules may be non-obvious.
+- Add `@remarks` to any table column factory or selection helper where status-specific affordances or selection-reset rules may be non-obvious.
 
 ### Implementation notes / deviations / follow-up
 
@@ -472,14 +752,22 @@ Playwright:
 
 ### Constraints
 
+- Bulk actions are also the single-row edit path.
+- Bulk requests dispatch one request per selected row in parallel.
+- Execution continues for every selected row and reports failures per row rather than stopping on first error.
+- Summary ordering should follow the row order captured at submit time so user feedback remains predictable.
+- If the user closes a modal while requests are already in flight, those requests continue; there is no cancellation mechanism in this delivery.
 - Bulk actions must keep failed rows selected after partial failure.
 - Create uses `cohortKey`, `yearGroupKey`, and `courseLength` with default `1`.
+- Newly created classes default to `active=true`.
 - Delete copy must make clear that both full and partial `ABClass` records are removed.
 - Active-state updates must never create missing classes.
+- Partial-failure modals remain open briefly with inline feedback, then close and hand off the persistent result to the top-level alert stack.
 
 ### Acceptance criteria
 
 - Bulk create works for `notCreated` rows only.
+- Bulk create sets `active=true` by default for newly created classes.
 - Bulk delete works for active, inactive, and orphaned rows.
 - Bulk set active or inactive works only for eligible existing rows.
 - Partial-success summaries are shown and failed rows remain selected.
@@ -502,31 +790,32 @@ Frontend tests:
 
 Vitest:
 
-1. Bulk create modal covers opening, ready, validation-error, submitting, partial-success, and success-close states.
-2. Bulk create validates required cohort and year-group inputs, applies the default `courseLength` of `1`, and dispatches one mutation per selected row.
+1. Bulk create modal covers opening, ready, validation-error, submitting, partial-success-briefly-open, and success-close states.
+2. Bulk create validates required cohort and year-group inputs, applies the default `courseLength` of `1`, dispatches one mutation per selected row in parallel, and marks created classes active by default.
 3. Bulk delete confirmation copy states that both full and partial stored class records are removed.
-4. Bulk delete workflow covers ready, submitting, partial-success, and submission-failure summary mapping.
+4. Bulk delete workflow covers ready, submitting, partial-success-briefly-open, and submission-failure summary mapping.
 5. Bulk active-state action blocks ineligible selections before open and maps submitting and partial-success outcomes correctly.
 6. Partial failures keep failed rows selected and drive the top-level mutation summary state expected by the tab.
+7. Closing the modal while requests are already in flight does not cancel the outstanding requests.
 
 Playwright:
 
-1. User selects `notCreated` rows, opens Bulk create, sees active-cohort-only options, validates required fields, and completes a successful create flow.
-2. User triggers a bulk-create partial failure and sees failed rows remain selected with warning feedback after close.
+1. User selects `notCreated` rows, opens Bulk create, sees active-cohort-only options, validates required fields, and completes a successful create flow with active rows after refresh.
+2. User triggers a bulk-create partial failure and sees inline warning feedback briefly before the modal closes and the tab-level summary persists.
 3. User opens Bulk delete, sees the destructive copy, confirms, and receives success or partial-failure summary feedback.
 4. User attempts an ineligible bulk active/inactive action and sees the blocked-before-open explanation.
 5. User completes an eligible bulk active or inactive confirmation flow and sees the tab-level summary update after the modal closes.
 
 ### Section checks
 
-- `npm run frontend:test -- src/features/classes/**/*.spec.tsx src/features/classes/**/*.spec.ts`
-- `npm run frontend:test:e2e -- e2e-tests/classes-crud.spec.ts -g "bulk"`
+- `npm run frontend:test -- src/features/classes/bulkCreate.spec.tsx src/features/classes/bulkDelete.spec.tsx src/features/classes/bulkActiveState.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-bulk-core.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` where batch-processing semantics, failed-row retention, or modal-state handling could confuse future maintainers.
+- Add `@remarks` where batch-processing semantics, parallel dispatch, failed-row retention, or modal-close timing could confuse future maintainers.
 
 ### Implementation notes / deviations / follow-up
 
@@ -536,25 +825,24 @@ Playwright:
 
 ---
 
-## Section 8 — Bulk cohort/year-group updates and reference-data management modals
+## Section 8 — Bulk set cohort workflow
 
 ### Objective
 
-- Implement the remaining class-metadata bulk actions plus the secondary modals for cohort and year-group CRUD.
+- Implement the bulk cohort update workflow for active and inactive classes.
 
 ### Constraints
 
+- Bulk actions are also the single-row edit path.
 - Cohort selectors must only offer active cohorts for assignment.
-- Reference-data delete actions must surface blocked states clearly when values are in use.
-- Reference-data modals must invalidate and refresh shared queries on successful mutation.
-- Visible modal interactions require Playwright coverage.
+- Requests dispatch one per selected row in parallel and continue across the full selection.
+- Partial-failure modals remain open briefly with inline feedback before closing.
 
 ### Acceptance criteria
 
-- Bulk set cohort and bulk set year group work for eligible active/inactive rows.
-- Cohort management modal supports create, edit, delete, and active-state changes.
-- Year-group management modal supports create, edit, and delete.
-- In-use delete attempts are surfaced clearly to the user.
+- Bulk set cohort works for eligible active/inactive rows.
+- Cohort selection offers only active cohorts.
+- Partial failures keep failed rows selected and the tab-level summary reflects the final outcome after close.
 
 ### Required test cases (Red first)
 
@@ -564,7 +852,195 @@ Backend model tests:
 
 Backend controller tests:
 
-1. None beyond any additional cases revealed by new modal-driven reference-data flows.
+1. None beyond any additional cases revealed by the workflow.
+
+API layer tests:
+
+1. Extend mutation transport tests only if a payload-shape or error-mapping mismatch is discovered.
+
+Frontend tests:
+
+Vitest:
+
+1. Bulk cohort modal covers ready, validation-error, submitting, and partial-success-briefly-open states and offers only active cohorts.
+2. Bulk cohort workflow dispatches one request per selected row in parallel and preserves failed-row selection.
+
+Playwright:
+
+1. User opens Bulk set cohort, sees active cohorts only, submits a valid change, and receives summary feedback.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/bulkSetCohort.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-bulk-cohort.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where active-only cohort selection or partial-failure timing would not be obvious.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 9 — Bulk set year-group workflow
+
+### Objective
+
+- Implement the bulk year-group update workflow for active and inactive classes.
+
+### Constraints
+
+- Bulk actions are also the single-row edit path.
+- Requests dispatch one per selected row in parallel and continue across the full selection.
+- Partial-failure modals remain open briefly with inline feedback before closing.
+
+### Acceptance criteria
+
+- Bulk set year group works for eligible active/inactive rows.
+- Partial failures keep failed rows selected and the tab-level summary reflects the final outcome after close.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None beyond any additional cases revealed by the workflow.
+
+API layer tests:
+
+1. Extend mutation transport tests only if a payload-shape or error-mapping mismatch is discovered.
+
+Frontend tests:
+
+Vitest:
+
+1. Bulk year-group modal covers ready, validation-error, submitting, and partial-success-briefly-open states with key-based options and payloads.
+2. Bulk year-group workflow dispatches one request per selected row in parallel and preserves failed-row selection.
+
+Playwright:
+
+1. User opens Bulk set year group, submits a valid change, and sees the updated value reflected after refresh.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/bulkSetYearGroup.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-bulk-year-group.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where year-group option handling or partial-failure timing would not be obvious.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 10 — Bulk set course-length workflow
+
+### Objective
+
+- Implement the course-length edit workflow for existing classes using the same bulk modal pattern as the other class metadata updates.
+
+### Constraints
+
+- Bulk actions are also the single-row edit path.
+- Requests dispatch one per selected row in parallel and continue across the full selection.
+- `courseLength` must validate as an integer greater than or equal to `1`.
+- Partial-failure modals remain open briefly with inline feedback before closing.
+
+### Acceptance criteria
+
+- Existing active/inactive classes can update `courseLength` through a dedicated bulk modal.
+- The same workflow supports single-row edits by selecting one row.
+- Partial failures keep failed rows selected and the tab-level summary reflects the final outcome after close.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None beyond any additional cases revealed by the workflow.
+
+API layer tests:
+
+1. Extend mutation transport tests only if a payload-shape or error-mapping mismatch is discovered.
+
+Frontend tests:
+
+Vitest:
+
+1. Bulk course-length modal covers ready, validation-error, submitting, and partial-success-briefly-open states.
+2. Bulk course-length workflow validates integer input, dispatches one request per selected row in parallel, and preserves failed-row selection.
+
+Playwright:
+
+1. User selects one or more existing classes, opens Bulk set course length, submits a valid value, and sees the updated value reflected after refresh.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/bulkSetCourseLength.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-bulk-course-length.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where course-length validation or bulk-single-row dual use would not be obvious.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 11 — Cohort management modal
+
+### Objective
+
+- Implement the cohort management modal flows for create, edit, active-state change, and delete.
+
+### Constraints
+
+- Reference-data delete actions open a confirmation modal.
+- Blocked delete state shows a disabled delete button plus explanatory warning state inside the confirmation modal.
+- A blocked delete response keeps the modal open with inline feedback until the user closes it.
+- Successful mutations invalidate and refresh the `cohorts` query.
+- Visible modal interactions require Playwright coverage.
+
+### Acceptance criteria
+
+- Cohort management modal supports create, edit, delete, and active-state changes.
+- In-use cohort delete attempts are surfaced clearly in the confirmation modal.
+- Successful mutations refresh cohort data for active consumers.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None beyond any additional cases revealed by the modal-driven flows.
 
 API layer tests:
 
@@ -574,34 +1050,25 @@ Frontend tests:
 
 Vitest:
 
-1. Bulk cohort modal covers ready, validation-error, submitting, and partial-success states and offers only active cohorts.
-2. Bulk year-group modal covers ready, validation-error, submitting, and partial-success states with key-based options and payloads.
-3. Manage cohorts modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
-4. Create/Edit cohort modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
-5. Delete cohort confirmation covers ready, blocked, submitting, success-close, and submission-failure states, including in-use delete messaging.
-6. Manage year groups modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
-7. Create/Edit year group modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
-8. Delete year group confirmation covers ready, blocked, submitting, success-close, and submission-failure states.
+1. Manage cohorts modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
+2. Create/Edit cohort modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
+3. Delete cohort confirmation covers ready, blocked-with-disabled-delete, blocked-inline-feedback, submitting, success-close, and submission-failure states.
 
 Playwright:
 
-1. User opens Bulk set cohort, sees active cohorts only, submits a valid change, and receives summary feedback.
-2. User opens Bulk set year group, submits a valid change, and sees the updated year-group value reflected in the table.
-3. User opens Manage cohorts, exercises empty or ready states as applicable, then completes create, edit, active-state change, and delete flows.
-4. User attempts to delete an in-use cohort and sees the blocked state clearly before the modal closes.
-5. User opens Manage year groups and completes create, edit, and delete flows.
-6. User attempts to delete an in-use year group and sees the blocked state clearly before the modal closes.
+1. User opens Manage cohorts, exercises empty or ready states as applicable, then completes create, edit, active-state change, and delete flows.
+2. User attempts to delete an in-use cohort and sees the blocked confirmation modal remain open with explanatory warning state.
 
 ### Section checks
 
-- `npm run frontend:test -- src/features/classes/**/*.spec.tsx src/features/classes/**/*.spec.ts`
-- `npm run frontend:test:e2e -- e2e-tests/classes-crud.spec.ts -g "cohort|year group"`
+- `npm run frontend:test -- src/features/classes/manageCohorts.spec.tsx src/features/classes/manageCohortDelete.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-manage-cohorts.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` where reference-data invalidation, active-only cohort selection, or delete-blocked handling would not be obvious from the final code.
+- Add `@remarks` where active-state toggling, invalidation, or blocked-delete handling would not be obvious from the final code.
 
 ### Implementation notes / deviations / follow-up
 
@@ -611,24 +1078,92 @@ Playwright:
 
 ---
 
-## Section 9 — Error states, polish, and page-level integration completeness
+## Section 12 — Year-group management modal
 
 ### Objective
 
-- Finish the page-level UX by adding blocking and partial-load alerts, empty states, mutation summary persistence, and any remaining integration glue.
+- Implement the year-group management modal flows for create, edit, and delete.
+
+### Constraints
+
+- Reference-data delete actions open a confirmation modal.
+- Blocked delete state shows a disabled delete button plus explanatory warning state inside the confirmation modal.
+- A blocked delete response keeps the modal open with inline feedback until the user closes it.
+- Successful mutations invalidate and refresh the `yearGroups` query.
+- Visible modal interactions require Playwright coverage.
+
+### Acceptance criteria
+
+- Year-group management modal supports create, edit, and delete.
+- In-use year-group delete attempts are surfaced clearly in the confirmation modal.
+- Successful mutations refresh year-group data for active consumers.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None beyond any additional cases revealed by the modal-driven flows.
+
+API layer tests:
+
+1. Extend reference-data transport tests only if new payload-shape or error-mapping behaviour is introduced.
+
+Frontend tests:
+
+Vitest:
+
+1. Manage year groups modal covers opening/list-loading, empty, ready, mutation-in-progress, and list-reload-warning states.
+2. Create/Edit year group modal covers opening, ready, validation-error, submitting, success-close, and submission-failure states.
+3. Delete year group confirmation covers ready, blocked-with-disabled-delete, blocked-inline-feedback, submitting, success-close, and submission-failure states.
+
+Playwright:
+
+1. User opens Manage year groups and completes create, edit, and delete flows.
+2. User attempts to delete an in-use year group and sees the blocked confirmation modal remain open with explanatory warning state.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/manageYearGroups.spec.tsx src/features/classes/manageYearGroupDelete.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-manage-year-groups.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` where invalidation or blocked-delete handling would not be obvious from the final code.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 13 — Error states, loading states, and empty-state integration
+
+### Objective
+
+- Finish the page-level UX for blocking failures, loading states, and empty states.
 
 ### Constraints
 
 - Use top-level Ant Design `Alert` for blocking failures by default.
-- Keep stale data visible where the shared-query policy calls for background refresh rather than hard replacement.
-- Do not widen scope into non-CRUD page functionality.
+- Startup warm-up failure is owned by the app-level boundary and rendered here as blocking.
+- Google Classroom entry failure is blocking.
+- The default assumption is that stale table data should not remain visible when a required refresh fails.
+- Keep this section focused on load/error/empty-state rendering rather than mutation-summary persistence rules.
 
 ### Acceptance criteria
 
-- Blocking load failures render a top-level `Alert`.
-- Partial-load failures keep usable data visible with a warning `Alert`.
+- Blocking startup-prefetch failure renders a top-level `Alert` with normal interaction disabled.
+- Blocking Google Classroom entry failure renders a top-level `Alert` rather than an empty state.
 - Empty states are correct for no active Google Classrooms and first-run no-`ABClass` cases.
-- Mutation summaries persist clearly enough for users to understand partial success.
+- Summary and toolbar shells render the correct blocked, loading, and ready states.
 
 ### Required test cases (Red first)
 
@@ -648,30 +1183,92 @@ Frontend tests:
 
 Vitest:
 
-1. Alert stack renders no-alert, blocking startup-prefetch failure, blocking Google Classroom entry failure, partial-load warning, and mutation-summary states in severity order.
+1. Alert stack renders no-alert, blocking startup-prefetch failure, blocking Google Classroom entry failure, and partial-load warning states in severity order.
 2. Summary card covers initial loading, ready-with-data, ready-with-zero-values, and blocked suppression behaviour.
 3. Toolbar card covers no-selection, mixed eligible/ineligible selection, mutation-in-progress, and ready states.
-4. Table empty-state and failure-state rendering matches the agreed no-active-classrooms, first-run, partial-load, and blocking-failure rules.
-5. Mutation summary alerts render the correct counts, severity, persistence behaviour, and replacement rules.
+4. Table empty-state and blocking-failure rendering matches the agreed no-active-classrooms and first-run rules.
 
 Playwright:
 
 1. User encounters a startup-prefetch failure and sees the blocking top-level alert with normal interaction disabled.
 2. User encounters a Google Classroom entry failure and sees the blocking error rather than an empty state.
-3. User encounters a partial-load warning and still sees usable summary, toolbar, and table content.
-4. User encounters the no-active-classrooms empty state and still has access to cohort and year-group management launchers.
-5. User completes a mutation that yields success or partial-failure feedback and sees the alert-stack summary persist clearly after modal close.
+3. User encounters the no-active-classrooms empty state and still has access to cohort and year-group management launchers.
 
 ### Section checks
 
-- `npm run frontend:test -- src/features/classes/**/*.spec.tsx`
-- `npm run frontend:test:e2e -- e2e-tests/classes-crud.spec.ts -g "error|empty|summary"`
+- `npm run frontend:test -- src/features/classes/ClassesAlertStack.spec.tsx src/features/classes/ClassesSummaryCard.spec.tsx src/features/classes/ClassesEmptyStates.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-load-states.spec.ts`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`
 
 ### Optional `@remarks` JSDoc follow-through
 
-- Add `@remarks` if the final hook or page code contains non-obvious load-state or summary-state behaviour.
+- Add `@remarks` if the final hook or page code contains non-obvious load-state behaviour.
+
+### Implementation notes / deviations / follow-up
+
+- **Implementation notes:** describe actual changes made when done.
+- **Deviations from plan:** note any departures from the original section design.
+- **Follow-up implications for later sections:** record effects for downstream work.
+
+---
+
+## Section 14 — Mutation-summary persistence and re-fetch-failure integration
+
+### Objective
+
+- Finish the page-level mutation summary UX, including the default re-fetch-failure behaviour after successful mutations.
+
+### Constraints
+
+- Mutation summaries must persist clearly enough for users to understand partial success.
+- If a mutation succeeds but the follow-up re-fetch fails, the alert must report that the update succeeded but the refresh failed and that the user must refresh the page to see changes.
+- The default assumption is that stale table data should not remain visible after that failed refresh.
+- Partial-failure bulk modals remain open briefly with inline feedback before closing and handing off to the top-level alert stack.
+
+### Acceptance criteria
+
+- Mutation summaries persist clearly enough for users to understand success and partial success.
+- Post-success re-fetch failures render the combined message: successful update, failed refresh, refresh-the-page guidance.
+- The page does not leave stale table data visible after a required refresh fails.
+
+### Required test cases (Red first)
+
+Backend model tests:
+
+1. None.
+
+Backend controller tests:
+
+1. None.
+
+API layer tests:
+
+1. None.
+
+Frontend tests:
+
+Vitest:
+
+1. Mutation summary alerts render the correct counts, severity, persistence behaviour, and replacement rules.
+2. Post-success re-fetch-failure state renders success-plus-warning guidance and suppresses stale table data.
+3. Partial-failure modal-close timing hands off inline feedback to the top-level alert stack correctly.
+
+Playwright:
+
+1. User completes a mutation that yields success or partial-failure feedback and sees the alert-stack summary persist clearly after modal close.
+2. User completes a mutation whose data refresh fails and sees an alert explaining that the update succeeded but the page must be refreshed to see changes.
+
+### Section checks
+
+- `npm run frontend:test -- src/features/classes/mutationSummary.spec.tsx src/features/classes/refetchFailureState.spec.tsx`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-mutation-summary.spec.ts`
+- `npm run frontend:lint`
+- `npm exec tsc -- -b src/frontend/tsconfig.json`
+
+### Optional `@remarks` JSDoc follow-through
+
+- Add `@remarks` if the final hook or page code contains non-obvious summary or re-fetch-failure behaviour.
 
 ### Implementation notes / deviations / follow-up
 
@@ -707,14 +1304,14 @@ Playwright:
 2. Run touched frontend service/UI suites.
 3. Run backend and frontend lint commands.
 4. Run required Playwright tests for Classes CRUD interactions.
-5. Run frontend coverage if the touched suites need a confidence pass against the coverage gate.
+5. Run frontend coverage after Green for a completed slice or before sign-off so the touched suites can confirm branch coverage once the feature path is working.
 6. Run frontend type-check.
 
 ### Section checks
 
 - `npm test -- tests/models/<model-test-path> tests/controllers/<controller-test-path> tests/api/<api-test-path>`
 - `npm run frontend:test -- src/features/classes/<feature-test-path> src/services/<service-test-path> src/query/<query-test-path>`
-- `npm run frontend:test:e2e -- e2e-tests/classes-crud.spec.ts`
+- `npm run frontend:test:e2e -- e2e-tests/classes-crud-table.spec.ts e2e-tests/classes-crud-bulk-core.spec.ts e2e-tests/classes-crud-bulk-cohort.spec.ts e2e-tests/classes-crud-bulk-year-group.spec.ts e2e-tests/classes-crud-bulk-course-length.spec.ts e2e-tests/classes-crud-manage-cohorts.spec.ts e2e-tests/classes-crud-manage-year-groups.spec.ts e2e-tests/classes-crud-load-states.spec.ts e2e-tests/classes-crud-mutation-summary.spec.ts`
 - `npm run lint`
 - `npm run frontend:lint`
 - `npm run frontend:test:coverage`
@@ -772,11 +1369,21 @@ Playwright:
 1. Section 1 — Reference-data key contract groundwork
 2. Section 2 — `ABClass` contract update and partial-shape refresh
 3. Section 3 — `ABClass` mutation validation hardening
-4. Section 4 — Frontend service, schema, and shared-query groundwork
-5. Section 5 — Settings-page Classes-tab entry and merged view-model orchestration
-6. Section 6 — Main table rendering, selection, and status affordances
-7. Section 7 — Bulk create, delete, and active-state workflows
-8. Section 8 — Bulk cohort/year-group updates and reference-data management modals
-9. Section 9 — Error states, polish, and page-level integration completeness
-10. Regression and contract hardening
-11. Documentation and rollout notes
+4. Section 4A — Frontend service and schema groundwork
+5. Section 4B — Shared query keys and query-options groundwork
+6. Section 4C — App-level startup warm-up ownership and readiness contract
+7. Section 4D — Shared-query invalidation and post-mutation refetch contract
+8. Section 4E — Browser-test harness and transport-scenario fixtures
+9. Section 5A — Settings-page Classes-tab feature shell
+10. Section 5B — Merged row view-model derivation and default sorting
+11. Section 6 — Main table rendering, selection, and status affordances
+12. Section 7 — Bulk create, delete, and active-state workflows
+13. Section 8 — Bulk set cohort workflow
+14. Section 9 — Bulk set year-group workflow
+15. Section 10 — Bulk set course-length workflow
+16. Section 11 — Cohort management modal
+17. Section 12 — Year-group management modal
+18. Section 13 — Error states, loading states, and empty-state integration
+19. Section 14 — Mutation-summary persistence and re-fetch-failure integration
+20. Regression and contract hardening
+21. Documentation and rollout notes

--- a/CLASSES_TAB_LAYOUT_AND_MODALS.md
+++ b/CLASSES_TAB_LAYOUT_AND_MODALS.md
@@ -32,7 +32,7 @@ This document does **not** redefine backend contracts, data shapes, or rollout a
 1. Keep `SettingsPage.tsx` as a composition layer only.
 2. Keep the Classes feature inside the existing **Classes** tab; do not add a new top-level route for this work.
 3. Use one visible CRUD table rather than nested inner tabs.
-4. Use modal-driven workflows for create, bulk-edit, and reference-data management.
+4. Use modal-driven workflows for create, bulk-edit, and reference-data management; the same bulk modals are also the single-row edit path in v1.
 5. Use top-level `Alert` components for blocking and partial-load failures.
 6. Prefer built-in Ant Design behaviours before creating bespoke interaction patterns.
 7. Keep the tab readable in reduced-motion mode and avoid decorative motion that obscures status changes.
@@ -232,6 +232,7 @@ Menu items:
 - Set selected classes inactive
 - Set cohort
 - Set year group
+- Set course length
 
 ### States
 
@@ -245,6 +246,8 @@ Menu items:
    - disable bulk trigger and modal launchers
 4. **Ready state**
    - all launchers available subject to row-selection rules
+5. **Selection reset**
+   - after delete or tab re-entry, reset selection rather than trying to preserve invisible rows
 
 ## 4. Table card
 
@@ -275,7 +278,8 @@ Menu items:
 5. course length
 6. year group
 7. active flag
-8. row-level actions (only if needed after the bulk-first flow is stable)
+
+There are no separate row-level class-edit actions in v1; selecting one row uses the same bulk modal workflow.
 
 `classId` should remain the `rowKey` and an internal identifier for actions, but it does not need a visible column. `class owner` and `teachers` should stay out of the table because they are backend-managed Google Classroom metadata and are only populated after the stored `ABClass` exists.
 
@@ -317,6 +321,7 @@ Classes tab
 ├── BulkSetActiveStateConfirmModal
 ├── BulkSetCohortModal
 ├── BulkSetYearGroupModal
+├── BulkSetCourseLengthModal
 ├── ManageCohortsModal
 │   ├── CreateOrEditCohortModal
 │   └── DeleteCohortConfirmModal
@@ -332,7 +337,8 @@ Classes tab
 3. Keep one primary modal open at a time unless a secondary create/edit/delete modal is explicitly nested from a management modal.
 4. When a secondary modal closes successfully, return focus to the invoking button inside the parent modal.
 5. Use `destroyOnHidden` only when resetting state is desirable; otherwise keep parent modal state stable during child modal flows. In the current Ant Design Modal docs this is the supported prop, while `destroyOnClose` is shown as deprecated.
-6. Surface final mutation summaries in the top-level alert stack after the modal closes.
+6. For bulk partial-success flows, keep the modal open briefly with inline feedback, then close and surface the persistent summary in the top-level alert stack.
+7. If a successful mutation is followed by a required re-fetch failure, hide stale table data and surface an alert explaining that the update succeeded but the user must refresh the page to see changes.
 
 ## Modal state vocabulary
 
@@ -382,10 +388,13 @@ Create missing `ABClass` records for selected `notCreated` rows.
 4. **submitting**
    - OK button loading
    - form disabled
+   - dispatch one request per selected row in parallel
 5. **partial success**
-   - modal may either remain open to show failures or close and let the tab-level summary alert carry the result
-   - failed rows remain selected
+   - continue attempting every selected row even if some fail
+   - show inline warning feedback briefly
+   - failed rows remain selected after close if those rows still exist
 6. **success-close**
+   - newly created classes default to `active=true`
    - close modal
    - update top-level summary alert
 
@@ -415,6 +424,7 @@ Must state that the action deletes:
 2. **submitting**
    - confirm button loading/disabled
 3. **partial success**
+   - show inline warning briefly
    - close modal and show summary `Alert` in the tab
 4. **submission failure**
    - keep modal open only if the error is actionable in-place; otherwise close and show the alert stack result
@@ -439,7 +449,9 @@ Apply a status change to eligible existing rows.
    - confirmation text includes target state and affected count
 3. **submitting**
    - confirm button loading
+   - dispatch one request per selected row in parallel
 4. **partial success**
+   - show inline warning briefly
    - close modal and surface summary at tab level
 
 ## Bulk set cohort modal
@@ -463,7 +475,9 @@ Apply one cohort to multiple eligible existing rows.
    - missing selection or stale option
 3. **submitting**
    - form disabled, OK button loading
+   - dispatch one request per selected row in parallel
 4. **partial success**
+   - show inline warning briefly
    - same summary pattern as other bulk workflows
 
 ## Bulk set year group modal
@@ -481,9 +495,42 @@ Apply one year group to multiple eligible existing rows.
 ### States
 
 1. **ready**
+   - all selected rows eligible
 2. **validation error**
+   - missing selection or stale option
 3. **submitting**
+   - form disabled, OK button loading
+   - dispatch one request per selected row in parallel
 4. **partial success**
+   - show inline warning briefly
+   - same summary pattern as other bulk workflows
+
+## Bulk set course length modal
+
+### Purpose
+
+Apply one `courseLength` value to one or more existing `ABClass` rows.
+
+This is the supported edit workflow for `courseLength` in v1, including the single-row case.
+
+### Components
+
+- `Modal`
+- `Form`
+- `InputNumber`
+
+### States
+
+1. **ready**
+   - all selected rows eligible
+2. **validation error**
+   - missing or invalid integer input
+3. **submitting**
+   - form disabled, OK button loading
+   - dispatch one request per selected row in parallel
+4. **partial success**
+   - show inline warning briefly
+   - same summary pattern as other bulk workflows
 
 ## Manage cohorts modal
 
@@ -551,10 +598,16 @@ Components:
 - `Modal.confirm` or standard `Modal`
 - `Alert` when delete is blocked because the cohort is in use
 
+Behaviour:
+
+- render a disabled delete button when the cohort is blocked
+- show explanatory warning state inside the modal
+- keep the modal open with inline feedback until the user closes it
+
 States:
 
 - ready
-- blocked (in use)
+- blocked (in use, disabled destructive action)
 - submitting
 - success-close
 - submission failure
@@ -613,28 +666,35 @@ Components:
 - `Modal.confirm` or standard `Modal`
 - `Alert` when delete is blocked because the year group is in use
 
+Behaviour:
+
+- render a disabled delete button when the year group is blocked
+- show explanatory warning state inside the modal
+- keep the modal open with inline feedback until the user closes it
+
 States:
 
 - ready
-- blocked
+- blocked (in use, disabled destructive action)
 - submitting
 - success-close
 - submission failure
 
 ## Preferred tab-state matrix
 
-| State                            | Visible UI                        | Primary components                                 | Interaction rule                             |
-| -------------------------------- | --------------------------------- | -------------------------------------------------- | -------------------------------------------- |
-| Startup prefetch loading         | summary skeleton + disabled shell | `Skeleton`, disabled `Button`, empty `Card` shells | do not allow bulk actions                    |
-| Startup prefetch failure         | blocking error                    | `Alert`                                            | fail fast and block normal interaction       |
-| Google Classroom entry load      | table loading                     | `Table.loading`                                    | keep shell stable while tab-entry fetch runs |
-| Google Classroom entry failure   | blocking error                    | `Alert`                                            | do not masquerade as empty state             |
-| No active classrooms             | empty state                       | `Empty`                                            | keep management launchers visible            |
-| Ready, no selection              | normal table                      | `Table`, `Dropdown`, `Button`                      | bulk trigger disabled                        |
-| Ready, with selection            | normal table + selection summary  | `Badge`/text summary                               | enable only eligible actions                 |
-| Mutation in progress             | ready state with disabled actions | loading `Button` / `Modal` buttons                 | prevent double-submit                        |
-| Mutation summary success         | summary feedback                  | success `Alert`                                    | keep table visible                           |
-| Mutation summary partial failure | warning feedback                  | warning `Alert`                                    | failed rows remain selected                  |
+| State                            | Visible UI                        | Primary components                                 | Interaction rule                                   |
+| -------------------------------- | --------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
+| Startup prefetch loading         | summary skeleton + disabled shell | `Skeleton`, disabled `Button`, empty `Card` shells | do not allow bulk actions                          |
+| Startup prefetch failure         | blocking error                    | `Alert`                                            | fail fast and block normal interaction             |
+| Google Classroom entry load      | table loading                     | `Table.loading`                                    | keep shell stable while tab-entry fetch runs       |
+| Google Classroom entry failure   | blocking error                    | `Alert`                                            | hide stale table; do not masquerade as empty state |
+| No active classrooms             | empty state                       | `Empty`                                            | keep management launchers visible                  |
+| Ready, no selection              | normal table                      | `Table`, `Dropdown`, `Button`                      | bulk trigger disabled                              |
+| Ready, with selection            | normal table + selection summary  | `Badge`/text summary                               | enable only eligible actions                       |
+| Mutation in progress             | ready state with disabled actions | loading `Button` / `Modal` buttons                 | prevent double-submit                              |
+| Mutation summary success         | summary feedback                  | success `Alert`                                    | keep table visible                                 |
+| Mutation summary partial failure | warning feedback                  | warning `Alert`                                    | failed rows remain selected                        |
+| Mutation success + refresh fail  | mixed success/warning             | warning `Alert`                                    | hide stale table and instruct page refresh         |
 
 ## Accessibility and usability requirements
 
@@ -644,7 +704,8 @@ States:
 4. The first actionable field in each form modal should receive focus on open.
 5. Destructive confirmations must name the record count or the specific record where practical.
 6. Row selection changes should remain visible after partial failures.
-7. The tab must remain readable without animation when reduced motion is enabled.
+7. Selection should reset on tab re-entry rather than preserving invisible rows.
+8. The tab must remain readable without animation when reduced motion is enabled.
 
 ## Testing implications
 
@@ -659,6 +720,8 @@ Vitest should cover the invisible behaviour that drives every explicit state in 
 - toolbar action-eligibility logic for no-selection, mixed-selection, ready, and mutation-in-progress states
 - table-column configuration, row-status derivation, selection rules, and empty-state mapping
 - modal state transitions for opening, ready, validation error, submitting, success-close, submission failure, partial success, and blocked flows
+- bulk course-length modal validation and submission behaviour
+- selection reset behaviour on delete and tab re-entry
 - reference-data management modal list-state mapping for loading, empty, ready, mutation-in-progress, and reload-warning states
 - summary and error mapping that keeps failed rows selected after partial-success batch operations
 
@@ -671,21 +734,21 @@ Playwright should cover the visible browser flows that correspond to those same 
 3. verify no-selection, mixed-selection, and ready-with-selection toolbar states, including tooltip-backed disabled actions
 4. verify table rendering for active, inactive, `notCreated`, and orphaned rows
 5. open and complete Bulk create, Bulk delete, and Bulk set active/inactive flows, including partial-failure feedback where applicable
-6. open and complete Bulk set cohort and Bulk set year-group flows
+6. open and complete Bulk set cohort, Bulk set year-group, and Bulk set course-length flows
 7. open Manage cohorts and Manage year groups, then exercise create, edit, delete, active-state, and blocked-delete flows
 8. verify mutation-summary success and partial-failure alerts persist at tab level after modal close
+9. verify a successful mutation followed by failed refresh hides stale table data and instructs the user to refresh the page
 
 ### Suggested spec organisation
 
 Keep the frontend suites split by testing responsibility:
 
 - Vitest: feature hook, view-model, table, toolbar, alert-stack, and modal component or helper specs under `src/frontend/src/features/classes/**`
-- Playwright: visible Classes-tab journeys in `src/frontend/e2e-tests/classes-crud.spec.ts` with test names grouped by ready, error, empty, bulk-action, and reference-data-management flows
+- Playwright: visible Classes-tab journeys split into focused specs such as table, bulk core actions, cohort/year-group metadata actions, management modals, load states, and mutation-summary flows
 
 ## Open decisions intentionally left to implementation
 
 1. whether the management modals use inner `Table` components or `List` for very small datasets
 2. whether the destructive bulk-confirm flows use standard `Modal` or `Modal.confirm`
-3. whether partial-failure bulk flows keep the modal open briefly or always close immediately and rely solely on the top-level alert stack
 
 These may be refined during implementation, but the overall hierarchy and state model above should remain stable.

--- a/SPEC.md
+++ b/SPEC.md
@@ -28,17 +28,22 @@ This page is **not** intended to host class analysis or assessment-run controls 
 6. The Google Classroom list should refresh on page load only; no manual refresh control is needed for now.
 7. Cohort and year-group management should use **secondary modals** for create, edit, and delete flows.
 8. Bulk editing should remain **modal-driven**, not inline.
-9. `courseLength` must be part of the create flow, with `1` accepted as the default.
-10. Active/inactive updates must **not** create missing `ABClass` records; frontend and backend validation must enforce this.
-11. Delete messaging should make clear that both the full and partial `ABClass` records are deleted.
-12. Bulk-action partial failures should keep failed rows selected and show a summary alert.
-13. Deleting cohorts or year groups that are still in use must be prevented.
-14. Cohort selection should:
+9. `courseLength` must be part of the create flow, with `1` accepted as the default, and existing classes must also support a modal-driven edit workflow for `courseLength`.
+10. Newly created `ABClass` records should default to `active=true`.
+11. Active/inactive updates must **not** create missing `ABClass` records; frontend and backend validation must enforce this.
+12. Delete messaging should make clear that both the full and partial `ABClass` records are deleted.
+13. Bulk-action partial failures should keep failed rows selected and show a summary alert.
+14. Deleting cohorts or year groups that are still in use must be prevented.
+15. Cohort selection should:
     - allow only active cohorts in create/edit selectors for new class flows
     - keep inactive cohorts visible in existing class data
     - keep inactive cohorts understandable when already assigned
-15. `cohorts` and `yearGroups` should be startup-prefetched alongside `classPartials` because they will become shared lookup data for querying and filtering across the frontend.
-16. Any create, edit, or delete operation affecting cohorts or year groups should invalidate the corresponding shared query and force a refresh.
+16. `cohorts` and `yearGroups` should be startup-prefetched alongside `classPartials` because they will become shared lookup data for querying and filtering across the frontend.
+17. The app-level auth / warm-up boundary should own startup readiness for `classPartials`, `cohorts`, and `yearGroups`.
+18. Any create, edit, or delete operation affecting cohorts or year groups should invalidate the corresponding shared query and force a refresh.
+19. Bulk actions are also the single-row edit path; selecting one row should use the same workflow as selecting many rows.
+20. Bulk requests should dispatch one request per selected row in parallel, continue across the full selection, and report failures per row in the original submitted row order.
+21. If a required re-fetch fails after a successful mutation, stale table data should not remain visible; the user should instead see an alert explaining that the update succeeded but a refresh is needed to see the latest state.
 
 ## Existing system constraints
 
@@ -204,7 +209,7 @@ The Settings-page **Classes** tab depends on four shared datasets:
 
 ### Startup
 
-Startup warm-up should prefetch:
+Startup warm-up should prefetch, under the app-level auth / warm-up boundary:
 
 - `classPartials`
 - `cohorts`
@@ -349,7 +354,14 @@ Display stored `ABClass` metadata resolved through the reference-data lookups wh
 
 ## Bulk-action specification
 
-Bulk actions are modal-driven only.
+Bulk actions are modal-driven only. They are also the supported single-row edit path in v1: selecting one row uses the same modal and transport behaviour as selecting many rows.
+
+Execution semantics for all bulk actions:
+
+- dispatch one request per selected row in parallel
+- continue attempting every selected row even if some requests fail
+- report success/failure counts in the submitted row order captured when the user confirms the modal
+- if the user closes a modal after requests have already been dispatched, those in-flight requests continue because cancellation is not supported in v1
 
 ## Bulk create `ABClass` records
 
@@ -365,9 +377,11 @@ Bulk actions are modal-driven only.
 
 ### Behaviour
 
-- submit one `upsertABClass` call per selected row
+- submit one `upsertABClass` call per selected row in parallel
+- newly created classes default to `active=true`
 - failed rows remain selected
 - successful rows are deselected
+- on partial success, keep the modal open briefly with inline feedback, then close and show a summary alert
 - show a summary alert after completion
 
 ## Bulk delete `ABClass` records
@@ -389,6 +403,7 @@ The confirmation should make clear that this deletes:
 
 - failed rows remain selected
 - successful rows are deselected
+- on partial success, keep the modal open briefly with inline feedback, then close and show summary alert
 - show summary alert
 
 ## Bulk set active / inactive
@@ -437,12 +452,34 @@ Rows in `notCreated` or `orphaned` status are not eligible in v1.
 
 - `yearGroupKey` select
 
+## Bulk set course length
+
+### Eligible rows
+
+- active rows
+- inactive rows
+
+Rows in `notCreated` or `orphaned` status are not eligible in v1.
+
+### Modal fields
+
+- `courseLength` (`InputNumber`, integer, min `1`)
+
+### Behaviour
+
+- this is the supported edit workflow for `courseLength` on existing classes
+- selecting one row uses the same workflow as selecting many rows
+- submit one `updateABClass` call per selected row in parallel
+
 ## Partial-success handling
 
 For all bulk actions:
 
-- keep failed rows selected
+- keep failed rows selected if those rows still exist after refresh
 - deselect successful rows
+- clear selection for rows that were deleted or are no longer visible
+- reset selection when the user leaves and re-enters the tab
+- keep the modal open briefly with inline feedback on partial success, then close and hand off to the persistent summary `Alert`
 - show a persistent summary `Alert`
 - include counts for attempted, succeeded, and failed rows
 
@@ -467,7 +504,7 @@ Deletion must be prevented when any persisted `ABClass` still references that co
 This safeguard should exist in both:
 
 - backend authoritative validation
-- frontend affordance or disabled state where feasible
+- a frontend confirmation modal that shows a disabled delete button plus explanatory warning state and remains open with inline feedback until the user closes it
 
 ## Year-group management modal
 
@@ -482,7 +519,7 @@ This safeguard should exist in both:
 
 Deletion must be prevented when any persisted `ABClass` still references that year-group key.
 
-As with cohorts, backend validation is authoritative.
+As with cohorts, backend validation is authoritative and the frontend should surface blocked deletes through the same confirmation-modal pattern, including a disabled delete button and inline warning state that remains open until the user closes it.
 
 ## Backend changes required to support agreed behaviour
 
@@ -542,12 +579,7 @@ The preferred implementation source for these in-use checks is the `abclass_part
 
 ## 5. Partial-response shaping
 
-Decide whether `getABClassPartials` should:
-
-1. return keys only and let the frontend resolve names, or
-2. return keys plus resolved display names for convenience
-
-The preferred initial approach is to keep storage and transport explicit by returning keys and resolving names in the frontend view model.
+`getABClassPartials` should return keys plus resolved display names for convenience. The transport contract should therefore expose explicit keys (`cohortKey`, `yearGroupKey`) alongside resolved labels (`cohortName`, `yearGroupName`).
 
 ## Frontend feature structure recommendation
 
@@ -608,7 +640,7 @@ The implementation plan should be organised around the following broad workstrea
 
 - add any controller helpers needed to resolve reference-data keys efficiently
 - ensure reference-data existence checks are shared rather than duplicated
-- review whether partial responses should expose keys only or keys plus resolved labels
+- return class partial responses with explicit keys plus resolved labels
 
 ## 5. Frontend service and schema work
 
@@ -633,7 +665,7 @@ The implementation plan should be organised around the following broad workstrea
 
 ## 8. Bulk-action workflows
 
-- implement bulk create, delete, set active or inactive, set cohort, and set year group flows
+- implement bulk create, delete, set active or inactive, set cohort, set year group, and set course length flows
 - add modal forms, validation, confirmation steps, and partial-success summaries
 - ensure failed rows remain selected after batch operations
 
@@ -670,11 +702,11 @@ If the Settings-page Classes tab cannot load any essential startup-prefetched da
 
 ## Partial-load failure
 
-If one dataset fails but others succeed:
+If one dataset fails but others succeed during a non-blocking refresh path:
 
-- keep usable data visible where practical
 - show a warning `Alert`
-- do not hide already-loaded table data unnecessarily
+- do not leave stale table data visible if the failed refresh is required to trust the current table state
+- if the failed refresh followed a successful mutation, tell the user the update succeeded but they must refresh the page to see changes
 
 ## Empty states
 
@@ -694,7 +726,7 @@ Orphaned rows, if any, will appear in the main table according to the specified 
 
 After successful mutations, refresh the relevant queries:
 
-- class create, update, delete -> refresh `classPartials`
+- class create, update, delete -> refresh `classPartials`; if that re-fetch fails after a successful mutation, show success-plus-refresh-needed guidance and do not keep stale table data visible
 - cohort create, edit, delete -> invalidate `cohorts` and force a refresh for active consumers
 - year-group create, edit, delete -> invalidate `yearGroups` and force a refresh for active consumers
 - Google Classrooms refreshes on page entry only in v1
@@ -705,7 +737,7 @@ After successful mutations, refresh the relevant queries:
 - orphaned state should be understandable by icon plus text or tooltip, not icon alone
 - modal forms should focus the first actionable field on open
 - destructive actions should require explicit confirmation
-- table selection state should remain predictable after partial failures
+- table selection state should remain predictable after partial failures and should reset on tab re-entry
 
 ## V1 scope recommendation
 

--- a/docs/developer/frontend/frontend-react-query-and-prefetch.md
+++ b/docs/developer/frontend/frontend-react-query-and-prefetch.md
@@ -32,6 +32,7 @@ Current shared keys:
 - `classPartials`
 - `cohorts`
 - `yearGroups`
+- `googleClassrooms`
 
 Keep future invalidation and warm-up work aligned to these helpers.
 
@@ -50,17 +51,21 @@ Runtime validation should happen at the service boundary before data is cached.
 
 ## 4. Startup warm-up policy
 
-Startup warm-up is intentionally narrow in this phase.
+Startup warm-up uses the shared lookup datasets needed across the growing interface.
 
 Current policy:
 
-- startup-prefetched dataset: `classPartials` only
+- startup-prefetched datasets: `classPartials`, `cohorts`, and `yearGroups`
 - trigger point: after the shared auth query resolves to authorised
+- ownership: the app-level auth / warm-up boundary owns startup readiness
 - scheduling: fire-and-forget from an app-level boundary outside `App.tsx`
 - query API: `fetchQuery`, so orchestration can observe failures
+- readiness rule: startup is considered warmed only after all three shared datasets succeed
 - logging: debug-only orchestration context if warm-up fails
 
 Warm-up must not block initial render, shell paint, or navigation readiness.
+
+`googleClassrooms` remains a view-entry prefetch for the Classes tab rather than a startup-prefetched dataset.
 
 ## 5. Prefetch decision framework for future features
 
@@ -80,11 +85,12 @@ The current query-client defaults support that by avoiding eager refetch on focu
 
 Deferred invalidation notes:
 
-- future cohort mutations should invalidate the `cohorts` query when those screens migrate
-- future year-group mutations should invalidate the `yearGroups` query when those screens migrate
-- `classPartials` invalidation is deferred until there is a backend-supported notifier or update signal for `ABClass` changes
+- cohort mutations should invalidate the `cohorts` query and refresh active consumers
+- year-group mutations should invalidate the `yearGroups` query and refresh active consumers
+- `classPartials` refresh remains feature-driven after successful class mutations
+- if a required post-mutation refresh fails, do not keep stale table data visible; surface user guidance that a page refresh is required to see changes
 
-Do not add speculative invalidation wiring before those feature migrations exist.
+Do not add speculative invalidation wiring beyond the feature contracts that exist.
 
 ## 7. Sensitive data and cache persistence
 


### PR DESCRIPTION
### Motivation

- Align the Classes CRUD action plan, UI layout, and spec with recent design decisions around stable reference-data keys, resolved labels in partials, and bulk-edit semantics.
- Make explicit app-level startup warm-up ownership, shared-query behaviour, and the Playwright harness requirements so implementation and testing are consistent.
- Clarify modal and bulk-action UX decisions such as single-row = bulk modal, parallel per-row dispatch, partial-success handling, and default `active` for newly created classes.

### Description

- Update `ACTION_PLAN.md`, `SPEC.md`, `CLASSES_TAB_LAYOUT_AND_MODALS.md`, and `docs/developer/frontend/frontend-react-query-and-prefetch.md` to record the revised contracts and UI/workflow decisions, including added sections for app-level warm-up ownership and browser-test harnessing.
- Add `courseLength` as a bulk/settable field and document the new `Bulk set course length` modal and that bulk modals are the single-row edit path in v1.
- Specify that `getABClassPartials` transport returns keys plus resolved `cohortName`/`yearGroupName`, that cohorts include `startYear`/`startMonth`, and that newly created classes default to `active=true`.
- Define execution semantics for bulk actions: dispatch one request per selected row in parallel, continue across the selection, keep failed rows selected, briefly show inline partial-failure feedback in modals, and surface persistent summaries in the alert stack.
- Clarify query-key and warm-up policy changes: startup-prefetch now includes `classPartials`, `cohorts`, and `yearGroups` under an app-level auth/warm-up boundary while `googleClassrooms` remains a Classes-tab view-entry prefetch, and `queryKeys` now list `googleClassrooms`.
- Refine modal and management UX: disabled destructive delete button for in-use reference-data with inline warning state, selection-reset behaviour on tab re-entry, and rules for hiding stale data when required re-fetches fail.

### Testing

- Ran repository lint and frontend lint commands: `npm run lint` and `npm run frontend:lint`, and TypeScript check `npm exec tsc -- -b src/frontend/tsconfig.json`, all reported as passing for these documentation edits.
- No unit or e2e test suites were modified or required to validate documentation-only changes, so no Vitest or Playwright feature tests were executed as part of this PR.
- The action-plan and spec updates include the updated test targets and Playwright/Vitest expectations to be used by follow-up implementation PRs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed0d231d48329bc41af1704ffc510)