### PR TITLE
Docs: refine frontend/backend action plans for Classes workflows and googleClassrooms prefetch

### DIFF
--- a/ACTION_PLAN.md
+++ b/ACTION_PLAN.md
@@ -81,9 +81,9 @@ The split above matches the largest codebase seams and the highest-risk gaps fou
 
 ### Bulk-workflow risks
 
-- `updateABClass` still behaves like an upsert for missing classes.
+- Workstream 1 hardened backend validation for missing-class `active` updates; Workstream 4 must preserve this behaviour while adding bulk flows.
 - There is no shared batch mutation engine yet.
-- The current test harness does not yet prove submitted-row ordering or partial-failure aggregation.
+- The shared Classes harness exists, but Workstream 4 still needs explicit bulk-journey assertions for submitted-row ordering and partial-failure aggregation.
 
 ### Reference-data modal and sign-off risks
 

--- a/ACTION_PLAN_2_FRONTEND_DATA_AND_QUERY.md
+++ b/ACTION_PLAN_2_FRONTEND_DATA_AND_QUERY.md
@@ -77,7 +77,7 @@ Acceptance:
 - Add `googleClassrooms.zod.ts` and `googleClassroomsService.ts`.
 - Add `queryKeys.googleClassrooms()`.
 - Add `getGoogleClassroomsQueryOptions()`.
-- Trigger this dataset prefetch when the Settings page loads.
+- Trigger this dataset prefetch when the Classes tab is entered.
 - Keep this dataset prefetch non-blocking and outside startup warm-up.
 
 Implementation detail:
@@ -91,7 +91,7 @@ Implementation detail:
    - `queryKeys.googleClassrooms()`
    - `getGoogleClassroomsQueryOptions()`
 4. Prefetch trigger location
-   - Trigger `queryClient.prefetchQuery(getGoogleClassroomsQueryOptions())` when the Settings page loads.
+   - Trigger `queryClient.prefetchQuery(getGoogleClassroomsQueryOptions())` when the Classes tab is entered.
    - Keep this prefetch fire-and-forget (non-blocking), with no startup gating dependency.
 5. Error handling
    - Prefetch failures are logged for diagnostics and surfaced only where the Classes experience consumes the dataset.

--- a/ACTION_PLAN_4_BULK_CLASS_WORKFLOWS.md
+++ b/ACTION_PLAN_4_BULK_CLASS_WORKFLOWS.md
@@ -19,10 +19,10 @@
 
 ## Exploration findings to account for
 
-- `updateABClass` still behaves like an upsert for missing classes.
+- Workstream 1 already hardened backend mutation validation for `active` updates on missing classes; keep this behaviour covered and do not regress it while implementing bulk flows.
 - There is no shared mutation engine yet.
 - Existing nearby mutation patterns collapse mutation failure and refresh failure into a single generic error state.
-- The harness is not yet proving submitted-row-order aggregation.
+- The shared Classes harness exists; Workstream 4 should extend its queue/helpers to prove submitted-row-order aggregation for bulk journeys.
 
 ## Work packages
 
@@ -34,6 +34,7 @@ Acceptance:
 - Result aggregation preserves submitted-row order, not promise-resolution order.
 - Failed rows remain selected when still present.
 - Single-row edits use the same path as bulk edits.
+- Selection resets on Classes-tab entry and re-entry.
 - No feature-specific retry loop is added on top of `callApi(...)`.
 
 Tests:
@@ -48,6 +49,8 @@ Acceptance:
 - Create uses `cohortKey`, `yearGroupKey`, and `courseLength`, defaulting `courseLength` to `1`.
 - Delete copy explicitly states that full and partial records are removed.
 - Active/inactive flows reject ineligible rows before opening.
+- Backend-authoritative validation remains enforced so active/inactive updates cannot create missing classes.
+- After destructive mutation refreshes, removed/invisible row keys are cleared from selection.
 
 Tests:
 
@@ -79,6 +82,19 @@ Acceptance:
 - Partial-success modals stay open briefly, then hand off to persistent summary alerts.
 - If the mutation succeeds but required re-fetch fails, the UI reports success plus refresh-needed guidance.
 - Required refresh failure suppresses stale table data.
+- Google Classroom data remains outside required post-mutation refresh paths; the v1 contract keeps this dataset on Classes-tab entry prefetch only.
+
+## Deferred closure map (Workstream 3 -> Workstream 4)
+
+Use this table as a completion gate so Workstream 3 deferred acceptance criteria close explicitly during Workstream 4:
+
+| Workstream 3 deferred item                                        | Workstream 4 closure section                        |
+| ----------------------------------------------------------------- | --------------------------------------------------- |
+| Selection reset on Classes-tab re-entry                           | 4.1 Shared batch mutation engine                    |
+| Selection clearing after destructive mutation refresh             | 4.2 Bulk create, delete, and active-state flows     |
+| Non-blocking partial-refresh warning semantics                    | 4.4 Mutation summary and refresh-failure UX         |
+| Success-plus-refresh-needed guidance with stale-table suppression | 4.4 Mutation summary and refresh-failure UX         |
+| Playwright coverage for deferred refresh-failure UX               | 4.4 tests (`classes-crud-mutation-summary.spec.ts`) |
 
 Tests:
 
@@ -90,11 +106,13 @@ Tests:
 
 - Rewrite backend/controller/API red tests first so they stop encoding create-on-missing update behaviour.
 - Keep modal shells thin; put dispatch and result mapping in shared helpers/hooks.
+- Extend the existing shared Classes CRUD harness/helpers; do not create a second harness.
 
 ## Section checks
 
 - `npm test -- tests/controllers/abclass-upsert-update.test.js tests/controllers/abclass-delete.test.js tests/api/abclassMutations.test.js`
 - `npm run frontend:test -- src/features/classes/batchMutationEngine.spec.ts src/features/classes/bulkCreate.spec.tsx src/features/classes/bulkDelete.spec.tsx src/features/classes/bulkActiveState.spec.tsx src/features/classes/bulkSetCohort.spec.tsx src/features/classes/bulkSetYearGroup.spec.tsx src/features/classes/bulkSetCourseLength.spec.tsx src/features/classes/mutationSummary.spec.tsx src/features/classes/refetchFailureState.spec.tsx`
 - `npm run frontend:test:e2e -- e2e-tests/classes-crud-bulk-core.spec.ts e2e-tests/classes-crud-bulk-cohort.spec.ts e2e-tests/classes-crud-bulk-year-group.spec.ts e2e-tests/classes-crud-bulk-course-length.spec.ts e2e-tests/classes-crud-mutation-summary.spec.ts`
+- `npm run lint`
 - `npm run frontend:lint`
 - `npm exec tsc -- -b src/frontend/tsconfig.json`


### PR DESCRIPTION
### Motivation

- Clarify implementation and acceptance criteria for the Classes bulk-workflow workstreams and avoid regressing backend validation for missing-class active updates.
- Move the `googleClassrooms` prefetch trigger to a more precise UI entrypoint (Classes tab) and document non-blocking prefetch behaviour.
- Record additional UX requirements around selection reset and refresh-failure handling to drive implementation and test coverage.

### Description

- Updated `ACTION_PLAN.md`, `ACTION_PLAN_2_FRONTEND_DATA_AND_QUERY.md`, and `ACTION_PLAN_4_BULK_CLASS_WORKFLOWS.md` to reflect that `googleClassrooms` prefetch is triggered when the Classes tab is entered rather than on Settings page load.
- Annotated that Workstream 1 hardened backend validation for `active` updates on missing classes must be preserved during Workstream 4 bulk flows and clarified related acceptance criteria.
- Added acceptance criteria requiring selection resets on Classes-tab entry and ensured selection clearing after destructive refreshes is specified for bulk flows.
- Added a deferred closure map table in the Workstream 4 plan to link Workstream 3 deferred items to Workstream 4 closure sections and updated test/validation command lists (including `npm run lint`).

### Testing

- No automated tests were executed as part of this documentation-only change.
- Validation commands were updated in the plans and include `npm run lint`, `npm run frontend:lint`, and test targets such as `npm run frontend:test` and `npm run frontend:test:e2e` for downstream verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37f13148883299302f880f099e60e)