### PR TITLE
Reference-data keys and cohort/year-group model refactor; update ABClass to use keys and include labels

### DIFF
--- a/src/backend/Models/ABClass.js
+++ b/src/backend/Models/ABClass.js
@@ -66,9 +66,9 @@ class ABClass {
         : {
             classId: arguments_[0],
             className: arguments_[1],
-            cohort: arguments_[2],
+            cohortKey: arguments_[2],
             courseLength: arguments_[3],
-            yearGroup: arguments_[4],
+            yearGroupKey: arguments_[4],
             classOwner: arguments_[5],
             teachers: arguments_[6],
             students: arguments_[7],
@@ -79,9 +79,11 @@ class ABClass {
     const {
       classId,
       className = null,
-      cohort = null,
+      cohortKey = null,
       courseLength = 1,
-      yearGroup = null,
+      yearGroupKey = null,
+      cohortLabel = null,
+      yearGroupLabel = null,
       classOwner = null,
       teachers = [],
       students = [],
@@ -96,18 +98,19 @@ class ABClass {
     // Explicit owner property (store as provided). Validation should be done via setClassOwner.
     this.classOwner = classOwner || null;
 
-    // Cohort can be a number (year) or string. Store as string for stability but expose helpers.
-    this.cohort = cohort !== undefined && cohort !== null ? String(cohort) : null;
+    const hasCohortKey = cohortKey === undefined || cohortKey === null;
+    this.cohortKey = hasCohortKey ? null : String(cohortKey);
 
     // courseLength in years (integer)
     this.courseLength = Number.isInteger(courseLength)
       ? courseLength
       : ABClass._parseNullableInt(courseLength, 1);
 
-    // yearGroup (integer), nullable
-    this.yearGroup = Number.isInteger(yearGroup)
-      ? yearGroup
-      : ABClass._parseNullableInt(yearGroup, null);
+    const hasYearGroupKey = yearGroupKey === undefined || yearGroupKey === null;
+    this.yearGroupKey = hasYearGroupKey ? null : String(yearGroupKey);
+
+    this.cohortLabel = cohortLabel ?? null;
+    this.yearGroupLabel = yearGroupLabel ?? null;
 
     // Arrays of domain objects; consumers may push instances or plain objects.
     this.teachers = Array.isArray(teachers) ? [...teachers] : [];
@@ -206,8 +209,8 @@ class ABClass {
    * @returns {number|null} The cohort start year, or null if not parseable
    */
   getCohortStartYear() {
-    if (!this.cohort) return null;
-    const number_ = Number.parseInt(this.cohort, 10);
+    if (!this.cohortLabel) return null;
+    const number_ = Number.parseInt(String(this.cohortLabel), 10);
     return Number.isNaN(number_) ? null : number_;
   }
 
@@ -343,9 +346,9 @@ class ABClass {
     return {
       classId: this.classId,
       className: this.className,
-      cohort: this.cohort,
+      cohortKey: this.cohortKey,
       courseLength: this.courseLength,
-      yearGroup: this.yearGroup,
+      yearGroupKey: this.yearGroupKey,
       classOwner: serialiseOwner(this.classOwner),
       teachers: serialiseArray(this.teachers),
       students: serialiseArray(this.students),
@@ -360,16 +363,26 @@ class ABClass {
    * @returns {Object} A partial object representation with class metadata and teachers, but no students or assignments
    */
   toPartialJSON() {
-    return {
+    const partial = {
       classId: this.classId,
       className: this.className,
-      cohort: this.cohort,
+      cohortKey: this.cohortKey,
       courseLength: this.courseLength,
-      yearGroup: this.yearGroup,
+      yearGroupKey: this.yearGroupKey,
       classOwner: serialiseOwner(this.classOwner),
       teachers: serialiseArray(this.teachers),
       active: this.active,
     };
+
+    if (this.cohortLabel !== null && this.cohortLabel !== undefined) {
+      partial.cohortLabel = this.cohortLabel;
+    }
+
+    if (this.yearGroupLabel !== null && this.yearGroupLabel !== undefined) {
+      partial.yearGroupLabel = this.yearGroupLabel;
+    }
+
+    return partial;
   }
 
   // fromJSON reconstructs an ABClass instance from previously serialized data.
@@ -383,13 +396,17 @@ class ABClass {
     const inst = Object.create(ABClass.prototype);
     inst.classId = json.classId;
     inst.className = json.className || null;
-    inst.cohort = json.cohort !== undefined && json.cohort !== null ? String(json.cohort) : null;
+    inst.cohortKey =
+      json.cohortKey !== undefined && json.cohortKey !== null ? String(json.cohortKey) : null;
     inst.courseLength = Number.isInteger(json.courseLength)
       ? json.courseLength
       : ABClass._parseNullableInt(json.courseLength, 1);
-    inst.yearGroup = Number.isInteger(json.yearGroup)
-      ? json.yearGroup
-      : ABClass._parseNullableInt(json.yearGroup, null);
+    inst.yearGroupKey =
+      json.yearGroupKey !== undefined && json.yearGroupKey !== null
+        ? String(json.yearGroupKey)
+        : null;
+    inst.cohortLabel = json.cohortLabel ?? null;
+    inst.yearGroupLabel = json.yearGroupLabel ?? null;
 
     // Restore explicit owner (attempt Teacher.fromJSON when available)
     try {

--- a/src/backend/Models/Cohort.js
+++ b/src/backend/Models/Cohort.js
@@ -2,7 +2,17 @@
 
 /* global Validate */
 
-const CONSTRUCTOR_ARG_COUNT_WITH_ACTIVE = 2;
+const ACADEMIC_YEAR_START_MONTH = 9;
+
+/**
+ * Resolves the academic-year start for a given date.
+ * @param {Date} [now] - Current date reference.
+ * @returns {number} Academic-year start year.
+ */
+function getCurrentAcademicYearStart(now = new Date()) {
+  const month = now.getMonth() + 1;
+  return month >= ACADEMIC_YEAR_START_MONTH ? now.getFullYear() : now.getFullYear() - 1;
+}
 
 /**
  * Represents a cohort reference record.
@@ -10,16 +20,47 @@ const CONSTRUCTOR_ARG_COUNT_WITH_ACTIVE = 2;
 class Cohort {
   /**
    * Constructs a Cohort instance.
+   * @param {string} key - Stable key for the cohort
    * @param {string} name - The cohort display name
    * @param {boolean} [active] - Whether the cohort is active (defaults to true)
+   * @param {number} [startYear] - Academic year start
+   * @param {number} [startMonth] - Academic year start month
    */
-  constructor(name, active) {
-    Validate.requireParams({ name }, 'Cohort.constructor');
+  constructor(key, name, active, startYear, startMonth) {
+    Validate.requireParams({ key, name }, 'Cohort.constructor');
+    this.key = '';
     this.name = '';
     this.active = true;
+    this.startYear = getCurrentAcademicYearStart();
+    this.startMonth = ACADEMIC_YEAR_START_MONTH;
 
+    this.setKey(key);
     this.setName(name);
-    this.setActive(arguments.length < CONSTRUCTOR_ARG_COUNT_WITH_ACTIVE ? true : active);
+    this.setActive(active === undefined ? true : active);
+    this.setStartMonth(startMonth === undefined ? ACADEMIC_YEAR_START_MONTH : startMonth);
+    this.setStartYear(startYear === undefined ? getCurrentAcademicYearStart() : startYear);
+  }
+
+  /**
+   * Gets the cohort stable key.
+   * @returns {string} Stable key
+   */
+  getKey() {
+    return this.key;
+  }
+
+  /**
+   * Sets the cohort stable key.
+   * @param {string} key - Stable key
+   */
+  setKey(key) {
+    Validate.requireParams({ key }, 'Cohort.setKey');
+
+    if (!Validate.isNonEmptyString(key)) {
+      throw new TypeError('key must be a non-empty string.');
+    }
+
+    this.key = key.trim();
   }
 
   /**
@@ -67,13 +108,60 @@ class Cohort {
   }
 
   /**
+   * Gets the cohort start year.
+   * @returns {number} Academic year start
+   */
+  getStartYear() {
+    return this.startYear;
+  }
+
+  /**
+   * Sets the cohort start year.
+   * @param {number} startYear - Academic year start
+   */
+  setStartYear(startYear) {
+    Validate.requireParams({ startYear }, 'Cohort.setStartYear');
+
+    if (!Number.isInteger(startYear)) {
+      throw new TypeError('startYear must be an integer.');
+    }
+
+    this.startYear = startYear;
+  }
+
+  /**
+   * Gets the cohort start month.
+   * @returns {number} Academic year start month
+   */
+  getStartMonth() {
+    return this.startMonth;
+  }
+
+  /**
+   * Sets the cohort start month.
+   * @param {number} startMonth - Academic year start month
+   */
+  setStartMonth(startMonth) {
+    Validate.requireParams({ startMonth }, 'Cohort.setStartMonth');
+
+    if (!Number.isInteger(startMonth) || startMonth < 1 || startMonth > 12) {
+      throw new TypeError('startMonth must be an integer between 1 and 12.');
+    }
+
+    this.startMonth = startMonth;
+  }
+
+  /**
    * Serializes the Cohort instance to a JSON object.
    * @returns {Object} The JSON representation of the cohort
    */
   toJSON() {
     return {
+      key: this.key,
       name: this.name,
       active: this.active,
+      startYear: this.startYear,
+      startMonth: this.startMonth,
     };
   }
 
@@ -90,7 +178,14 @@ class Cohort {
     }
 
     const active = Object.hasOwn(json, 'active') ? json.active : true;
-    return new Cohort(json.name, active);
+    const startMonth = Object.hasOwn(json, 'startMonth')
+      ? json.startMonth
+      : ACADEMIC_YEAR_START_MONTH;
+    const startYear = Object.hasOwn(json, 'startYear')
+      ? json.startYear
+      : getCurrentAcademicYearStart();
+
+    return new Cohort(json.key, json.name, active, startYear, startMonth);
   }
 }
 

--- a/src/backend/Models/Cohort.js
+++ b/src/backend/Models/Cohort.js
@@ -56,11 +56,7 @@ class Cohort {
   setKey(key) {
     Validate.requireParams({ key }, 'Cohort.setKey');
 
-    if (!Validate.isNonEmptyString(key)) {
-      throw new TypeError('key must be a non-empty string.');
-    }
-
-    this.key = key.trim();
+    this.key = Validate.validateTrimmedNonEmptyString('key', key);
   }
 
   /**
@@ -78,11 +74,7 @@ class Cohort {
   setName(name) {
     Validate.requireParams({ name }, 'Cohort.setName');
 
-    if (!Validate.isNonEmptyString(name)) {
-      throw new TypeError('name must be a non-empty string.');
-    }
-
-    this.name = name.trim();
+    this.name = Validate.validateTrimmedNonEmptyString('name', name);
   }
 
   /**
@@ -173,19 +165,17 @@ class Cohort {
   static fromJSON(json) {
     Validate.requireParams({ json }, 'Cohort.fromJSON');
 
-    if (!json || typeof json !== 'object' || Array.isArray(json)) {
-      throw new TypeError('json must be an object.');
-    }
+    const cohortJson = Validate.validatePlainObject('json', json);
 
-    const active = Object.hasOwn(json, 'active') ? json.active : true;
-    const startMonth = Object.hasOwn(json, 'startMonth')
-      ? json.startMonth
+    const active = Object.hasOwn(cohortJson, 'active') ? cohortJson.active : true;
+    const startMonth = Object.hasOwn(cohortJson, 'startMonth')
+      ? cohortJson.startMonth
       : ACADEMIC_YEAR_START_MONTH;
-    const startYear = Object.hasOwn(json, 'startYear')
-      ? json.startYear
+    const startYear = Object.hasOwn(cohortJson, 'startYear')
+      ? cohortJson.startYear
       : getCurrentAcademicYearStart();
 
-    return new Cohort(json.key, json.name, active, startYear, startMonth);
+    return new Cohort(cohortJson.key, cohortJson.name, active, startYear, startMonth);
   }
 }
 

--- a/src/backend/Models/YearGroup.js
+++ b/src/backend/Models/YearGroup.js
@@ -35,11 +35,7 @@ class YearGroup {
   setKey(key) {
     Validate.requireParams({ key }, 'YearGroup.setKey');
 
-    if (!Validate.isNonEmptyString(key)) {
-      throw new TypeError('key must be a non-empty string.');
-    }
-
-    this.key = key.trim();
+    this.key = Validate.validateTrimmedNonEmptyString('key', key);
   }
 
   /**
@@ -57,11 +53,7 @@ class YearGroup {
   setName(name) {
     Validate.requireParams({ name }, 'YearGroup.setName');
 
-    if (!Validate.isNonEmptyString(name)) {
-      throw new TypeError('name must be a non-empty string.');
-    }
-
-    this.name = name.trim();
+    this.name = Validate.validateTrimmedNonEmptyString('name', name);
   }
 
   /**
@@ -83,11 +75,9 @@ class YearGroup {
   static fromJSON(json) {
     Validate.requireParams({ json }, 'YearGroup.fromJSON');
 
-    if (!json || typeof json !== 'object' || Array.isArray(json)) {
-      throw new TypeError('json must be an object.');
-    }
+    const yearGroupJson = Validate.validatePlainObject('json', json);
 
-    return new YearGroup(json.key, json.name);
+    return new YearGroup(yearGroupJson.key, yearGroupJson.name);
   }
 }
 

--- a/src/backend/Models/YearGroup.js
+++ b/src/backend/Models/YearGroup.js
@@ -9,12 +9,37 @@
 class YearGroup {
   /**
    * Constructs a YearGroup instance.
+   * @param {string} key - Stable key for the year group
    * @param {string} name - The year-group display name
    */
-  constructor(name) {
-    Validate.requireParams({ name }, 'YearGroup.constructor');
+  constructor(key, name) {
+    Validate.requireParams({ key, name }, 'YearGroup.constructor');
+    this.key = '';
     this.name = '';
+    this.setKey(key);
     this.setName(name);
+  }
+
+  /**
+   * Gets the stable year-group key.
+   * @returns {string} Stable key identifier
+   */
+  getKey() {
+    return this.key;
+  }
+
+  /**
+   * Sets the stable year-group key.
+   * @param {string} key - Stable key identifier
+   */
+  setKey(key) {
+    Validate.requireParams({ key }, 'YearGroup.setKey');
+
+    if (!Validate.isNonEmptyString(key)) {
+      throw new TypeError('key must be a non-empty string.');
+    }
+
+    this.key = key.trim();
   }
 
   /**
@@ -45,6 +70,7 @@ class YearGroup {
    */
   toJSON() {
     return {
+      key: this.key,
       name: this.name,
     };
   }
@@ -61,7 +87,7 @@ class YearGroup {
       throw new TypeError('json must be an object.');
     }
 
-    return new YearGroup(json.name);
+    return new YearGroup(json.key, json.name);
   }
 }
 

--- a/src/backend/Models/YearGroup.js
+++ b/src/backend/Models/YearGroup.js
@@ -77,6 +77,9 @@ class YearGroup {
 
     const yearGroupJson = Validate.validatePlainObject('json', json);
 
+    if (!Object.prototype.hasOwnProperty.call(json, 'key')) {
+      throw new TypeError('json.key is required.');
+    }
     return new YearGroup(yearGroupJson.key, yearGroupJson.name);
   }
 }

--- a/src/backend/Utils/Validate.js
+++ b/src/backend/Utils/Validate.js
@@ -214,6 +214,36 @@ const Validate = {
   },
 
   /**
+   * Validates that a value is a non-empty string and returns a trimmed value.
+   * @param {string} label - Human-readable label for error messaging.
+   * @param {*} value - Value to validate.
+   * @returns {string} The validated, trimmed string value.
+   * @throws {TypeError} If value is not a non-empty string.
+   */
+  validateTrimmedNonEmptyString(label, value) {
+    if (!Validate.isNonEmptyString(value)) {
+      throw new TypeError(`${label} must be a non-empty string.`);
+    }
+
+    return value.trim();
+  },
+
+  /**
+   * Validates that a value is a plain object (non-null and not an array).
+   * @param {string} label - Human-readable label for error messaging.
+   * @param {*} value - Value to validate.
+   * @returns {Object} The validated plain object value.
+   * @throws {TypeError} If value is not a plain object.
+   */
+  validatePlainObject(label, value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new TypeError(`${label} must be an object.`);
+    }
+
+    return value;
+  },
+
+  /**
    * Validates that a value is a valid URL string.
    * @param {string} label - Human-readable label for error messaging.
    * @param {*} value - Value to validate.

--- a/src/backend/y_controllers/ABClassController.js
+++ b/src/backend/y_controllers/ABClassController.js
@@ -165,9 +165,11 @@ class ABClassController {
     return {
       classId: partialDocument.classId,
       className: partialDocument.className,
-      cohort: partialDocument.cohort,
+      cohortKey: partialDocument.cohortKey,
+      cohortLabel: partialDocument.cohortLabel,
       courseLength: partialDocument.courseLength,
-      yearGroup: partialDocument.yearGroup,
+      yearGroupKey: partialDocument.yearGroupKey,
+      yearGroupLabel: partialDocument.yearGroupLabel,
       classOwner: partialDocument.classOwner,
       teachers: [...partialDocument.teachers],
       active: partialDocument.active,
@@ -580,13 +582,13 @@ class ABClassController {
    * Initialises an ABClass instance by populating data that can be fetched using
    * the classId (Google Classroom courseId) alone. Populates: className,
    * classOwner, teachers and students. Additional properties (assignments,
-   * cohort, courseLength, yearGroup) may be provided via options.
+   * cohortKey, courseLength, yearGroupKey) may be provided via options.
    *
    * @param {string} classId - The Classroom course ID.
    * @param {Object} [options={}] - Optional configuration for class properties.
-   * @param {string|number} [options.cohort] - Cohort value for the class.
+   * @param {string} [options.cohortKey] - Cohort key value for the class.
    * @param {number} [options.courseLength] - Course duration in weeks.
-   * @param {number} [options.yearGroup] - Academic year group.
+   * @param {string} [options.yearGroupKey] - Academic year-group key.
    * @param {Assignment[]} [options.assignments] - Assignments to add to the class.
    * @returns {ABClass} Populated ABClass instance with roster data.
    * @throws {TypeError} If classId is missing.
@@ -598,18 +600,16 @@ class ABClassController {
     const abClass = new ABClass({ classId });
 
     // Apply straightforward options first
-    if (options.cohort !== undefined) {
-      abClass.cohort = options.cohort === null ? null : String(options.cohort);
+    if (options.cohortKey !== undefined) {
+      abClass.cohortKey = options.cohortKey === null ? null : String(options.cohortKey);
     }
     if (options.courseLength !== undefined) {
       abClass.courseLength = Number.isInteger(options.courseLength)
         ? options.courseLength
         : ABClass._parseNullableInt(options.courseLength, abClass.courseLength);
     }
-    if (options.yearGroup !== undefined) {
-      abClass.yearGroup = Number.isInteger(options.yearGroup)
-        ? options.yearGroup
-        : ABClass._parseNullableInt(options.yearGroup, abClass.yearGroup);
+    if (options.yearGroupKey !== undefined) {
+      abClass.yearGroupKey = options.yearGroupKey === null ? null : String(options.yearGroupKey);
     }
     if (options.assignments?.length) {
       options.assignments.forEach((assignment) => abClass.addAssignment(assignment));
@@ -688,8 +688,8 @@ class ABClassController {
   /**
    * Builds a patch object from update parameters for selective field updates.
    * @param {Object} parameters - The update parameters object.
-   * @param {*} [parameters.cohort] - Optional cohort value.
-   * @param {*} [parameters.yearGroup] - Optional year group value.
+   * @param {*} [parameters.cohortKey] - Optional cohort key value.
+   * @param {*} [parameters.yearGroupKey] - Optional year group key value.
    * @param {*} [parameters.courseLength] - Optional course length (validated).
    * @param {boolean} [parameters.active] - Optional active flag.
    * @returns {Object} Patch object containing only provided fields.
@@ -698,12 +698,13 @@ class ABClassController {
   _buildUpdatePatch(parameters) {
     const patch = {};
 
-    if (Object.hasOwn(parameters, 'cohort')) {
-      patch.cohort = parameters.cohort === null ? null : String(parameters.cohort);
+    if (Object.hasOwn(parameters, 'cohortKey')) {
+      patch.cohortKey = parameters.cohortKey === null ? null : String(parameters.cohortKey);
     }
 
-    if (Object.hasOwn(parameters, 'yearGroup')) {
-      patch.yearGroup = parameters.yearGroup;
+    if (Object.hasOwn(parameters, 'yearGroupKey')) {
+      patch.yearGroupKey =
+        parameters.yearGroupKey === null ? null : String(parameters.yearGroupKey);
     }
 
     if (Object.hasOwn(parameters, 'courseLength')) {
@@ -725,12 +726,12 @@ class ABClassController {
    * @private
    */
   _applyPatchToClass(abClass, patch) {
-    if (Object.hasOwn(patch, 'cohort')) {
-      abClass.cohort = patch.cohort;
+    if (Object.hasOwn(patch, 'cohortKey')) {
+      abClass.cohortKey = patch.cohortKey;
     }
 
-    if (Object.hasOwn(patch, 'yearGroup')) {
-      abClass.yearGroup = patch.yearGroup;
+    if (Object.hasOwn(patch, 'yearGroupKey')) {
+      abClass.yearGroupKey = patch.yearGroupKey;
     }
 
     if (Object.hasOwn(patch, 'courseLength')) {
@@ -757,11 +758,11 @@ class ABClassController {
   /**
    * Creates a new ABClass or updates an existing one with fresh classroom data and custom metadata.
    * Validates all required parameters, then either creates a new class or refreshes an existing one,
-   * applying the provided metadata (cohort, yearGroup, courseLength).
+   * applying the provided metadata (cohortKey, yearGroupKey, courseLength).
    * @param {Object} parameters - Update parameters.
    * @param {string} parameters.classId - Classroom course identifier (required).
-   * @param {*} parameters.cohort - User-managed cohort value (required).
-   * @param {*} parameters.yearGroup - User-managed year group value (required).
+   * @param {*} parameters.cohortKey - User-managed cohort key (required).
+   * @param {*} parameters.yearGroupKey - User-managed year-group key (required).
    * @param {number} parameters.courseLength - Required course length, validated as an integer >= 1 (required).
    * @returns {Object} Partial ABClass summary from toPartialJSON().
    * @throws {Error} If required parameters are missing or validation fails.
@@ -770,8 +771,8 @@ class ABClassController {
     Validate.requireParams(
       {
         classId: parameters?.classId,
-        cohort: parameters?.cohort,
-        yearGroup: parameters?.yearGroup,
+        cohortKey: parameters?.cohortKey,
+        yearGroupKey: parameters?.yearGroupKey,
         courseLength: parameters?.courseLength,
       },
       'upsertABClass'
@@ -785,14 +786,15 @@ class ABClassController {
 
     if (existingDocument) {
       abClass = ABClass.fromJSON(existingDocument);
-      abClass.cohort = parameters.cohort === null ? null : String(parameters.cohort);
-      abClass.yearGroup = parameters.yearGroup;
+      abClass.cohortKey = parameters.cohortKey === null ? null : String(parameters.cohortKey);
+      abClass.yearGroupKey =
+        parameters.yearGroupKey === null ? null : String(parameters.yearGroupKey);
       abClass.courseLength = courseLength;
       this._refreshRoster(abClass, classId);
     } else {
       abClass = this.initialise(classId, {
-        cohort: parameters.cohort,
-        yearGroup: parameters.yearGroup,
+        cohortKey: parameters.cohortKey,
+        yearGroupKey: parameters.yearGroupKey,
         courseLength: courseLength,
       });
     }
@@ -806,8 +808,8 @@ class ABClassController {
    * If the class does not yet exist, initialises it first using the supplied patch fields.
    * @param {Object} parameters - Patch parameters object.
    * @param {string} parameters.classId - Classroom course identifier (required).
-   * @param {*} [parameters.cohort] - Optional cohort replacement.
-   * @param {*} [parameters.yearGroup] - Optional year-group replacement.
+   * @param {*} [parameters.cohortKey] - Optional cohort-key replacement.
+   * @param {*} [parameters.yearGroupKey] - Optional year-group-key replacement.
    * @param {*} [parameters.courseLength] - Optional validated course length.
    * @param {boolean|null} [parameters.active] - Optional active-state replacement.
    * @returns {Object} Partial ABClass summary from toPartialJSON().
@@ -821,15 +823,16 @@ class ABClassController {
     const existingDocument = collection.findOne({ classId: classId });
 
     if (!existingDocument) {
+      if (Object.hasOwn(patch, 'active')) {
+        this.dbManager.getCollection('abclass_partials');
+        throw new Error('updateABClass: active patch requires an existing class');
+      }
+
       const abClass = this.initialise(classId, {
-        cohort: Object.hasOwn(patch, 'cohort') ? patch.cohort : undefined,
-        yearGroup: Object.hasOwn(patch, 'yearGroup') ? patch.yearGroup : undefined,
+        cohortKey: Object.hasOwn(patch, 'cohortKey') ? patch.cohortKey : undefined,
+        yearGroupKey: Object.hasOwn(patch, 'yearGroupKey') ? patch.yearGroupKey : undefined,
         courseLength: Object.hasOwn(patch, 'courseLength') ? patch.courseLength : undefined,
       });
-
-      if (Object.hasOwn(patch, 'active')) {
-        abClass.active = patch.active;
-      }
 
       this.saveClass(abClass);
       return this._buildClassSummary(abClass);

--- a/src/backend/y_controllers/ABClassController.js
+++ b/src/backend/y_controllers/ABClassController.js
@@ -824,7 +824,6 @@ class ABClassController {
 
     if (!existingDocument) {
       if (Object.hasOwn(patch, 'active')) {
-        this.dbManager.getCollection('abclass_partials');
         throw new Error('updateABClass: active patch requires an existing class');
       }
 

--- a/src/backend/y_controllers/ReferenceDataController.js
+++ b/src/backend/y_controllers/ReferenceDataController.js
@@ -1,5 +1,31 @@
 /* global Cohort, DbManager, Validate, YearGroup */
 
+const ACADEMIC_YEAR_START_MONTH = 9;
+let fallbackKeyCounter = 0;
+
+/**
+ * Generates a stable key for reference-data records.
+ * @returns {string} Stable key.
+ */
+function generateStableKey() {
+  if (typeof Utilities !== 'undefined' && typeof Utilities.getUuid === 'function') {
+    return Utilities.getUuid();
+  }
+
+  fallbackKeyCounter += 1;
+  return `${Date.now()}-${fallbackKeyCounter}`;
+}
+
+/**
+ * Resolves the current academic-year start year.
+ * @param {Date} [now] - Current date reference.
+ * @returns {number} Academic-year start year.
+ */
+function resolveAcademicYearStart(now = new Date()) {
+  const month = now.getMonth() + 1;
+  return month >= ACADEMIC_YEAR_START_MONTH ? now.getFullYear() : now.getFullYear() - 1;
+}
+
 /**
  * ReferenceDataController
  *
@@ -16,7 +42,7 @@ class ReferenceDataController {
 
   /**
    * Retrieves all cohort records from storage.
-   * @returns {Array<{name: string, active: boolean}>} List of all cohorts sorted by name.
+   * @returns {Array<{key: string, name: string, active: boolean, startYear: number, startMonth: number}>} List of all cohorts sorted by name.
    */
   listCohorts() {
     return this._listRecords(this._getConfig('cohort'));
@@ -24,8 +50,8 @@ class ReferenceDataController {
 
   /**
    * Creates a new cohort record in storage.
-   * @param {{name: string, active?: boolean}} record - The cohort data to create.
-   * @returns {{name: string, active: boolean}} The persisted cohort record.
+   * @param {{name: string, active?: boolean, startYear?: number, startMonth?: number}} record - The cohort data to create.
+   * @returns {{key: string, name: string, active: boolean, startYear: number, startMonth: number}} The persisted cohort record.
    */
   createCohort(record) {
     Validate.requireParams({ record }, 'ReferenceDataController.createCohort');
@@ -34,29 +60,29 @@ class ReferenceDataController {
 
   /**
    * Updates an existing cohort record in storage.
-   * @param {{originalName: string, record: {name: string, active?: boolean}}} payload - Object containing the original name and updated record data.
-   * @returns {{name: string, active: boolean}} The updated cohort record.
+   * @param {{key: string, record: {name: string, active?: boolean, startYear?: number, startMonth?: number}}} payload - Object containing key and updated record data.
+   * @returns {{key: string, name: string, active: boolean, startYear: number, startMonth: number}} The updated cohort record.
    */
   updateCohort(payload) {
     Validate.requireParams({ payload }, 'ReferenceDataController.updateCohort');
-    const { originalName, record } = payload;
-    Validate.requireParams({ originalName, record }, 'ReferenceDataController.updateCohort');
-    return this._updateRecord(this._getConfig('cohort'), originalName, record);
+    const { key, record } = payload;
+    Validate.requireParams({ key, record }, 'ReferenceDataController.updateCohort');
+    return this._updateRecord(this._getConfig('cohort'), key, record);
   }
 
   /**
    * Deletes a cohort record from storage.
-   * @param {string} name - The name of the cohort to delete.
+   * @param {string} key - The key of the cohort to delete.
    * @returns {void}
    */
-  deleteCohort(name) {
-    Validate.requireParams({ name }, 'ReferenceDataController.deleteCohort');
-    this._deleteRecord(this._getConfig('cohort'), name);
+  deleteCohort(key) {
+    Validate.requireParams({ key }, 'ReferenceDataController.deleteCohort');
+    this._deleteRecord(this._getConfig('cohort'), key);
   }
 
   /**
    * Retrieves all year group records from storage.
-   * @returns {Array<{name: string}>} List of all year groups sorted by name.
+   * @returns {Array<{key: string, name: string}>} List of all year groups sorted by name.
    */
   listYearGroups() {
     return this._listRecords(this._getConfig('yearGroup'));
@@ -65,7 +91,7 @@ class ReferenceDataController {
   /**
    * Creates a new year group record in storage.
    * @param {{name: string}} record - The year group data to create.
-   * @returns {{name: string}} The persisted year group record.
+   * @returns {{key: string, name: string}} The persisted year group record.
    */
   createYearGroup(record) {
     Validate.requireParams({ record }, 'ReferenceDataController.createYearGroup');
@@ -74,40 +100,37 @@ class ReferenceDataController {
 
   /**
    * Updates an existing year group record in storage.
-   * @param {{originalName: string, record: {name: string}}} payload - Object containing the original name and updated record data.
-   * @returns {{name: string}} The updated year group record.
+   * @param {{key: string, record: {name: string}}} payload - Object containing key and updated record data.
+   * @returns {{key: string, name: string}} The updated year group record.
    */
   updateYearGroup(payload) {
     Validate.requireParams({ payload }, 'ReferenceDataController.updateYearGroup');
-    const { originalName, record } = payload;
-    Validate.requireParams({ originalName, record }, 'ReferenceDataController.updateYearGroup');
-    return this._updateRecord(this._getConfig('yearGroup'), originalName, record);
+    const { key, record } = payload;
+    Validate.requireParams({ key, record }, 'ReferenceDataController.updateYearGroup');
+    return this._updateRecord(this._getConfig('yearGroup'), key, record);
   }
 
   /**
    * Deletes a year group record from storage.
-   * @param {string} name - The name of the year group to delete.
+   * @param {string} key - The key of the year group to delete.
    * @returns {void}
    */
-  deleteYearGroup(name) {
-    Validate.requireParams({ name }, 'ReferenceDataController.deleteYearGroup');
-    this._deleteRecord(this._getConfig('yearGroup'), name);
+  deleteYearGroup(key) {
+    Validate.requireParams({ key }, 'ReferenceDataController.deleteYearGroup');
+    this._deleteRecord(this._getConfig('yearGroup'), key);
   }
 
   /**
-   * Retrieves configuration object for a resource type (cohort or yearGroup).
-   * Contains collection name and model class to use for that resource.
-   *
-   * @param {string} resourceType - Resource type identifier ('cohort' or 'yearGroup').
-   * @returns {{collectionName: string, modelClass: Function}} Configuration object.
-   * @throws {Error} If resourceType is not supported.
-   * @private
+   * Returns config for a supported resource type.
+   * @param {string} resourceType - Supported reference-data resource.
+   * @returns {{collectionName: string, modelClass: Function, partialsReferenceField: string}} Resource config.
    */
   _getConfig(resourceType) {
     if (resourceType === 'cohort') {
       return {
         collectionName: 'cohorts',
         modelClass: Cohort,
+        partialsReferenceField: 'cohortKey',
       };
     }
 
@@ -115,6 +138,7 @@ class ReferenceDataController {
       return {
         collectionName: 'year_groups',
         modelClass: YearGroup,
+        partialsReferenceField: 'yearGroupKey',
       };
     }
 
@@ -122,12 +146,9 @@ class ReferenceDataController {
   }
 
   /**
-   * Retrieves all records from a collection and normalises them.
-   * Records are sorted by name ascending and storage metadata is stripped.
-   *
-   * @param {{collectionName: string, modelClass: Function}} config - Resource configuration.
-   * @returns {Array<Object>} Plain record objects sorted by name.
-   * @private
+   * Lists and sorts records by name.
+   * @param {{collectionName: string}} config - Resource configuration.
+   * @returns {Array<Object>} Sorted plain records.
    */
   _listRecords(config) {
     const collection = this.dbManager.getCollection(config.collectionName);
@@ -137,19 +158,23 @@ class ReferenceDataController {
   }
 
   /**
-   * Creates a new record in the collection.
-   * Validates for duplicates (by normalised name) before insertion.
-   *
+   * Creates and persists a new keyed record.
    * @param {{collectionName: string, modelClass: Function}} config - Resource configuration.
-   * @param {Object} record - The record to create.
-   * @returns {Object} The persisted record as a plain object.
-   * @throws {Error} If a duplicate record (by normalised name) already exists.
-   * @private
+   * @param {Object} record - Incoming record payload.
+   * @returns {Object} Persisted plain record.
    */
   _createRecord(config, record) {
     const collection = this.dbManager.getCollection(config.collectionName);
     const storedRecords = collection.find({});
-    const serialisedRecord = this._buildRecord(config, record);
+    const serialisedRecord = this._buildRecord(config, {
+      ...record,
+      key: generateStableKey(),
+      active: Object.hasOwn(record, 'active') ? record.active : true,
+      startMonth: Object.hasOwn(record, 'startMonth')
+        ? record.startMonth
+        : ACADEMIC_YEAR_START_MONTH,
+      startYear: Object.hasOwn(record, 'startYear') ? record.startYear : resolveAcademicYearStart(),
+    });
     const normalisedName = this._normaliseName(serialisedRecord.name);
 
     if (this._findByNormalisedName(storedRecords, normalisedName)) {
@@ -163,70 +188,86 @@ class ReferenceDataController {
   }
 
   /**
-   * Updates an existing record by name.
-   * Validates for duplicates (by normalised name) before replacement, excluding the original record.
-   *
+   * Updates and persists an existing keyed record.
    * @param {{collectionName: string, modelClass: Function}} config - Resource configuration.
-   * @param {string} originalName - The original record name to find and replace.
-   * @param {Object} record - The updated record data.
-   * @returns {Object} The updated record as a plain object.
-   * @throws {Error} If the original record is not found or a duplicate exists.
-   * @private
+   * @param {string} key - Stable key to update.
+   * @param {Object} record - Update payload.
+   * @returns {Object} Persisted plain record.
    */
-  _updateRecord(config, originalName, record) {
+  _updateRecord(config, key, record) {
     const collection = this.dbManager.getCollection(config.collectionName);
     const storedRecords = collection.find({});
-    const trimmedOriginalName = this._trimName(originalName);
-    const existingRecord = this._findByExactName(storedRecords, trimmedOriginalName);
+    const trimmedKey = this._trimKey(key);
+    const existingRecord = this._findByKey(storedRecords, trimmedKey);
 
     if (!existingRecord) {
-      throw new Error(`${config.collectionName} record not found: ${trimmedOriginalName}`);
+      throw new Error(`${config.collectionName} record not found: ${trimmedKey}`);
     }
 
-    const serialisedRecord = this._buildRecord(config, record);
+    const serialisedRecord = this._buildRecord(config, {
+      ...record,
+      key: trimmedKey,
+      active: Object.hasOwn(record, 'active') ? record.active : existingRecord.active,
+      startYear: Object.hasOwn(record, 'startYear') ? record.startYear : existingRecord.startYear,
+      startMonth: Object.hasOwn(record, 'startMonth')
+        ? record.startMonth
+        : existingRecord.startMonth,
+    });
     const normalisedReplacementName = this._normaliseName(serialisedRecord.name);
     const conflictingRecord = this._findByNormalisedName(storedRecords, normalisedReplacementName);
 
-    if (conflictingRecord && conflictingRecord.name !== existingRecord.name) {
+    if (conflictingRecord && conflictingRecord.key !== existingRecord.key) {
       throw new Error(`Duplicate ${config.collectionName} record: ${serialisedRecord.name}`);
     }
 
-    collection.replaceOne({ name: trimmedOriginalName }, serialisedRecord);
+    collection.replaceOne({ key: trimmedKey }, serialisedRecord);
     collection.save();
 
     return this._toPlainObject(serialisedRecord);
   }
 
   /**
-   * Deletes an existing record by name.
-   *
-   * @param {{collectionName: string}} config - Resource configuration.
-   * @param {string} name - The record name to find and delete.
-   * @throws {Error} If the record is not found.
-   * @private
+   * Deletes a keyed record if unused by class partials.
+   * @param {{collectionName: string, partialsReferenceField: string}} config - Resource configuration.
+   * @param {string} key - Stable key to delete.
+   * @returns {void}
    */
-  _deleteRecord(config, name) {
+  _deleteRecord(config, key) {
     const collection = this.dbManager.getCollection(config.collectionName);
     const storedRecords = collection.find({});
-    const trimmedName = this._trimName(name);
-    const existingRecord = this._findByExactName(storedRecords, trimmedName);
+    const trimmedKey = this._trimKey(key);
+    const existingRecord = this._findByKey(storedRecords, trimmedKey);
 
     if (!existingRecord) {
-      throw new Error(`${config.collectionName} record not found: ${trimmedName}`);
+      throw new Error(`${config.collectionName} record not found: ${trimmedKey}`);
     }
 
-    collection.deleteOne({ name: trimmedName });
+    const partialsCollection = this.dbManager.getCollection('abclass_partials');
+    const partials = partialsCollection.find({});
+    const isInUse = partials.some(
+      (partial) =>
+        partial &&
+        typeof partial === 'object' &&
+        partial[config.partialsReferenceField] === trimmedKey
+    );
+
+    if (isInUse) {
+      const error = new Error(
+        `${config.collectionName} record is referenced by one or more classes`
+      );
+      error.reason = 'IN_USE';
+      throw error;
+    }
+
+    collection.deleteOne({ key: trimmedKey });
     collection.save();
   }
 
   /**
-   * Builds a record by deserialising from JSON and reserialising.
-   * Ensures the record conforms to the model class serialisation format.
-   *
+   * Builds a canonical serialised record through the model contract.
    * @param {{modelClass: Function}} config - Resource configuration.
-   * @param {Object} record - The record data to build.
-   * @returns {Object} The built (serialised) record.
-   * @private
+   * @param {Object} record - Raw record data.
+   * @returns {Object} Canonical serialised record.
    */
   _buildRecord(config, record) {
     const modelInstance = config.modelClass.fromJSON(record);
@@ -234,63 +275,59 @@ class ReferenceDataController {
   }
 
   /**
-   * Trims whitespace from a name string.
-   *
-   * @param {string} name - The name to trim.
-   * @returns {string} The trimmed name.
-   * @throws {TypeError} If name is not a string.
-   * @private
+   * Trims and validates a key.
+   * @param {string} key - Key to trim.
+   * @returns {string} Trimmed key.
    */
-  _trimName(name) {
-    Validate.requireParams({ name }, 'ReferenceDataController._trimName');
+  _trimKey(key) {
+    Validate.requireParams({ key }, 'ReferenceDataController._trimKey');
+
+    if (!Validate.isString(key)) {
+      throw new TypeError('key must be a string.');
+    }
+
+    return key.trim();
+  }
+
+  /**
+   * Normalises a name for duplicate checks.
+   * @param {string} name - Name to normalise.
+   * @returns {string} Lower-case trimmed name.
+   */
+  _normaliseName(name) {
+    Validate.requireParams({ name }, 'ReferenceDataController._normaliseName');
+
     if (!Validate.isString(name)) {
       throw new TypeError('name must be a string.');
     }
-    return name.trim();
+
+    return name.trim().toLowerCase();
   }
 
   /**
-   * Normalises a name by trimming and converting to lowercase for comparison purposes.
-   *
-   * @param {string} name - The name to normalise.
-   * @returns {string} The normalised name.
-   * @private
+   * Finds a record by key.
+   * @param {Array<Object>} records - Source records.
+   * @param {string} key - Key to match.
+   * @returns {Object|null} Matching record.
    */
-  _normaliseName(name) {
-    return this._trimName(name).toLowerCase();
+  _findByKey(records, key) {
+    return records.find((record) => this._trimKey(record.key) === key) || null;
   }
 
   /**
-   * Finds a record by exact (trimmed) name match from a list.
-   *
-   * @param {Array<Object>} records - List of records to search.
-   * @param {string} name - The exact name to find (with trimming).
-   * @returns {Object|null} The matching record or null if not found.
-   * @private
-   */
-  _findByExactName(records, name) {
-    return records.find((record) => this._trimName(record.name) === name) || null;
-  }
-
-  /**
-   * Finds a record by normalised name match from a list.
-   * Useful for case-insensitive duplicate detection.
-   *
-   * @param {Array<Object>} records - List of records to search.
-   * @param {string} normalisedName - The normalised name to find.
-   * @returns {Object|null} The matching record or null if not found.
-   * @private
+   * Finds a record by normalised name.
+   * @param {Array<Object>} records - Source records.
+   * @param {string} normalisedName - Normalised name.
+   * @returns {Object|null} Matching record.
    */
   _findByNormalisedName(records, normalisedName) {
     return records.find((record) => this._normaliseName(record.name) === normalisedName) || null;
   }
 
   /**
-   * Converts a record to a plain object, stripping storage-only metadata (e.g. _id).
-   *
-   * @param {Object} record - The record to convert.
-   * @returns {Object} Plain object without storage metadata.
-   * @private
+   * Removes storage-only metadata from a record.
+   * @param {Object} record - Stored record.
+   * @returns {Object} Plain record.
    */
   _toPlainObject(record) {
     const plainObject = {};
@@ -305,11 +342,9 @@ class ReferenceDataController {
   }
 
   /**
-   * Sorts records by name using merge sort algorithm.
-   *
+   * Sorts records by name using merge sort.
    * @param {Array<Object>} records - Records to sort.
-   * @returns {Array<Object>} Sorted records by name ascending.
-   * @private
+   * @returns {Array<Object>} Sorted records.
    */
   _sortRecordsByName(records) {
     const minimumMergeSortPartitionSize = 2;
@@ -319,39 +354,28 @@ class ReferenceDataController {
     }
 
     const midpoint = Math.floor(records.length / minimumMergeSortPartitionSize);
-    const leftRecords = [];
-    const rightRecords = [];
+    const left = this._sortRecordsByName(records.slice(0, midpoint));
+    const right = this._sortRecordsByName(records.slice(midpoint));
 
-    for (const [index, record] of records.entries()) {
-      if (index < midpoint) {
-        leftRecords.push(record);
-      } else {
-        rightRecords.push(record);
-      }
-    }
-
-    return this._mergeSortedRecords(
-      this._sortRecordsByName(leftRecords),
-      this._sortRecordsByName(rightRecords)
-    );
+    return this._mergeByName(left, right);
   }
 
   /**
-   * Merges two sorted record arrays by name in ascending order.
-   * Used by merge sort to combine sorted partitions.
-   *
+   * Merges two sorted record lists by name.
    * @param {Array<Object>} leftRecords - Left sorted partition.
    * @param {Array<Object>} rightRecords - Right sorted partition.
    * @returns {Array<Object>} Merged sorted records.
-   * @private
    */
-  _mergeSortedRecords(leftRecords, rightRecords) {
+  _mergeByName(leftRecords, rightRecords) {
     const mergedRecords = [];
     let leftIndex = 0;
     let rightIndex = 0;
 
     while (leftIndex < leftRecords.length && rightIndex < rightRecords.length) {
-      if (leftRecords[leftIndex].name.localeCompare(rightRecords[rightIndex].name) <= 0) {
+      const leftName = leftRecords[leftIndex].name;
+      const rightName = rightRecords[rightIndex].name;
+
+      if (leftName.localeCompare(rightName) <= 0) {
         mergedRecords.push(leftRecords[leftIndex]);
         leftIndex += 1;
       } else {
@@ -374,6 +398,6 @@ class ReferenceDataController {
   }
 }
 
-if (typeof module !== 'undefined') {
+if (typeof module !== 'undefined' && module.exports) {
   module.exports = ReferenceDataController;
 }

--- a/src/backend/z_Api/abclassMutations.js
+++ b/src/backend/z_Api/abclassMutations.js
@@ -106,8 +106,8 @@ function validateUpsertABClassParameters(parameters) {
   requireParameters(
     {
       classId: parameters.classId,
-      cohort: parameters.cohort,
-      yearGroup: parameters.yearGroup,
+      cohortKey: parameters.cohortKey,
+      yearGroupKey: parameters.yearGroupKey,
       courseLength: parameters.courseLength,
     },
     methodName

--- a/src/backend/z_Api/referenceData.js
+++ b/src/backend/z_Api/referenceData.js
@@ -45,11 +45,11 @@ function updateCohort(parameters) {
  * Handler that deletes a cohort record by name.
  *
  * @param {Object} parameters - Request payload.
- * @param {{name: string}} parameters - The cohort name to delete.
+ * @param {{key: string}} parameters - The cohort key to delete.
  * @returns {void}
  */
 function deleteCohort(parameters) {
-  return getController().deleteCohort(parameters.name);
+  return getController().deleteCohort(parameters.key);
 }
 
 /**
@@ -88,11 +88,11 @@ function updateYearGroup(parameters) {
  * Handler that deletes a year group record by name.
  *
  * @param {Object} parameters - Request payload.
- * @param {{name: string}} parameters - The year group name to delete.
+ * @param {{key: string}} parameters - The year group key to delete.
  * @returns {void}
  */
 function deleteYearGroup(parameters) {
-  return getController().deleteYearGroup(parameters.name);
+  return getController().deleteYearGroup(parameters.key);
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/frontend/src/App.spec.tsx
+++ b/src/frontend/src/App.spec.tsx
@@ -705,7 +705,7 @@ describe('App', () => {
       expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
     });
     expect(consoleDebugSpy.mock.calls[0]?.[0]).toBe(
-      'features/auth/AppAuthGate.classPartialsWarmup'
+      'features/auth/AppAuthGate.startupWarmup'
     );
   });
 });

--- a/src/frontend/src/navigation/appNavigation.spec.tsx
+++ b/src/frontend/src/navigation/appNavigation.spec.tsx
@@ -1,7 +1,9 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { AppNavigationKey } from './appNavigation';
 import { navigationItems, pageRenderers } from './appNavigation';
 import { pageExpectations } from '../test/pageExpectations';
+import { createAppQueryClient } from '../query/queryClient';
 
 describe('app navigation config', () => {
   it('contains exact four page entries with stable keys', () => {
@@ -37,7 +39,10 @@ describe('app navigation config', () => {
 
   it('page switch map resolves keys to correct component', () => {
     for (const { heading, key, summary } of pageExpectations) {
-      const { unmount } = render(<>{pageRenderers[key]()}</>);
+      const queryClient = createAppQueryClient();
+      const { unmount } = render(
+        <QueryClientProvider client={queryClient}>{pageRenderers[key]()}</QueryClientProvider>
+      );
 
       expect(screen.getByRole('heading', { level: 2, name: heading })).toBeInTheDocument();
       expect(screen.getByText(summary)).toBeInTheDocument();

--- a/src/frontend/src/pages/pages.spec.tsx
+++ b/src/frontend/src/pages/pages.spec.tsx
@@ -1,6 +1,8 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { ComponentType } from 'react';
 import { pageExpectations } from '../test/pageExpectations';
+import { createAppQueryClient } from '../query/queryClient';
 
 type AppNavigationKey = (typeof pageExpectations)[number]['key'];
 
@@ -29,7 +31,13 @@ describe('page components', () => {
     async ({ heading, key, summary }) => {
       const PageComponent = await pageComponentLoaders[key]();
 
-      render(<PageComponent />);
+      const queryClient = createAppQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PageComponent />
+        </QueryClientProvider>
+      );
 
       expect(screen.getByRole('heading', { level: 2, name: heading })).toBeInTheDocument();
       expect(screen.getByText(summary)).toBeInTheDocument();


### PR DESCRIPTION
### Motivation

- Introduce stable keys for cohort and year-group reference data and migrate ABClass to reference those keys rather than free-text values.
- Enrich cohort model with academic-year metadata (startYear/startMonth) and make YearGroup/Cohort models consistent with a key+name contract.
- Harden CRUD behavior for reference data (duplicate detection by name, deletion prevention when in-use) and update API/controller surfaces to use keys.

### Description

- Replaced `cohort`/`yearGroup` fields with `cohortKey`/`yearGroupKey` across `ABClass`, `ABClassController`, API handlers, and serialization, and added optional `cohortLabel` and `yearGroupLabel` to `ABClass` partial payloads.
- Extended `Cohort` model to include `key`, `startYear`, and `startMonth` with validation and accessor methods, and added `key` handling to `YearGroup` model with validation and JSON contract changes.
- Reworked `ReferenceDataController` to create and manage keyed records, generate stable keys (`generateStableKey`), default/resolve academic year start, prevent deletion of reference records that are referenced by class partials, and adjust listing/updating logic to operate on keys; also improved record-building and sorting utilities.
- Adjusted ABClassController to accept and persist `cohortKey`/`yearGroupKey`, updated patch building and application, and added a check that prevents applying an `active` patch for non-existing classes.
- Updated API handler signatures (`referenceData.js`, `abclassMutations.js`) and frontend tests to reflect the new keys and query client provider usage, and renamed a debug message expectation in a test.

### Testing

- Ran backend unit tests and controller-level tests (reference-data and ABClass flows); all updated tests passed.
- Ran frontend Jest/React Testing Library specs updated to wrap pages with `QueryClientProvider`; the modified tests passed.
- Performed integration-style validation for reference-data create/update/delete and class upsert/patch workflows using the updated keyed API surface with expected results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb95f43fc832982bb7b04bfe72ccf)