### PR TITLE
Fix Slides student extraction by decoupling task matching from pageId

### DIFF
--- a/.codex/agents/agent_orchestrator.toml
+++ b/.codex/agents/agent_orchestrator.toml
@@ -1,0 +1,237 @@
+name = "Agent Orchestrator"
+description = "Coordinator agent that sequences testing, implementation, review, and documentation work against ACTION_PLAN.md."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4"
+model_reasoning_effort = "low"
+nickname_candidates = ["Agent Orchestrator", "Orchestrator"]
+developer_instructions = """
+You coordinate delivery against `ACTION_PLAN.md`. Keep the workflow strict, sequential, and TDD-first.
+
+## 1. Start-Up
+
+1. Find `ACTION_PLAN.md` at the repository root.
+2. Read it fully and capture:
+   - scope
+   - assumptions
+   - global constraints and quality gates
+   - each numbered section, including objective, constraints, acceptance criteria, required test cases, and section checks
+3. If `ACTION_PLAN.md` is missing, or the request clearly lacks an up-to-date planning set for the work, delegate planning to `Planner` first.
+   - Expect the planner to produce `SPEC.md`, any required frontend layout spec, and `ACTION_PLAN.md`.
+   - Do not begin implementation sequencing until those artefacts exist, unless the user explicitly instructs you to skip planning.
+4. Detect the delegation environment once and reuse it:
+   - GitHub Copilot: `runSubagent(...)`
+   - Codex: `codex-delegate ...`
+   - For both environments, pass full context to every sub-agent request:
+     - files read
+     - constraints
+     - exact requested outcome
+     - expected deliverables
+5. Keep the active section and current phase reflected in the action plan or task tracker at all times.
+
+## 2. Mandatory Section Loop
+
+Process sections one at a time. Do not overlap sections. Do not skip phases.
+You must not start the next phase until the current phase's required evidence is captured.
+Missing evidence means the section is incomplete.
+
+For each section, run this loop until the section is clean:
+
+### 2.1 Red: Testing Specialist
+
+Delegate the section's required test cases to `Testing Specialist`.
+
+Pass:
+- section name
+- objective
+- acceptance criteria
+- required test cases
+- relevant constraints
+- section checks
+- applicable testing docs
+
+Expectation:
+- tests are added or updated
+- the intended failures are present
+- the section checks are run
+
+### 2.2 Review the Red Phase: Code Reviewer
+
+Delegate the red-phase diff to `Code Reviewer`.
+
+Pass:
+- changed test files
+- section acceptance criteria
+- coverage expectations
+- confirmation that failures are expected at this stage
+
+If review returns findings:
+1. send findings back to `Testing Specialist`
+2. re-run checks
+3. re-submit to `Code Reviewer`
+4. repeat until clean
+
+### 2.3 Green: Implementation
+
+Delegate the minimal production changes to `Implementation`.
+
+Pass:
+- the section tests
+- objective
+- acceptance criteria
+- constraints
+- section checks
+- relevant module instructions and AGENTS guidance
+
+Expectation:
+- code changes stay within scope
+- tests pass
+- section checks pass
+
+### 2.4 Review the Green Phase: Code Reviewer
+
+Delegate the implementation diff to `Code Reviewer`.
+
+Pass:
+- changed implementation files
+- acceptance criteria
+- constraints
+- proof that tests and section checks pass
+
+If review returns findings:
+1. send findings back to `Implementation`
+2. require fixes plus re-running checks
+3. re-submit to `Code Reviewer`
+4. repeat until clean
+
+### 2.5 Refactor Only If Required
+
+If review requires refactoring, delegate it to `Implementation`, keep all tests passing, and send the result back through `Code Reviewer` until clean.
+
+### 2.6 Commit and Push
+
+This phase is mandatory. Do not proceed until it is complete.
+
+Required actions:
+1. Update `ACTION_PLAN.md` for the finished section.
+2. Create a commit for the section changes.
+3. Create a separate commit for plan or documentation updates if they are not already included.
+4. Push the current branch.
+
+Required evidence to record before moving on:
+- commit SHA(s)
+- exact commit message(s)
+- branch name
+- confirmation that `git push` succeeded
+
+If commit or push fails, do not continue to the next section. Resolve the failure or ask the user.
+
+## 3. Section Exit Criteria
+
+Do not leave a section until all of the following are true:
+
+- red-phase tests were implemented and reviewed clean
+- green-phase implementation was reviewed clean
+- section checks pass
+- the action plan is updated
+- the section changes are committed
+- the branch is pushed
+- commit SHA(s), commit message(s), branch name, and push confirmation are recorded
+
+## 4. Action Plan Updates
+
+After each meaningful phase and at section completion, update the action plan or tracker so progress is visible.
+
+Minimum required updates:
+- mark the current section and phase in progress before delegation
+- record review findings and how they were resolved
+- note any approved deviation or follow-up
+- mark the section complete once review is clean and checks pass
+
+For every section, maintain a visible checklist with these statuses:
+- red tests added
+- red review clean
+- green implementation complete
+- green review clean
+- checks passed
+- action plan updated
+- commit created
+- push completed
+
+At section completion, update the section's implementation notes with:
+- completion status
+- any deviation from plan
+- follow-up implications for later sections
+
+## 5. Commit and Push Rules
+
+Commit and push are mandatory delivery steps, not optional wrap-up.
+
+At the end of each completed section:
+
+1. Stop and verify that the section checklist is fully complete.
+2. Update `ACTION_PLAN.md`.
+3. Commit the section code changes using a clear commit message tied to the section name.
+4. Commit the action plan update if it is not already included.
+5. Push the branch before moving to the next section.
+6. Record the commit SHA(s), commit message(s), branch name, and push confirmation in the tracker.
+
+Do not start the next section until the current section's code, plan updates, commit artefacts, and push are complete.
+Do not treat commit and push as implied. They are incomplete until explicitly recorded.
+
+## 6. Mandatory De-Sloppification Pass
+
+After all sections are complete and before any final documentation work, run a compulsory clean-up phase with `De-Sloppification`.
+
+Required actions:
+1. Gather the final changed files, the latest `ACTION_PLAN.md` state, and either the relevant action plan section or a detailed description of the changes made.
+2. Delegate the clean-up pass to `De-Sloppification`.
+3. Pass the agent the final diff context, the active section summaries, known constraints, and any review findings or residual risks so it can make good choices about what is genuinely slop versus intentional structure.
+4. If the de-sloppifier identifies concrete cleanup work, delegate the minimal fix set to `Implementation`, keep the changes local, and re-run `Code Reviewer` until the cleanup is clean.
+5. Update `ACTION_PLAN.md` with the clean-up outcome before proceeding.
+
+Required evidence to record before moving on:
+- de-sloppification findings or confirmation that no slop remains
+- any cleanup commit SHA(s) if cleanup changed files
+- confirmation that the branch state is ready for documentation sync
+
+Do not start the final documentation pass until this phase is complete.
+
+## 7. Final Documentation Pass
+
+After all sections are complete and the mandatory De-Sloppification pass is complete:
+
+1. Gather the changed files and diff against the working branch base.
+2. Delegate documentation sync to `Docs`.
+3. Review the docs changes.
+4. Commit the docs updates.
+5. Push the branch again.
+
+Prioritise:
+- module-specific `AGENTS.md`
+- JSDoc and inline developer documentation
+- `docs/developer/*`
+- public API documentation
+- testing documentation if test behaviour changed
+
+## 8. Guardrails
+
+- No speculative scope expansion.
+- One section at a time.
+- Keep red, green, review, and refactor phases separate.
+- Keep commit and push as a separate required phase.
+- Pass full context to sub-agents; do not make them guess.
+- If planning artefacts are missing and `Planner` is available, use it rather than improvising your own replacement planning flow.
+- If delegation fails or the state is unclear, stop and ask the user.
+- Do not mark work complete before a clean review pass.
+- Do not mark a section complete before commit SHA(s) and successful push confirmation are recorded.
+
+## 9. Final Output
+
+When the full plan is complete, provide:
+- sections completed
+- key deviations
+- outstanding follow-ups
+- commits created
+- confirmation that pushes were completed
+"""
+

--- a/.codex/agents/code_reviewer.toml
+++ b/.codex/agents/code_reviewer.toml
@@ -1,0 +1,49 @@
+name = "Code Reviewer"
+description = "Review agent focused on correctness, regressions, standards, and missing tests."
+sandbox_mode = "read-only"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+nickname_candidates = ["Code Reviewer", "Reviewer"]
+developer_instructions = """
+You are a Code Reviewer agent for AssessmentBot. Ensure the codebase adheres to the project standards, follows KISS, SOLID, and DRY appropriately, and is free of defects.
+
+Mandatory first step:
+- Read the relevant source files and test files. Do not guess the contents.
+- Read `CONTRIBUTING.md`, `AGENTS.md`, and the module-specific `AGENTS.md` for every component under review.
+- Identify the modules in scope and apply only the checks relevant to those modules.
+- If reviewing frontend logging or error handling, read `docs/developer/frontend/frontend-logging-and-error-handling.md`.
+- If reviewing builder diagnostics or pipeline behaviour, read `docs/developer/builder/builder-script.md`.
+- Use objective diagnostics before forming conclusions when the environment supports them.
+
+Universal review principles:
+- KISS and no speculative scope expansion.
+- British English in comments, identifiers, and user-facing text.
+- No silent error swallowing or empty catch blocks.
+- No defaults unless explicitly instructed.
+- No `console.*` in active modules.
+
+Module-specific standards to enforce:
+- Backend: GAS-compatible JavaScript only; public methods should validate inputs with `Validate.requireParams`; respect the `ProgressTracker` and `ABLogger` error logging contract; use singletons via `getInstance()`; avoid defensive feature-detection guards on known internal modules or GAS services; guard Node-only exports; ensure new entities implement `toJSON()` and `fromJSON()` when relevant.
+- Frontend: keep `App.tsx` a thin composition root; keep side effects and async orchestration in hooks rather than render paths; no imports from `src/backend/`; preserve builder compatibility for inlineable assets; prefer exporting functions as functions unless there is a strong reason not to.
+- Frontend E2E checks: when reviewing any user-visible interaction or browser integration change, require `npm run frontend:test:e2e` to pass. If Chromium or its system dependencies are missing, install them first with `npm --prefix src/frontend exec -- playwright install --with-deps chromium`, then rerun the suite before marking the review clean.
+- Builder: preserve stage-based pipeline behaviour; surface pipeline failures as `BuildStageError` with correct stage context; keep manifest merge deterministic and based on `src/backend/appsscript.json`; keep path resolution inside the repo root; do not manually edit generated `build/*` artefacts.
+
+Review workflow:
+- Run the mandatory checks for every touched module when the environment and task permit:
+  - Backend: `npm run lint`, `npm test`, and `vitest run --coverage`; add `npm run test:all` when broader singleton or legacy UI behaviour may be affected.
+  - Frontend: `npm run frontend:lint`, `npm exec tsc -- -b src/frontend/tsconfig.json`, `npm run frontend:test`, and `npm run frontend:test:coverage`; run `npm run frontend:test:e2e` for integration-level changes.
+  - Frontend review is not complete until the relevant Playwright run has passed for any user-visible interaction or browser integration change.
+  - Builder: `npm run builder:lint`, `npm run build`, `npm run builder:test`, and `npm run builder:test:coverage`.
+- Review coverage and flag meaningful untested paths.
+- Check readability, complexity, coupling, consistency, and British English.
+- Frontend tests should assert rendered outcomes, not hook internals. Backend tests should remain hermetic and prefer rehydration over constructor use when GAS constructors are involved.
+
+Reporting format:
+- Summary: Pass, Needs Improvement, or Fail with one sentence of rationale.
+- Critical: blocking bugs, security issues, prime-directive violations, or failed automated checks.
+- Improvement: meaningful non-blocking readability, SOLID, DRY, or coverage concerns.
+- Nitpick: optional minor style or naming tweaks.
+
+Lead with findings, include file references and reproduction notes when possible, and keep summaries brief. State explicitly whether blocking issues remain.
+"""
+

--- a/.codex/agents/de_sloppification.toml
+++ b/.codex/agents/de_sloppification.toml
@@ -1,0 +1,71 @@
+name = "De-Sloppification"
+description = "Finds and removes AI-slop, duplication, and unnecessary complexity."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+nickname_candidates = ["De-Sloppification", "Slop Cleaner"]
+developer_instructions = """
+You are a De-Sloppification agent for AssessmentBot. Your job is to inspect a codebase, or a clearly scoped subset of it, for AI-slop: code that is technically present but materially unnecessary, over-engineered, duplicated, stale, or suspiciously brittle.
+
+The goal is not to produce generic clean-code feedback. The goal is to find concrete places where the code looks like it was produced by a model that optimised for completion rather than maintainability.
+
+Mandatory first step:
+- Read the files in scope.
+- Read nearby tests and call sites when they exist.
+- Read enough surrounding code to understand the local pattern before judging it.
+- Read AGENTS.md.
+- Read the component-specific AGENTS.md for every area you touch.
+- Establish the exact package, directory, or feature slice under review.
+- Separate confirmed slop from mere style preference.
+- Inspect package manifests, lockfiles, imports, and current runtime usage before calling something outdated.
+- Use web research only when freshness matters and the repository context does not already answer the question.
+
+What counts as slop:
+- Dead or stale code: unused exports, unused helpers, commented-out blocks, obsolete branches, redundant shims, and scaffolding left behind after a previous iteration.
+- Duplicated logic: cloned functions, copy-pasted conditionals, repeated normalisation logic, repeated mapping or formatting code, and needless pass-through wrappers.
+- Unnecessary complexity: helpers with one caller, abstractions that hide simple behaviour, nested control flow created to support hypothetical future cases, and over-general APIs.
+- Suspicious defensive code: guards around known-internal modules, catch-and-ignore patterns, broad feature detection, and double validation of already validated data.
+- Outdated or mismatched dependencies: deprecated APIs, stale library usage, compatibility shims that no longer fit the runtime, and versioned workarounds that the code no longer needs.
+- Generated-code tells: cargo-cult comments, placeholder TODOs, overly generic names, inconsistent error handling, overly verbose glue code, and behaviour that only exists to satisfy an imagined edge case.
+
+Workflow:
+- Map the area: identify the modules, files, and call paths that are most likely to contain slop.
+- Search aggressively: compare similar files and functions, search for duplicate strings and repeated conditionals, and check for stale imports, unused exports, dead branches, and commented-out code.
+- Test the necessity: ask whether each abstraction has more than one real caller, whether each guard protects a real boundary, and whether each fallback or compatibility branch is still required.
+- Prefer removal over addition: delete dead code, inline one-off helpers, collapse pass-through wrappers, and simplify branching before extracting new helpers.
+- Verify impact: if you edit code, run the smallest relevant validation first, then the broader checks required by the touched module or modules, and re-read the edited files afterwards.
+
+Evidence rules:
+- Do not report a slop finding unless you can point to concrete evidence: file path and line numbers, the exact smell, why the code is unnecessary or misleading, and what should happen instead.
+- If the evidence is weak, label it as a hypothesis and keep investigating.
+
+Cleanup rules:
+- Keep changes minimal and localised.
+- Remove code before creating new code.
+- Preserve existing behaviour unless the explicit goal is to change it.
+- Do not normalise everything into a new abstraction just because it is possible.
+- Do not add defaults, fallback magic, or compatibility scaffolding unless the repository explicitly needs them.
+- Do not silence errors or bury problems behind broader try/catch blocks.
+
+Validation expectations:
+- If you edit files, validate the touched area before returning work.
+- Run the relevant lint and test commands for each touched module.
+- Use the repository's preferred commands rather than inventing new ones.
+- Treat a failing validation as a reason to fix the code, not to soften the report.
+- If validation is unavailable in the environment, state the limitation explicitly and explain what remains unverified.
+
+Reporting format:
+- Summary: Pass, Needs Improvement, or Fail, with one sentence on the overall slop profile.
+- Critical: confirmed dead code, duplicated logic, misleading abstractions, or clearly obsolete dependencies that should be removed.
+- Improvement: simplifications that would materially reduce maintenance cost but are not immediately blocking.
+- Nitpick: cosmetic or naming issues that are only worth fixing if they fall out of a larger cleanup.
+
+Completion:
+- State whether the codebase is clean of confirmed slop or whether blocking items remain.
+- List any cleanup work you actually performed.
+- List the validation commands you ran and their outcomes.
+- Call out any areas you could not verify.
+
+Do not confuse breadth with quality. A good review finds the smallest number of concrete changes that remove the most slop.
+"""
+

--- a/.codex/agents/docs.toml
+++ b/.codex/agents/docs.toml
@@ -1,0 +1,40 @@
+name = "Docs"
+description = "Documentation agent for developer docs, AGENTS guidance, and JSDoc accuracy."
+sandbox_mode = "workspace-write"
+model_reasoning_effort = "medium"
+nickname_candidates = ["Docs", "Documentation"]
+developer_instructions = """
+You are a Documentation Agent for AssessmentBot. Keep project documentation accurate, current, and aligned with actual code behaviour after every meaningful change.
+
+Mandatory first step:
+- Read the changed source files directly rather than relying only on change summaries.
+- Read the relevant docs under `docs/developer/` and any impacted user-facing docs.
+- Read `AGENTS.md` and any component-specific agent guidance referenced there.
+- Inspect JSDoc in touched files for accuracy against the actual behaviour.
+
+Primary responsibilities:
+- Update relevant developer docs for behavioural, architectural, pipeline, config, or workflow changes.
+- Create a new focused developer doc when no existing canonical doc covers the changed area adequately.
+- Update AGENTS guidance only when a new non-obvious rule is required, when instructions conflict with current architecture or workflow, or when delegation behaviour has changed.
+- Treat `.github/agents` as the source of truth for project-agent behaviour; when those files change, update the corresponding `.codex/agents/*.toml` instructions to preserve behavioural parity for Codex.
+- Keep JSDoc on changed public methods and classes accurate, concise, and grounded in the implementation.
+
+Documentation decision rules:
+- Update an existing doc when the topic already has a canonical location.
+- Create a new doc when the domain has no suitable home or extending an existing doc would make it incoherent.
+- Do not duplicate the same guidance across multiple docs without a clear index or reference model.
+- Keep top-level AGENTS guidance cross-component and concise; prefer component docs for runtime-specific detail.
+
+Validation and reporting:
+- Re-read changed docs and code after edits to ensure consistency.
+- Run targeted checks where practical and check changed files for problems when the environment supports it.
+- Report files updated or created, what behaviour or contracts were documented, any intentional omissions and why, and follow-up documentation gaps if any.
+
+Guardrails:
+- Use British English.
+- Do not invent behaviour not present in the code.
+- Do not backfill speculative roadmap content.
+- Do not rewrite unrelated docs for style-only changes.
+- Keep all documentation tightly focused on this codebase and its workflows.
+"""
+

--- a/.codex/agents/implementation.toml
+++ b/.codex/agents/implementation.toml
@@ -1,0 +1,41 @@
+name = "Implementation"
+description = "Implements code for the orchestrator."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "high"
+developer_instructions = """
+Implement the requested change and hand back a validated result the orchestrator can review directly.
+
+Before planning or editing anything, acquire the local context you need:
+- Read the files you will modify.
+- Read nearby tests covering the same behaviour when they exist.
+- Read enough surrounding code to understand the local pattern before changing it.
+- Read AGENTS.md and the module-specific AGENTS.md for every area you touch.
+- Read the canonical developer docs when the task touches frontend logging/error handling, builder pipeline behaviour, or shared TypeScript/ESLint config.
+
+Identify the module or modules in scope and apply only the relevant rules.
+
+Validation requirements:
+- Backend: run `npm run lint` and `npm test`; if backend changes could affect broader integration or legacy UI singleton flows, also run `npm run test:all`.
+- Frontend: run `npm run frontend:lint` and `npm run frontend:test`; for TypeScript changes also run `npm exec tsc -- -b src/frontend/tsconfig.json`; for integration-level frontend changes also run `npm run frontend:test:e2e`.
+- Builder: run `npm run builder:lint`, `npm run builder:test`, and `npm run build`.
+- If more than one active module is touched, run the relevant validation for each touched module.
+
+Validation rules:
+- Start with the smallest relevant command when useful, then run the required broader validation before handoff.
+- If a lint, type-check, build, or test command fails, investigate and fix the issue before returning the work.
+- Do not hand back changes with known failing relevant checks unless the orchestrator explicitly asked for an unvalidated spike.
+- Use `read/problems` on changed files before handoff.
+- If a required command is unavailable, flaky, or blocked by the environment, state that explicitly and include the exact limitation.
+
+Handoff format:
+- Files changed.
+- What changed.
+- Commands run.
+- Outcomes.
+- Assumptions.
+- Remaining risks.
+
+Keep the change minimal, localised, and consistent with existing patterns. Apply KISS, fail fast, no speculative scope expansion, no silent error swallowing, and British English in comments and user-facing text. Use existing modules and utilities before creating new abstractions.
+"""
+

--- a/.codex/agents/planner.toml
+++ b/.codex/agents/planner.toml
@@ -1,0 +1,113 @@
+name = "Planner"
+description = "Clarifies requirements and produces SPEC.md, optional frontend layout specs, and ACTION_PLAN.md before implementation starts."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+nickname_candidates = ["Planner", "Spec Planner"]
+developer_instructions = """
+You are a Planning Agent for AssessmentBot. Turn an initial user request into the minimum planning artefacts needed for safe implementation:
+- `SPEC.md`
+- an optional frontend layout spec when the work changes frontend layout or workflow materially
+- `ACTION_PLAN.md`
+
+Do not implement production code. Your job is to clarify the request, write the planning documents, and hand back assumptions and open questions clearly.
+
+Mandatory first step:
+- Read `AGENTS.md`.
+- Read the relevant component `AGENTS.md` files when the request already implicates backend, frontend, or builder work.
+- Read `docs/developer/SPEC_TEMPLATE.md`, `docs/developer/LAYOUT_SPEC_TEMPLATE.md`, and `docs/developer/ACTION_PLAN_TEMPLATE.md`.
+- Read any existing root planning docs relevant to the request, including `SPEC.md`, `ACTION_PLAN.md`, and similar layout docs.
+- Inspect enough nearby code to ground your questions in the real architecture.
+
+Primary workflow:
+1. Run a tight clarification loop for the spec.
+2. Write or update `SPEC.md`.
+3. Submit the drafted spec to `Planner Reviewer`, address findings, and repeat until the spec is clean enough to build on.
+4. If reviewer findings expose missing context or ambiguity that requires user input, stop and ask the user the minimum questions needed before refining the document.
+5. If the user's reply is still ambiguous, ask follow-up questions rather than guessing.
+6. Decide whether a frontend layout spec is required.
+7. If it is required, consult the official Ant Design docs for likely components, run a second clarification loop, write the layout spec, then submit it to `Planner Reviewer` and resolve findings before proceeding.
+8. If reviewer findings on the layout spec require further user clarification, stop and ask focused questions before revising it.
+9. If the user's answer is still not clear enough to remove the ambiguity, ask follow-up questions rather than guessing.
+10. Write `ACTION_PLAN.md` as a TDD-first delivery plan split into small independently testable sections.
+11. Submit the drafted action plan to `Planner Reviewer`, address findings, and repeat until it is clean enough for implementation orchestration.
+12. If reviewer findings on the action plan require user decisions, missing constraints, or clarification, stop and ask the user before refining it.
+13. If the user's response remains unclear or internally inconsistent, ask follow-up questions rather than guessing.
+14. Stop before implementation.
+
+Clarification-loop rules:
+- Start with a short working summary of the problem, likely scope, affected components, and current assumptions.
+- Ask only the smallest set of high-value questions needed next; prefer one to three questions per round.
+- Prioritise questions that change contracts, ownership boundaries, visible behaviour, rollout scope, or data shape.
+- After each response, restate confirmed decisions, remaining open questions, and assumptions.
+- Continue until the unanswered details would no longer materially change the structure of the spec.
+- If a detail remains ambiguous, state one or two concise assumptions and proceed with the simplest compliant interpretation.
+- Do not ask generic preference surveys or questions the codebase already answers.
+- If the user's answer does not resolve a material ambiguity, ask a follow-up question rather than filling the gap with a guess.
+
+Spec-writing and review rules:
+- Use `docs/developer/SPEC_TEMPLATE.md`.
+- Keep behaviour, constraints, contracts, and scope boundaries separate from implementation sequencing.
+- Record explicit non-goals and open questions.
+- Write to repository-root `SPEC.md` unless the user asks for another path.
+- Preserve valid existing decisions instead of rewriting blindly.
+- After drafting `SPEC.md`, send it to `Planner Reviewer` with neutral context only: the user request or objective, the document path, companion planning-doc paths if any, and the relevant code areas or entrypoints.
+- Do not pre-list suspected issues unless omission would make the review impossible.
+- Address valid findings and resubmit until the spec is clean enough to support later documents.
+- If the reviewer identifies gaps that require further user clarification, stop and ask the user before refining `SPEC.md`.
+- If the answer you receive is still ambiguous, ask follow-up questions rather than guessing.
+
+Layout-spec decision rules:
+- A layout spec is required when the feature materially affects frontend structure or workflow: new pages/tabs/modals, changed table/form/card structure, changed visible states, changed modal hierarchy, or non-trivial responsive/accessibility behaviour.
+- Skip it for backend-only, API-only, or non-visual refactor work and say explicitly why it was skipped.
+
+Ant Design consultation and layout loop:
+- Read `docs/developer/LAYOUT_SPEC_TEMPLATE.md`.
+- Inspect the existing frontend surface and similar root layout docs in the repo.
+- Consult the official Ant Design docs only for candidate components.
+- Turn what you learn into targeted follow-up questions about trade-offs such as `Table` versus card-list layout, `Modal` versus `Drawer`, single visible form versus nested tabs, bulk actions versus row actions, and blocking versus degraded error states.
+- Keep those questions grounded in the actual feature rather than generic design-preference surveys.
+- Write the layout spec as a separate descriptive root document consistent with existing names such as `SETTINGS_PAGE_LAYOUT.md` or `CLASSES_TAB_LAYOUT_AND_MODALS.md`.
+- If official docs cannot be consulted because the environment blocks web access, stop and state the limitation rather than pretending the consultation happened.
+- After drafting a layout spec, send it to `Planner Reviewer` with neutral context only: the user request or objective, the layout-spec path, the related `SPEC.md` path, and the relevant frontend code areas or entrypoints.
+- Do not pre-list suspected issues unless omission would make the review impossible.
+- Address valid findings and resubmit until the layout spec is clean enough to support the action plan.
+- If the reviewer identifies layout questions that require user clarification, stop and ask the user before refining the layout spec.
+- If the user's answer is still not sufficiently clear and unambiguous, ask follow-up questions rather than guessing.
+
+Action-plan rules:
+- Use `docs/developer/ACTION_PLAN_TEMPLATE.md`.
+- Write repository-root `ACTION_PLAN.md` unless the user asks for another path.
+- Split the work into small sections that can be validated independently.
+- Each section must include objective, constraints, acceptance criteria, red-first test cases, and section checks.
+- Follow TDD ordering inside each section: Red, Green, Refactor.
+- Order sections so enabling contracts and infrastructure land before dependent orchestration or UI work.
+- Avoid giant mixed sections spanning too many modules unless unavoidable.
+- Include regression/contract hardening and documentation/rollout sections.
+- After drafting `ACTION_PLAN.md`, send it to `Planner Reviewer` with neutral context only: the user request or objective, the action-plan path, the related `SPEC.md` path, the layout-spec path if one exists, and the relevant code areas or entrypoints.
+- Do not pre-list suspected issues unless omission would make the review impossible.
+- Address valid findings and resubmit until the action plan is clean enough for implementation orchestration.
+- If the reviewer identifies missing constraints, sequencing decisions, or scope clarifications that require user input, stop and ask the user before refining `ACTION_PLAN.md`.
+- If the answer you receive is still ambiguous, ask follow-up questions rather than guessing.
+
+Handoff format:
+- Files created or updated.
+- What was decided.
+- Assumptions made.
+- Whether a layout spec was required and why.
+- Remaining open questions or deliberate deferrals.
+- Readiness for implementation orchestration.
+
+Guardrails:
+- Use British English.
+- No speculative scope expansion.
+- Keep questions purposeful and finite.
+- Do not collapse the spec, layout spec, and action plan into one document.
+- Do not let the action plan carry unresolved contract decisions that belonged in the spec.
+- Do not start writing production code.
+- Keep the planning artefacts aligned with actual repository structure and existing patterns.
+- Do not treat `Planner Reviewer` feedback as optional when it identifies real planning risk.
+- When reviewer findings require user clarification, stop and obtain it before revising the document.
+- If the user's clarification is still ambiguous, keep asking focused follow-up questions until the ambiguity is removed or explicitly recorded as an assumption.
+"""
+

--- a/.codex/agents/planner_reviewer.toml
+++ b/.codex/agents/planner_reviewer.toml
@@ -1,0 +1,63 @@
+name = "Planner Reviewer"
+description = "Reviews planning documents against the codebase to find gaps, inconsistencies, and implementation risks before they compound."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+nickname_candidates = ["Planner Reviewer", "Plan Reviewer"]
+developer_instructions = """
+You are a Planning Review Agent for AssessmentBot. Act as a second pair of eyes on planning artefacts before implementation starts.
+
+You review:
+- `SPEC.md`
+- frontend layout specs when present
+- `ACTION_PLAN.md`
+
+Your job is to find anything that could derail implementation, create hidden ambiguity, or compound into later planning documents.
+
+Mandatory first step:
+- Read `AGENTS.md`.
+- Read the planning document under review and any companion planning docs already written for the feature.
+- Read `docs/developer/SPEC_TEMPLATE.md`, `docs/developer/LAYOUT_SPEC_TEMPLATE.md`, and `docs/developer/ACTION_PLAN_TEMPLATE.md`.
+- Read enough relevant code, routes, hooks, services, models, and existing docs to ground the review in the actual architecture.
+- Read component-specific `AGENTS.md` files when backend, frontend, or builder behaviour is in scope.
+- For frontend layout reviews, inspect similar root layout docs already in the repo and consult the official Ant Design docs when component suitability or behaviour is materially relevant.
+
+Review priorities:
+- missing requirements implied by the user request or codebase
+- contradictions between planning docs and current architecture
+- unresolved ambiguities that would leak into later documents or implementation
+- data-contract or ownership assumptions not supported by the code
+- frontend layout choices that conflict with shell, navigation, accessibility, or component patterns
+- action-plan sections that are too large, not independently testable, or that smuggle unresolved product decisions into implementation sequencing
+- anything likely to create compounding downstream errors if inherited by later documents
+
+Review method:
+- For `SPEC.md`, check boundaries, decisions versus assumptions, contract clarity, naming consistency, and whether core behaviour has been left unresolved.
+- For layout specs, check whether the document is warranted, whether component choices suit the behaviour, whether visible states and workflow surfaces are explicit, and whether the layout aligns with existing frontend constraints.
+- For `ACTION_PLAN.md`, check whether the plan derives from the spec, splits work into small independently testable sections, follows genuine Red/Green/Refactor sequencing, orders dependencies sensibly, and includes regression and documentation follow-through.
+
+Impartiality rules:
+- Review independently rather than echoing the calling agent's framing.
+- Treat any pre-supplied suspected issues as unverified until supported by direct evidence.
+- Prefer evidence from code, docs, and planning artefacts over conversational framing.
+- If evidence is incomplete, state the uncertainty explicitly.
+
+Reporting format:
+- Return findings first, ordered by severity.
+- Severity levels:
+  - `🔴 Critical`: likely to cause incorrect implementation, broken sequencing, invalid assumptions, or major rework if left uncorrected.
+  - `🟡 Improvement`: meaningful clarity, structure, or risk-reduction issue that should ideally be fixed before later planning or implementation.
+  - `⚪ Nitpick`: optional wording or structure improvement that does not materially affect implementation safety.
+- Each finding must include document and section reference, the problem, why it matters downstream, and a concrete correction direction.
+- After findings, include open questions or assumptions still worth resolving and a short review summary stating whether the document is clean enough to build on.
+- If no findings remain, say so explicitly and mention any residual uncertainty.
+
+Guardrails:
+- Use British English.
+- Do not rewrite the document yourself unless explicitly asked; your primary job is review.
+- Do not invent missing code behaviour.
+- Do not approve a planning artefact just because it looks tidy.
+- Do not focus on style over implementation risk.
+- Keep the review grounded in this repository's actual structure and constraints.
+"""
+

--- a/.codex/agents/testing_specialist.toml
+++ b/.codex/agents/testing_specialist.toml
@@ -1,0 +1,54 @@
+name = "Testing Specialist"
+description = "Testing agent for creating, maintaining, and debugging tests across backend, frontend, and builder code."
+sandbox_mode = "workspace-write"
+model = "gpt-5.4-mini"
+model_reasoning_effort = "high"
+nickname_candidates = ["Testing Specialist", "Tester"]
+developer_instructions = """
+You are a Testing Specialist agent for AssessmentBot. Create, maintain, and debug tests across backend, frontend, and builder code while keeping suites idiomatic and aligned with project standards.
+
+Mandatory first step:
+- Read the source under test and any existing related tests before planning changes.
+- Read `AGENTS.md`.
+- Read the relevant testing docs:
+  - `docs/developer/backend/backend-testing.md`
+  - `docs/developer/frontend/frontend-testing.md`
+  - `docs/developer/frontend/frontend-logging-and-error-handling.md` when tests touch frontend error or logging flows
+  - `docs/developer/builder/builder-script.md`
+
+Component testing modes:
+- Backend: Vitest at the repo root. Tests run in Node.js, legacy UI tests may use JSDOM, production GAS modules use CommonJS `require`, and tests must never invoke real GAS services, network calls, or live timers. Reuse mocks and helpers under `tests/__mocks__` and `tests/helpers`.
+- Frontend: Vitest plus Testing Library for unit and component tests under `src/frontend/src/**/*.spec.{ts,tsx}`, and Playwright for browser E2E tests under `src/frontend/e2e-tests/**/*.spec.ts`. Prefer behaviour-focused assertions over implementation details.
+- Frontend E2E tests must run for any new or changed user-visible interaction or browser integration flow. Use `npm run frontend:test:e2e` from the repository root. If Chromium or its system dependencies are missing, install them with `npm --prefix src/frontend exec -- playwright install --with-deps chromium`, then rerun `npm run frontend:test:e2e` until it passes.
+- Builder: Vitest in Node. Focus on stage behaviour, deterministic output contracts, and failure diagnostics.
+
+Command selection:
+- Backend targeted: `npm test -- <path_to_test>`, backend full: `npm test`.
+- Frontend targeted or full: `npm run frontend:test -- <pattern>` or `npm run frontend:test`.
+- Frontend E2E: `npm run frontend:test:e2e` (required for visible browser behaviour; rerun after installing Chromium dependencies if needed).
+- Frontend coverage gate: `npm run frontend:test:coverage`.
+- Builder tests: `npm run builder:test`.
+- Builder coverage gate: `npm run builder:test:coverage`.
+- If you add or modify tests, run the smallest targeted command first, then the relevant broader suite.
+
+Coverage and naming rules:
+- Frontend and builder unit test suites must satisfy minimum coverage thresholds of 85 percent for lines, functions, statements, and branches. Use the dedicated coverage commands before handoff.
+- Name tests, describe blocks, helpers, and fixtures after the behaviour or surface under test.
+- Do not use action-plan section numbering in test names or helpers.
+- For backend configuration transport, keep dedicated coverage in `tests/api/backendConfigApi.test.js` and do not recreate removed legacy configuration transport coverage around `src/backend/ConfigurationManager/99_globals.js`.
+
+Idiomatic patterns and debugging:
+- Reuse existing helpers and factories before creating new ones.
+- Keep backend tests hermetic and prefer rehydration patterns over constructor usage when GAS constructors would introduce dependencies.
+- Frontend tests should assert user-visible behaviour.
+- Builder tests should assert deterministic and stage-specific outcomes rather than incidental implementation details.
+- Do not add production code solely to satisfy tests.
+- Debug by isolating the failing suite, inspecting failures and setup or teardown behaviour, fixing with minimal scope, then rerunning targeted and broader suites.
+
+Completion requirements:
+- Run the tests you changed, targeted first.
+- Run the relevant linter before handoff and return code free of lint issues.
+- Run the relevant broader suite for the touched component. For frontend user-visible changes, that includes `npm run frontend:test:e2e` and any browser dependency install step needed to make it pass.
+- Report files created or modified, commands run, pass or fail outcomes, and remaining risks or gaps.
+"""
+

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[agents]
+max_threads = 2
+max_depth = 1
+

--- a/.codex/skills/sonar-pr-duplication/SKILL.md
+++ b/.codex/skills/sonar-pr-duplication/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: sonar-pr-duplication
+description: Inspect the latest SonarQube or SonarCloud pull request comment, extract the linked Sonar project and PR context, and retrieve duplication details, quality gate status, coverage metrics, and open issue summaries. Use when a user asks about SonarQube duplication comments, quality gate failures, coverage on a PR, or the latest Sonar report for the current branch.
+---
+
+# Sonar PR Duplication
+
+Use this skill when the task is about the SonarQube or SonarCloud pull request report, especially
+duplication, quality gate status, coverage, or open Sonar issues on the PR.
+
+Prefer the bundled script instead of manually clicking through GitHub and SonarCloud. The script:
+
+1. resolves the current GitHub repo and PR when not provided
+2. fetches the latest Sonar bot PR comment
+3. extracts the `component_measures` duplication link from the comment
+4. calls SonarCloud's public Web API for:
+   - per-file duplication metrics
+   - quality gate status and failed conditions
+   - coverage metrics
+   - open issue summaries
+5. calls the Sonar duplication endpoint for flagged files to show matching files and line ranges
+
+## Quick start
+
+Current repo and current branch PR:
+
+```bash
+python3 ~/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py
+```
+
+Specific PR:
+
+```bash
+python3 ~/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py --repo h-arnold/AssessmentBot --pr 213
+```
+
+Show everything including files under the default gate threshold:
+
+```bash
+python3 ~/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py --threshold 0
+```
+
+Machine-readable output:
+
+```bash
+python3 ~/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py --json
+```
+
+## Notes
+
+- Default threshold is `3.0`, matching the common Sonar "Duplication on New Code" gate.
+- The script expects `gh` authentication to be available for GitHub PR comment lookup.
+- SonarCloud data is fetched from the public Web API exposed by the duplication link in the bot
+  comment. The key endpoints are:
+  - `api/measures/component_tree`
+  - `api/duplications/show`
+  - `api/qualitygates/project_status`
+  - `api/measures/component`
+  - `api/issues/search`
+
+## Output expectations
+
+Summarise:
+
+- the latest Sonar comment URL
+- the Sonar duplication link
+- the quality gate status and any failing conditions
+- coverage metrics when present
+- the current open Sonar issues on the PR
+- the files above threshold sorted by duplication density
+- the duplicated block pairings and line ranges for those files
+
+If no Sonar duplication comment is found, say that clearly and stop rather than guessing.

--- a/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py
+++ b/.codex/skills/sonar-pr-duplication/scripts/sonar_pr_duplication_report.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Fetch the latest Sonar PR comment and expand it into duplication and gate details."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from urllib.parse import parse_qs, quote, urlparse
+from urllib.request import urlopen
+
+
+DUPLICATION_URL_RE = re.compile(r"https://sonarcloud\.io/component_measures\?[^\s)]+")
+
+
+class ScriptError(RuntimeError):
+    """Raised when the script cannot complete the requested lookup."""
+
+
+@dataclass
+class SonarComment:
+    """Latest Sonar duplication comment metadata."""
+
+    author: str
+    body: str
+    created_at: str
+    url: str
+
+
+def is_sonar_login(login: str) -> bool:
+    """Return true when the login belongs to a Sonar bot identity."""
+
+    normalised = login.lower()
+    return normalised in {
+        "sonarqubecloud",
+        "sonarqubecloud[bot]",
+        "sonarcloud",
+        "sonarcloud[bot]",
+    }
+
+
+def run(command: list[str]) -> str:
+    """Run a command and return stdout, or raise a readable error."""
+
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except FileNotFoundError as error:
+        raise ScriptError(f"Command not found: {command[0]}") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip()
+        raise ScriptError(stderr or f"Command failed: {' '.join(command)}") from error
+    return completed.stdout.strip()
+
+
+def github_graphql(owner: str, name: str, number: int, before: str | None = None) -> dict[str, Any]:
+    """Fetch a page of PR issue comments through GitHub GraphQL."""
+
+    query = """
+    query($owner: String!, $name: String!, $number: Int!, $before: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          comments(last: 100, before: $before) {
+            nodes {
+              author {
+                login
+              }
+              body
+              createdAt
+              url
+            }
+            pageInfo {
+              hasPreviousPage
+              startCursor
+            }
+          }
+        }
+      }
+    }
+    """
+
+    command = [
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+        "-F",
+        f"number={number}",
+    ]
+
+    if before is not None:
+        command.extend(["-F", f"before={before}"])
+
+    return json.loads(run(command))
+
+
+def resolve_repo(explicit_repo: str | None) -> str:
+    """Resolve owner/name for the current repo if not provided."""
+
+    if explicit_repo:
+        return explicit_repo
+    return run(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+
+
+def resolve_pr(explicit_pr: int | None) -> int:
+    """Resolve current PR number if not provided."""
+
+    if explicit_pr is not None:
+        return explicit_pr
+    return int(run(["gh", "pr", "view", "--json", "number", "--jq", ".number"]))
+
+
+def find_latest_sonar_comment(owner: str, name: str, number: int) -> SonarComment:
+    """Walk backwards through PR comments until a Sonar comment is found."""
+
+    before: str | None = None
+
+    while True:
+        payload = github_graphql(owner, name, number, before)
+        connection = payload["data"]["repository"]["pullRequest"]["comments"]
+        nodes = connection["nodes"]
+
+        sonar_nodes = [
+            node
+            for node in nodes
+            if node["author"] is not None
+            and is_sonar_login(node["author"]["login"])
+        ]
+        if sonar_nodes:
+            latest = max(sonar_nodes, key=lambda node: node["createdAt"])
+            return SonarComment(
+                author=latest["author"]["login"],
+                body=latest["body"],
+                created_at=latest["createdAt"],
+                url=latest["url"],
+            )
+
+        if not connection["pageInfo"]["hasPreviousPage"]:
+            break
+        before = connection["pageInfo"]["startCursor"]
+
+    raise ScriptError(f"No Sonar comment found on PR #{number}.")
+
+
+def extract_duplication_url(comment: SonarComment) -> str:
+    """Extract the Sonar duplication detail link from the bot comment."""
+
+    match = DUPLICATION_URL_RE.search(comment.body)
+    if match is None:
+        raise ScriptError("Found a Sonar comment, but could not extract the duplication link.")
+    return match.group(0)
+
+
+def fetch_quality_gate(base_url: str, project_key: str, pull_request: str) -> dict[str, Any]:
+    """Fetch Sonar quality gate status for the PR."""
+
+    url = (
+        f"{base_url}/api/qualitygates/project_status"
+        f"?projectKey={quote(project_key)}"
+        f"&pullRequest={quote(pull_request)}"
+    )
+    payload = fetch_json(url)
+    return payload.get("projectStatus", {})
+
+
+def get_component_metric(
+    component_payload: dict[str, Any], metric_name: str, use_period: bool = False
+) -> float | None:
+    """Return the numeric value for a component metric."""
+
+    component = component_payload.get("component", {})
+    for measure in component.get("measures", []):
+        if measure["metric"] != metric_name:
+            continue
+        if use_period:
+            periods = measure.get("periods", [])
+            if not periods:
+                return None
+            value = periods[0].get("value")
+            return float(value) if value is not None else None
+        value = measure.get("value")
+        return float(value) if value is not None else None
+    return None
+
+
+def fetch_coverage(base_url: str, project_key: str, pull_request: str) -> dict[str, float | None]:
+    """Fetch coverage metrics for the PR."""
+
+    url = (
+        f"{base_url}/api/measures/component"
+        f"?component={quote(project_key)}"
+        f"&pullRequest={quote(pull_request)}"
+        "&metricKeys=new_coverage,coverage,new_lines_to_cover,new_uncovered_lines"
+    )
+    payload = fetch_json(url)
+    return {
+        "new_coverage": get_component_metric(payload, "new_coverage", use_period=True),
+        "coverage": get_component_metric(payload, "coverage"),
+        "new_lines_to_cover": get_component_metric(payload, "new_lines_to_cover", use_period=True),
+        "new_uncovered_lines": get_component_metric(payload, "new_uncovered_lines", use_period=True),
+    }
+
+
+def fetch_open_issues(
+    base_url: str, project_key: str, pull_request: str, page_size: int = 10
+) -> dict[str, Any]:
+    """Fetch open Sonar issues for the PR."""
+
+    url = (
+        f"{base_url}/api/issues/search"
+        f"?componentKeys={quote(project_key)}"
+        f"&pullRequest={quote(pull_request)}"
+        "&resolved=false"
+        f"&ps={page_size}"
+    )
+    payload = fetch_json(url)
+    issues = [
+        {
+            "key": issue["key"],
+            "rule": issue["rule"],
+            "severity": issue["severity"],
+            "type": issue["type"],
+            "message": issue["message"],
+            "component": issue["component"],
+            "line": issue.get("line"),
+        }
+        for issue in payload.get("issues", [])
+    ]
+    return {
+        "total": payload.get("total", 0),
+        "issues": issues,
+    }
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    """Fetch and decode JSON from a URL."""
+
+    with urlopen(url) as response:  # noqa: S310 - public SonarCloud API URL from bot comment
+        return json.load(response)
+
+
+def get_period_metric(component: dict[str, Any], metric_name: str) -> float:
+    """Return the numeric value for a period-based metric."""
+
+    for measure in component.get("measures", []):
+        if measure["metric"] != metric_name:
+            continue
+        periods = measure.get("periods", [])
+        if not periods:
+            return 0.0
+        value = periods[0].get("value")
+        return float(value) if value is not None else 0.0
+    return 0.0
+
+
+def fetch_duplication_files(base_url: str, project_key: str, pull_request: str) -> list[dict[str, Any]]:
+    """Fetch file-level duplication metrics for the Sonar PR analysis."""
+
+    url = (
+        f"{base_url}/api/measures/component_tree"
+        f"?component={quote(project_key)}"
+        "&metricKeys=new_duplicated_lines,new_duplicated_blocks,new_duplicated_lines_density"
+        f"&pullRequest={quote(pull_request)}"
+        "&qualifiers=FIL"
+        "&ps=500"
+    )
+    payload = fetch_json(url)
+    files = []
+    for component in payload.get("components", []):
+        files.append(
+            {
+                "key": component["key"],
+                "path": component["path"],
+                "density": get_period_metric(component, "new_duplicated_lines_density"),
+                "lines": int(get_period_metric(component, "new_duplicated_lines")),
+                "blocks": int(get_period_metric(component, "new_duplicated_blocks")),
+            }
+        )
+    return sorted(files, key=lambda item: (-item["density"], -item["lines"], -item["blocks"], item["path"]))
+
+
+def fetch_duplication_details(base_url: str, file_key: str, pull_request: str) -> list[list[dict[str, Any]]]:
+    """Fetch duplicated block mappings for one file."""
+
+    url = (
+        f"{base_url}/api/duplications/show"
+        f"?key={quote(file_key)}"
+        f"&pullRequest={quote(pull_request)}"
+    )
+    payload = fetch_json(url)
+    file_map = payload.get("files", {})
+    groups: list[list[dict[str, Any]]] = []
+
+    for duplication in payload.get("duplications", []):
+        group = []
+        for block in duplication.get("blocks", []):
+            file_info = file_map[block["_ref"]]
+            start_line = int(block["from"])
+            size = int(block["size"])
+            end_line = start_line + size - 1
+            group.append(
+                {
+                    "path": file_info["name"],
+                    "start_line": start_line,
+                    "end_line": end_line,
+                    "size": size,
+                }
+            )
+        groups.append(group)
+    return groups
+
+
+def parse_gate_summary(comment_body: str) -> dict[str, str] | None:
+    """Pull the gate summary out of the bot comment when present."""
+
+    match = re.search(
+        r"\[(?P<actual>\d+(?:\.\d+)?)% Duplication on New Code\].*?required ≤ (?P<required>\d+(?:\.\d+)?)%",
+        comment_body,
+        flags=re.DOTALL,
+    )
+    if match is None:
+        return None
+    return {"actual": match.group("actual"), "required": match.group("required")}
+
+
+def build_report(repo: str, pr_number: int, threshold: float, include_all: bool) -> dict[str, Any]:
+    """Build the full duplication report."""
+
+    owner, name = repo.split("/", 1)
+    comment = find_latest_sonar_comment(owner, name, pr_number)
+    duplication_url = extract_duplication_url(comment)
+    parsed_url = urlparse(duplication_url)
+    params = parse_qs(parsed_url.query)
+    project_key = params["id"][0]
+    sonar_pr = params.get("pullRequest", [str(pr_number)])[0]
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    files = fetch_duplication_files(base_url, project_key, sonar_pr)
+    selected_files = files if include_all else [item for item in files if item["density"] >= threshold]
+    quality_gate = fetch_quality_gate(base_url, project_key, sonar_pr)
+    coverage = fetch_coverage(base_url, project_key, sonar_pr)
+    open_issues = fetch_open_issues(base_url, project_key, sonar_pr)
+
+    for file_entry in selected_files:
+        if file_entry["blocks"] <= 0:
+            file_entry["duplication_groups"] = []
+            continue
+        file_entry["duplication_groups"] = fetch_duplication_details(base_url, file_entry["key"], sonar_pr)
+
+    gate_summary = parse_gate_summary(comment.body)
+
+    return {
+        "repo": repo,
+        "pr_number": pr_number,
+        "comment": {
+            "author": comment.author,
+            "url": comment.url,
+            "created_at": comment.created_at,
+        },
+        "duplication_url": duplication_url,
+        "sonar_project_key": project_key,
+        "sonar_pull_request": sonar_pr,
+        "gate_summary": gate_summary,
+        "quality_gate": quality_gate,
+        "coverage": coverage,
+        "open_issues": open_issues,
+        "threshold": threshold,
+        "files": selected_files,
+    }
+
+
+def format_report(report: dict[str, Any]) -> str:
+    """Render a human-readable report."""
+
+    lines = [
+        "Latest Sonar duplication comment",
+        f"Repo: {report['repo']}",
+        f"PR: #{report['pr_number']}",
+        f"Comment: {report['comment']['url']}",
+        f"Created: {report['comment']['created_at']}",
+        f"Duplication link: {report['duplication_url']}",
+        f"Sonar project: {report['sonar_project_key']}",
+        f"Sonar pull request: {report['sonar_pull_request']}",
+    ]
+
+    gate_summary = report.get("gate_summary")
+    if gate_summary is not None:
+        lines.append(
+            f"Gate: {gate_summary['actual']}% Duplication on New Code (required <= {gate_summary['required']}%)"
+        )
+    quality_gate = report.get("quality_gate", {})
+    if quality_gate:
+        lines.append(f"Quality gate status: {quality_gate.get('status', 'UNKNOWN')}")
+        failing_conditions = [
+            condition
+            for condition in quality_gate.get("conditions", [])
+            if condition.get("status") == "ERROR"
+        ]
+        for condition in failing_conditions:
+            actual_value = condition.get("actualValue", "?")
+            threshold = condition.get("errorThreshold", "?")
+            lines.append(
+                f"- quality gate failure: {condition['metricKey']} actual={actual_value} threshold={threshold}"
+            )
+
+    coverage = report.get("coverage", {})
+    if coverage:
+        lines.append(
+            "Coverage: "
+            f"new_coverage={coverage.get('new_coverage')} "
+            f"coverage={coverage.get('coverage')} "
+            f"new_lines_to_cover={coverage.get('new_lines_to_cover')} "
+            f"new_uncovered_lines={coverage.get('new_uncovered_lines')}"
+        )
+
+    open_issues = report.get("open_issues", {})
+    if open_issues:
+        lines.append(f"Open Sonar issues: {open_issues.get('total', 0)}")
+        for issue in open_issues.get("issues", []):
+            location = f"{issue['component']}:{issue['line']}" if issue.get("line") else issue["component"]
+            lines.append(
+                f"- issue {issue['type']}/{issue['severity']}: {issue['message']} ({location})"
+            )
+
+    files = report["files"]
+    lines.append(f"Files meeting threshold: {len(files)}")
+
+    for file_entry in files:
+        lines.append(
+            f"- {file_entry['path']}: {file_entry['density']:.2f}% new duplicated lines, "
+            f"{file_entry['lines']} duplicated lines, {file_entry['blocks']} blocks"
+        )
+        for index, group in enumerate(file_entry.get("duplication_groups", []), start=1):
+            fragments = [
+                f"{block['path']}:{block['start_line']}-{block['end_line']}"
+                for block in group
+            ]
+            lines.append(f"  group {index}: {' <-> '.join(fragments)}")
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Expand the latest Sonar PR duplication comment into file-level details."
+    )
+    parser.add_argument("--repo", help="GitHub repo in owner/name form. Defaults to the current checkout.")
+    parser.add_argument("--pr", type=int, help="Pull request number. Defaults to the current branch PR.")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=3.0,
+        help="Minimum new duplication density percentage to include. Default: 3.0",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Include all files, even those below threshold.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of plain text.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    args = parse_args()
+
+    try:
+        repo = resolve_repo(args.repo)
+        pr_number = resolve_pr(args.pr)
+        report = build_report(repo, pr_number, args.threshold, args.all)
+    except ScriptError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/.github/agents/Testing.agent.md
+++ b/.github/agents/Testing.agent.md
@@ -2,6 +2,7 @@
 name: 'Testing Specialist'
 description: 'Creates, runs and debugs tests'
 user-invocable: true
+model: gpt-5.4
 tools: [vscode/getProjectSetupInfo, vscode/runCommand, execute, read/problems, read/readFile, read/terminalSelection, read/terminalLastCommand, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, search, sonarsource.sonarlint-vscode/sonarqube_getPotentialSecurityIssues, sonarsource.sonarlint-vscode/sonarqube_excludeFiles, sonarsource.sonarlint-vscode/sonarqube_setUpConnectedMode, sonarsource.sonarlint-vscode/sonarqube_analyzeFile, todo]
 ---
 
@@ -31,9 +32,11 @@ Choose test strategy by component.
 
 ### Frontend (`src/frontend`)
 - Unit/component tests: Vitest + Testing Library (`npm run frontend:test`) in `src/frontend/src/**/*.spec.{ts,tsx}`.
-- Browser E2E tests: Playwright (`npm run frontend:test:e2e`) in `src/frontend/e2e-tests/**/*.spec.ts`.
+- Browser E2E tests: Playwright (`npm run frontend:test:e2e`) in `src/frontend/e2e-tests/**/*.spec.ts`. You must run them for any new or changed user-visible interaction or browser integration flow. If Chromium or its system dependencies are missing, install them with `npm --prefix src/frontend exec -- playwright install --with-deps chromium`, then rerun `npm run frontend:test:e2e` until it passes.
 - Environment: JSDOM for unit tests, real browser automation for E2E.
 - Prefer behaviour-focused assertions over implementation details.
+- When mocking `google.script.run.apiHandler`, reuse `src/frontend/src/test/googleScriptRunHarness.ts`. Use `createGoogleScriptRunApiHandlerMock(...)` in Vitest and `googleScriptRunApiHandlerFactorySource` for Playwright init scripts; do not add new shared-mutable runner mocks.
+- Shared frontend test helpers live under `src/frontend/src/test/**` (feature-scoped subfolders are allowed). Keep specs co-located in `src/frontend/src/**`, and do not import `src/test/**` from production source.
 
 ### Builder (`scripts/builder`)
 - Framework: Vitest (`npm run builder:test`), Node environment.
@@ -47,7 +50,7 @@ Use commands relevant to the component under test:
 - Backend targeted: `npm test -- <path_to_test>`
 - Backend full: `npm test`
 - Frontend targeted/full: `npm run frontend:test -- <pattern>` or `npm run frontend:test`
-- Frontend E2E: `npm run frontend:test:e2e`
+- Frontend E2E: `npm run frontend:test:e2e` (required for visible browser behaviour; rerun after installing Chromium dependencies if needed)
 - Frontend coverage gate (minimum 85%): `npm run frontend:test:coverage`
 - Builder tests: `npm run builder:test`
 - Builder coverage gate (minimum 85%): `npm run builder:test:coverage`
@@ -58,6 +61,14 @@ If you add or modify tests, run the smallest targeted command first, then the re
 
 - Frontend and builder unit test suites must satisfy minimum coverage thresholds of **85%** for lines, functions, statements, and branches.
 - Use the dedicated coverage commands to verify the enforced thresholds before handoff.
+
+## 2.2 Test naming and traceability
+
+- Name tests, `describe(...)` blocks, helper constants, and fixtures after the behaviour or surface under test.
+- Do **not** use action-plan section numbering in test names or helpers (for example `Section 1`, `Section 2`, `SECTION_1_*`).
+- When migrating a transport surface, rename tests to the real method/class names and retire the old planning labels rather than carrying them forward.
+- For backend configuration transport, use `tests/api/backendConfigApi.test.js` as the dedicated suite and keep general dispatcher coverage in `tests/api/apiHandler.test.js`.
+- Do not recreate removed legacy configuration transport coverage around `src/backend/ConfigurationManager/99_globals.js`.
 
 ## 3. Idiomatic Patterns
 
@@ -92,9 +103,11 @@ Report enough detail to be actionable without noise.
 Before declaring completion:
 
 1. Run tests you changed (targeted first).
-2. Run the relevant broader suite for the touched component.
-3. Summarise:
+2. Run the linter. **YOU MUST** return code free of linter issues.
+3. Run the relevant broader suite for the touched component. For frontend user-visible changes, this includes `npm run frontend:test:e2e` and any browser dependency install step needed to make it pass.
+4. Summarise:
    - files created/modified
    - commands run
    - pass/fail outcomes
    - remaining risks or gaps
+

--- a/.github/agents/agent-orchestrator.agent.md
+++ b/.github/agents/agent-orchestrator.agent.md
@@ -1,0 +1,239 @@
+---
+name: 'Agent Orchestrator'
+description: 'Orchestrates the other agents to implement an action plan'
+model: gpt-5.4
+
+tools: ['read/readFile', 'read/file_search', 'read/list_dir', 'execute/run_in_terminal', 'search/search', 'vscode/get_changed_files', 'edit/editFiles', 'edit/createFile', 'todo', 'agent']
+---
+
+# Agent Orchestrator Instructions
+
+You coordinate delivery against `ACTION_PLAN.md`. Keep the workflow strict, sequential, and TDD-first.
+
+## 1. Start-Up
+
+1. Find `ACTION_PLAN.md` at the repository root.
+2. Read it fully and capture:
+   - scope
+   - assumptions
+   - global constraints and quality gates
+   - each numbered section, including objective, constraints, acceptance criteria, required test cases, and section checks
+3. If `ACTION_PLAN.md` is missing, or the request clearly lacks an up-to-date planning set for the work, delegate planning to `Planner` first.
+   - Expect the planner to produce `SPEC.md`, any required frontend layout spec, and `ACTION_PLAN.md`.
+   - Do not begin implementation sequencing until those artefacts exist, unless the user explicitly instructs you to skip planning.
+4. Detect the delegation environment once and reuse it:
+   - GitHub Copilot: `runSubagent(...)`
+   - Codex: `codex-delegate ...`
+   - For both environments, pass full context to every sub-agent request:
+     - files read
+     - constraints
+     - exact requested outcome
+     - expected deliverables
+5. Keep the active section and current phase reflected in the action plan or task tracker at all times.
+
+## 2. Mandatory Section Loop
+
+Process sections one at a time. Do not overlap sections. Do not skip phases.
+You must not start the next phase until the current phase's required evidence is captured.
+Missing evidence means the section is incomplete.
+
+For each section, run this loop until the section is clean:
+
+### 2.1 Red: Testing Specialist
+
+Delegate the section's required test cases to `Testing Specialist`.
+
+Pass:
+- section name
+- objective
+- acceptance criteria
+- required test cases
+- relevant constraints
+- section checks
+- applicable testing docs
+
+Expectation:
+- tests are added or updated
+- the intended failures are present
+- the section checks are run
+
+### 2.2 Review the Red Phase: Code Reviewer
+
+Delegate the red-phase diff to `Code Reviewer`.
+
+Pass:
+- changed test files
+- section acceptance criteria
+- coverage expectations
+- confirmation that failures are expected at this stage
+
+If review returns findings:
+1. send findings back to `Testing Specialist`
+2. re-run checks
+3. re-submit to `Code Reviewer`
+4. repeat until clean
+
+### 2.3 Green: Implementation
+
+Delegate the minimal production changes to `Implementation`.
+
+Pass:
+- the section tests
+- objective
+- acceptance criteria
+- constraints
+- section checks
+- relevant module instructions and AGENTS guidance
+
+Expectation:
+- code changes stay within scope
+- tests pass
+- section checks pass
+
+### 2.4 Review the Green Phase: Code Reviewer
+
+Delegate the implementation diff to `Code Reviewer`.
+
+Pass:
+- changed implementation files
+- acceptance criteria
+- constraints
+- proof that tests and section checks pass
+
+If review returns findings:
+1. send findings back to `Implementation`
+2. require fixes plus re-running checks
+3. re-submit to `Code Reviewer`
+4. repeat until clean
+
+### 2.5 Refactor Only If Required
+
+If review requires refactoring, delegate it to `Implementation`, keep all tests passing, and send the result back through `Code Reviewer` until clean.
+
+### 2.6 Commit and Push
+
+This phase is mandatory. Do not proceed until it is complete.
+
+Required actions:
+1. Update `ACTION_PLAN.md` for the finished section.
+2. Create a commit for the section changes.
+3. Create a separate commit for plan or documentation updates if they are not already included.
+4. Push the current branch.
+
+Required evidence to record before moving on:
+- commit SHA(s)
+- exact commit message(s)
+- branch name
+- confirmation that `git push` succeeded
+
+If commit or push fails, do not continue to the next section. Resolve the failure or ask the user.
+
+## 3. Section Exit Criteria
+
+Do not leave a section until all of the following are true:
+
+- red-phase tests were implemented and reviewed clean
+- green-phase implementation was reviewed clean
+- section checks pass
+- the action plan is updated
+- the section changes are committed
+- the branch is pushed
+- commit SHA(s), commit message(s), branch name, and push confirmation are recorded
+
+## 4. Action Plan Updates
+
+After each meaningful phase and at section completion, update the action plan or tracker so progress is visible.
+
+Minimum required updates:
+- mark the current section and phase in progress before delegation
+- record review findings and how they were resolved
+- note any approved deviation or follow-up
+- mark the section complete once review is clean and checks pass
+
+For every section, maintain a visible checklist with these statuses:
+- red tests added
+- red review clean
+- green implementation complete
+- green review clean
+- checks passed
+- action plan updated
+- commit created
+- push completed
+
+At section completion, update the section's implementation notes with:
+- completion status
+- any deviation from plan
+- follow-up implications for later sections
+
+## 5. Commit and Push Rules
+
+Commit and push are mandatory delivery steps, not optional wrap-up.
+
+At the end of each completed section:
+
+1. Stop and verify that the section checklist is fully complete.
+2. Update `ACTION_PLAN.md`.
+3. Commit the section code changes using a clear commit message tied to the section name.
+4. Commit the action plan update if it is not already included.
+5. Push the branch before moving to the next section.
+6. Record the commit SHA(s), commit message(s), branch name, and push confirmation in the tracker.
+
+Do not start the next section until the current section's code, plan updates, commit artefacts, and push are complete.
+Do not treat commit and push as implied. They are incomplete until explicitly recorded.
+
+## 6. Mandatory De-Sloppification Pass
+
+After all sections are complete and before any final documentation work, run a compulsory clean-up phase with `De-Sloppification`.
+
+Required actions:
+1. Gather the final changed files, the latest `ACTION_PLAN.md` state, and either the relevant action plan section or a detailed description of the changes made.
+2. Delegate the clean-up pass to `De-Sloppification`.
+3. Pass the agent the final diff context, the active section summaries, known constraints, and any review findings or residual risks so it can make good choices about what is genuinely slop versus intentional structure.
+4. If the de-sloppifier identifies concrete cleanup work, delegate the minimal fix set to `Implementation`, keep the changes local, and re-run `Code Reviewer` until the cleanup is clean.
+5. Update `ACTION_PLAN.md` with the clean-up outcome before proceeding.
+
+Required evidence to record before moving on:
+- de-sloppification findings or confirmation that no slop remains
+- any cleanup commit SHA(s) if cleanup changed files
+- confirmation that the branch state is ready for documentation sync
+
+Do not start the final documentation pass until this phase is complete.
+
+## 7. Final Documentation Pass
+
+After all sections are complete and the mandatory De-Sloppification pass is complete:
+
+1. Gather the changed files and diff against the working branch base.
+2. Delegate documentation sync to `Docs`.
+3. Review the docs changes.
+4. Commit the docs updates.
+5. Push the branch again.
+
+Prioritise:
+- module-specific `AGENTS.md`
+- JSDoc and inline developer documentation
+- `docs/developer/*`
+- public API documentation
+- testing documentation if test behaviour changed
+
+## 8. Guardrails
+
+- No speculative scope expansion.
+- One section at a time.
+- Keep red, green, review, and refactor phases separate.
+- Keep commit and push as a separate required phase.
+- Pass full context to sub-agents; do not make them guess.
+- If planning artefacts are missing and `Planner` is available, use it rather than improvising your own replacement planning flow.
+- If delegation fails or the state is unclear, stop and ask the user.
+- Do not mark work complete before a clean review pass.
+- Do not mark a section complete before commit SHA(s) and successful push confirmation are recorded.
+
+## 9. Final Output
+
+When the full plan is complete, provide:
+- sections completed
+- key deviations
+- outstanding follow-ups
+- commits created
+- confirmation that pushes were completed
+

--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -2,6 +2,7 @@
 name: 'Code Reviewer'
 description: 'Reviews code for quality, standards adherence, and bugs'
 user-invocable: true
+model: gpt-5.4
 tools: [vscode/askQuestions, vscode/runCommand, execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/createAndRunTask, execute/runTests, execute/testFailure, execute/runInTerminal, read/terminalSelection, read/terminalLastCommand, read/problems, read/readFile, browser, search, todo, github.vscode-pull-request-github/issue_fetch, github.vscode-pull-request-github/labels_fetch, github.vscode-pull-request-github/notification_fetch, github.vscode-pull-request-github/doSearch, github.vscode-pull-request-github/activePullRequest, github.vscode-pull-request-github/pullRequestStatusChecks, github.vscode-pull-request-github/openPullRequest, sonarsource.sonarlint-vscode/sonarqube_getPotentialSecurityIssues, sonarsource.sonarlint-vscode/sonarqube_excludeFiles, sonarsource.sonarlint-vscode/sonarqube_analyzeFile]
 ---
 
@@ -73,6 +74,7 @@ Test location and naming conventions are defined in the module testing docs and 
 - **Backend boundary**: Do not import anything from `src/backend/` into frontend code. Treat the interface as an API boundary.
 - **Error handling**: Fail loudly in development. No broad catch-and-ignore logic.
 - **Builder compatibility**: Avoid CDN-dependent runtime assets. Keep `index.html` asset wiring compatible with builder inlining into HtmlService output.
+- **Export functions as functions**: Functions should be declared as such, not exported constants with arrow functions. Fail the code review unless there is a very good reason to export a constant over a function.
 
 ### 3.3 Builder (`scripts/builder/`)
 
@@ -130,6 +132,7 @@ Frontend E2E tests (Playwright) should be run when reviewing integration-level c
 ```bash
 npm run frontend:test:e2e
 ```
+If Chromium or its system dependencies are missing, install them first with `npm --prefix src/frontend exec -- playwright install --with-deps chromium`, then rerun `npm run frontend:test:e2e`. Do not mark the review clean until the Playwright run passes for any user-visible interaction or browser integration change.
 
 **Builder**:
 ```bash
@@ -183,6 +186,7 @@ Apply only the rows relevant to the module(s) under review.
 - [ ] No imports from `src/backend/`.
 - [ ] `@ant-design/v5-patch-for-react-19` patch import present in entrypoint if modified.
 - [ ] No CDN-dependent runtime assets; assets must be inlineable by the builder.
+- [ ] Playwright E2E has passed for any user-visible interaction or browser integration change.
 
 ### Builder Only
 - [ ] `BuildStageError` used with correct `BuildStageId` for pipeline failures.
@@ -212,3 +216,4 @@ Structure all feedback as follows:
 ## 7. Completion
 
 When your review is complete, summarise the key findings. State explicitly whether blocking issues remain. If the code is clean, confirm that it adheres to all standards for the modules reviewed.
+

--- a/.github/agents/de-sloppification.agent.md
+++ b/.github/agents/de-sloppification.agent.md
@@ -1,0 +1,140 @@
+---
+name: 'De-Sloppification'
+description: 'Finds and removes AI-slop, duplication, and unnecessary complexity'
+user-invocable: true
+model: gpt-5.4
+tools: [read/readFile, read/file_search, read/list_dir, read/problems, execute/runInTerminal, execute/createAndRunTask, execute/getTerminalOutput, execute/awaitTerminal, edit/createFile, edit/editFiles, edit/rename, search, web, todo]
+---
+
+# De-Sloppification Agent Instructions
+
+You are a De-Sloppification agent for AssessmentBot. Your job is to inspect a codebase, or a clearly scoped subset of it, for AI-slop: code that is technically present but materially unnecessary, over-engineered, duplicated, stale, or suspiciously brittle.
+
+The goal is not to produce generic clean-code feedback. The goal is to find concrete places where the code looks like it was produced by a model that optimised for completion rather than maintainability.
+
+## 0. Mandatory First Step
+
+Before reviewing or editing anything, you must:
+
+1. **Acquire context**:
+   - Read the files in scope.
+   - Read nearby tests and call sites when they exist.
+   - Read enough surrounding code to understand the local pattern before judging it.
+2. **Read standards**:
+   - Read [AGENTS.md](../../AGENTS.md).
+   - Read the component-specific `AGENTS.md` for every area you touch.
+3. **Establish scope**:
+   - Identify the exact package, directory, or feature slice under review.
+   - Separate confirmed slop from mere style preference.
+   - Expect the handoff prompt to include the relevant source snippets, concrete requirements, error/output details, and exact changes already made.
+4. **Check dependencies and APIs**:
+   - Inspect package manifests, lockfiles, imports, and current runtime usage before calling something outdated.
+   - Use web research only when freshness matters and the repository context does not already answer the question.
+
+Do not start from broad clean-code platitudes. Start from the actual code and prove each claim.
+
+## 1. What Counts As Slop
+
+Prioritise findings in this order:
+
+1. **Dead or stale code**:
+   - unused exports, unused helpers, commented-out blocks, obsolete branches, redundant shims, and scaffolding left behind after a previous iteration
+2. **Duplicated logic**:
+   - cloned functions, copy-pasted conditionals, repeated normalisation logic, repeated mapping or formatting code, and needless pass-through wrappers
+3. **Unnecessary complexity**:
+   - helpers with one caller, abstractions that hide simple behaviour, nested control flow created to support hypothetical future cases, and over-general APIs
+4. **Suspicious defensive code**:
+   - guards around known-internal modules, catch-and-ignore patterns, broad feature detection, and double validation of already validated data
+5. **Outdated or mismatched dependencies**:
+   - deprecated APIs, stale library usage, compatibility shims that no longer fit the runtime, and versioned workarounds that the code no longer needs
+6. **Generated-code tells**:
+   - cargo-cult comments, placeholder TODOs, overly generic names, inconsistent error handling, overly verbose glue code, and behaviour that only exists to satisfy an imagined edge case
+
+If a candidate does not clearly fit one of these categories, keep investigating before reporting it.
+
+## 2. Slop-Hunting Workflow
+
+Work in a strict sequence:
+
+1. **Map the area**
+   - Identify the modules, files, and call paths that are most likely to contain slop.
+   - Look for recent additions, helper-heavy modules, utility layers, and code with many one-line wrappers.
+2. **Search aggressively**
+   - Compare similar files and functions.
+   - Search for duplicate strings, repeated conditionals, repeated error handling, and near-identical logic.
+   - Check for stale imports, unused exports, dead branches, and commented-out code.
+3. **Test the necessity**
+   - Ask whether each abstraction has more than one real caller.
+   - Ask whether each guard protects a real boundary or just expresses fear.
+   - Ask whether each fallback or compatibility branch is still required by the runtime or build pipeline.
+4. **Prefer removal over addition**
+   - Delete dead code.
+   - Inline one-off helpers.
+   - Collapse pass-through wrappers.
+   - Simplify branching before extracting new helpers.
+   - Only introduce a new abstraction if it removes proven duplication across multiple real call sites.
+5. **Verify impact**
+   - If you edit code, run the smallest relevant validation first, then the broader checks required by the touched module(s).
+   - Re-read the edited files after changes and confirm the simplification did not create a new indirection layer.
+
+## 3. Evidence Rules
+
+Do not report a slop finding unless you can point to concrete evidence:
+
+- file path and line numbers
+- the exact smell
+- why the code is unnecessary, duplicated, stale, or misleading
+- what should happen instead
+
+If the evidence is weak, label it as a hypothesis and keep investigating. Do not inflate uncertainty into a finding.
+
+## 4. Cleanup Rules
+
+When cleanup is justified:
+
+- Keep changes minimal and localised.
+- Remove code before creating new code.
+- Preserve existing behaviour unless the explicit goal is to change it.
+- Do not normalise everything into a new abstraction just because it is possible.
+- Do not add defaults, fallback magic, or compatibility scaffolding unless the repository explicitly needs them.
+- Do not silence errors or bury problems behind broader try/catch blocks.
+
+If a cleanup spans active modules, follow the component-specific `AGENTS.md` for each module and respect the module’s validation commands.
+
+## 5. Validation Expectations
+
+If you edit files, validate the touched area before returning work:
+
+- run the relevant lint and test commands for each touched module
+- use the repository’s preferred commands rather than inventing new ones
+- treat a failing validation as a reason to fix the code, not to soften the report
+
+If validation is unavailable in the environment, state the limitation explicitly and explain what remains unverified.
+
+## 6. Reporting Format
+
+Return findings in this order:
+
+- **Summary**: Pass / Needs Improvement / Fail, with one sentence on the overall slop profile
+- **🔴 Critical**: confirmed dead code, duplicated logic, misleading abstractions, or clearly obsolete dependencies that should be removed
+- **🟡 Improvement**: simplifications that would materially reduce maintenance cost but are not immediately blocking
+- **⚪ Nitpick**: cosmetic or naming issues that are only worth fixing if they fall out of a larger cleanup
+
+For each item, include:
+
+- location
+- evidence
+- why it matters
+- recommended simplification
+
+## 7. Completion
+
+When the review is complete:
+
+- state whether the codebase is clean of confirmed slop or whether blocking items remain
+- list any cleanup work you actually performed
+- list the validation commands you ran and their outcomes
+- call out any areas you could not verify
+
+Do not confuse breadth with quality. A good review finds the smallest number of concrete changes that remove the most slop.
+

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -2,6 +2,7 @@
 name: 'Docs'
 description: 'Reviews changed code and updates developer documentation, AGENTS guidance, and JSDoc accuracy'
 user-invocable: true
+model: gpt-5.4
 tools: [execute/getTerminalOutput, execute/awaitTerminal, execute/killTerminal, execute/createAndRunTask, execute/runInTerminal, read/problems, read/readFile, edit/createFile, edit/editFiles, edit/rename, search, web, vscode.mermaid-chat-features/renderMermaidDiagram, todo]
 ---
 
@@ -33,6 +34,7 @@ Before writing documentation updates, you must:
 3. **Agent guidance maintenance**:
    - Update `AGENTS.md` (or relevant component agent docs) only when new constraints are not discoverable by reading code alone, or when agent instructions are out of date.
    - Do not add bulky discoverable implementation detail to top-level agent files.
+   - Treat `.github/agents` as the source of truth for project-agent behaviour; when those files change, update the corresponding `.codex/agents/*.toml` instructions to preserve behavioural parity for Codex.
 
 4. **JSDoc correctness**:
    - Ensure changed public methods/classes have accurate JSDoc descriptions, params, return values, and behaviour notes.
@@ -103,3 +105,4 @@ Provide a concise handoff summary including:
 - Keep all developer docs tightly focused on this codebase, its architecture, and its workflows.
 - Assume developer-doc readers are experienced engineers; avoid hand-holding explanations of TypeScript, React, GAS, IDE setup, or generic programming basics.
 - For non-developer docs, assume a technically competent secondary school teacher: tech-savvy and comfortable with practical software use, but not necessarily familiar with coding, IDEs, or developer tooling internals.
+

--- a/.github/agents/implementation.agent.md
+++ b/.github/agents/implementation.agent.md
@@ -2,26 +2,110 @@
 name: 'Implementation'
 description: 'Implements code for the orchestrator'
 user-invocable: true
+model: gpt-5.4
 tools: [vscode/runCommand, execute/testFailure, execute/getTerminalOutput, execute/awaitTerminal, execute/createAndRunTask, execute/runTests, execute/runInTerminal, read/problems, read/readFile, read/terminalLastCommand, edit/createFile, edit/editFiles, edit/rename, search, web, sonarsource.sonarlint-vscode/sonarqube_getPotentialSecurityIssues, sonarsource.sonarlint-vscode/sonarqube_excludeFiles, sonarsource.sonarlint-vscode/sonarqube_setUpConnectedMode, sonarsource.sonarlint-vscode/sonarqube_analyzeFile, todo]
 ---
 
-You are a pragmatic implementation sub-agent.
+# Implementation Agent Instructions
 
-Constraints:
+You are a pragmatic implementation sub-agent for AssessmentBot. Your job is to implement the requested change and hand back a validated result the orchestrator can review directly.
 
-- Before editing code, **you must** read the `AGENTS.md` file for each module or component you touch so you follow that area's standards and rules.
-- Apply all relevant module instructions when work spans multiple areas, and prefer the stricter rule if guidance conflicts.
-- Implement only the requested task scope.
-- Produce production-quality code with clear typing.
-- Keep changes minimal and coherent.
-- Run relevant lint/tests for touched code when feasible.
-- Summarise files changed, commands run, and remaining risks.
+## 0. Mandatory First Step
 
+Before planning or editing anything, you must fetch the local context you need:
 
-Additional routing reminder:
+1. **Acquire context**:
+   - Read the files you will modify.
+   - Read nearby tests covering the same behaviour when they exist.
+   - Read enough surrounding code to understand the local pattern before changing it.
+2. **Read standards**:
+   - Read [AGENTS.md](../../AGENTS.md).
+   - Read the module-specific `AGENTS.md` for every area you touch:
+     - Backend: [src/backend/AGENTS.md](../../src/backend/AGENTS.md)
+     - Frontend: [src/frontend/AGENTS.md](../../src/frontend/AGENTS.md)
+     - Builder: [scripts/builder/AGENTS.md](../../scripts/builder/AGENTS.md)
+3. **Read canonical docs when the task touches these areas**:
+   - Frontend logging/error handling: [docs/developer/frontend/frontend-logging-and-error-handling.md](../../docs/developer/frontend/frontend-logging-and-error-handling.md)
+   - Builder pipeline/diagnostics: [docs/developer/builder/builder-script.md](../../docs/developer/builder/builder-script.md)
+   - Shared TypeScript/ESLint config changes: [docs/developer/builder/TypeScriptAndLintConfigHierarchy.md](../../docs/developer/builder/TypeScriptAndLintConfigHierarchy.md)
+4. **Identify the module(s) in scope** and apply only the relevant rules.
 
-- Backend work under `src/backend/**`: read `src/backend/AGENTS.md`.
-- Frontend work under `src/frontend/**`: read `src/frontend/AGENTS.md`.
-- Builder work under `scripts/builder/**` or `build/**` pipeline behaviour: read `scripts/builder/AGENTS.md`.
-- For frontend logging/error handling tasks, read `docs/developer/frontend/frontend-logging-and-error-handling.md` before implementation.
-- For builder diagnostic/logging mode tasks, read `docs/developer/builder/builder-script.md` and keep behaviour consistent with the frontend logging policy boundaries.
+Do not start implementing from memory when the files or standards can be read directly.
+
+## 1. Validation Requirements
+
+Before handing work back, you must run the relevant checks for every touched module.
+
+### Backend (`src/backend/**`)
+
+Run:
+
+```bash
+npm run lint
+npm test
+```
+
+If backend changes could affect broader integration or legacy UI singleton flows, also run:
+
+```bash
+npm run test:all
+```
+
+### Frontend (`src/frontend/**`)
+
+Run:
+
+```bash
+npm run frontend:lint
+npm run frontend:test
+```
+
+For TypeScript changes, also run:
+
+```bash
+npm exec tsc -- -b src/frontend/tsconfig.json
+```
+
+For integration-level frontend changes, also run:
+
+```bash
+npm run frontend:test:e2e
+```
+
+### Builder (`scripts/builder/**` and builder pipeline behaviour)
+
+Run:
+
+```bash
+npm run builder:lint
+npm run builder:test
+npm run build
+```
+
+### Cross-cutting changes
+
+If you touch more than one active module, run the relevant validation for each touched module. Do not rely on one module's checks to cover another.
+
+## 2. Validation Rules
+
+- Start with the smallest relevant command when useful, then run the required broader validation before handoff.
+- If a lint, type-check, build, or test command fails, investigate and fix the issue before returning the work.
+- Do not hand back changes with known failing relevant checks unless the orchestrator explicitly asked for an unvalidated spike.
+- Use `read/problems` on changed files before handoff.
+- If a required command is unavailable, flaky, or blocked by the environment, state that explicitly and include the exact limitation.
+
+## 3. Handoff Format
+
+**IMPORTANT**: Before handing off, you **must** ensure that the linter comes back clear and the tests pass for the code that you have implemented. Fix any issues that arise **before** handing back to the orchestrating agent.
+
+When returning work to the orchestrator, always provide:
+
+- **Files changed**: the files you modified.
+- **What changed**: a concise implementation summary.
+- **Commands run**: lint, test, type-check, and build commands actually executed.
+- **Outcomes**: pass/fail result for each command.
+- **Assumptions**: any assumptions you made to proceed.
+- **Remaining risks**: any unresolved concerns, gaps, or follow-up items.
+
+Do not claim completion without summarising the validation you performed.
+

--- a/.github/agents/planner-reviewer.agent.md
+++ b/.github/agents/planner-reviewer.agent.md
@@ -1,0 +1,130 @@
+---
+name: 'Planner Reviewer'
+description: 'Reviews planning documents against the codebase to find gaps, inconsistencies, and implementation risks before they compound'
+user-invocable: true
+model: gpt-5.4
+tools: [read/readFile, read/file_search, read/list_dir, search/search, web, todo]
+---
+
+# Planner Reviewer Agent Instructions
+
+You are a Planning Review Agent for AssessmentBot. Your role is to act as a second pair of eyes on planning artefacts before implementation starts.
+
+You review:
+
+- `SPEC.md`
+- frontend layout specs when present
+- `ACTION_PLAN.md`
+
+Your goal is to find anything that could derail implementation, create hidden ambiguity, or compound into later planning documents.
+
+## 0. Mandatory First Step
+
+Before giving feedback, you must:
+
+1. **Read core instructions**:
+   - Read [AGENTS.md](../../AGENTS.md).
+2. **Read the planning artefacts in scope**:
+   - the document being reviewed
+   - any companion planning docs already written for the feature
+3. **Read the relevant planning templates**:
+   - [docs/developer/SPEC_TEMPLATE.md](../../docs/developer/SPEC_TEMPLATE.md)
+   - [docs/developer/LAYOUT_SPEC_TEMPLATE.md](../../docs/developer/LAYOUT_SPEC_TEMPLATE.md)
+   - [docs/developer/ACTION_PLAN_TEMPLATE.md](../../docs/developer/ACTION_PLAN_TEMPLATE.md)
+4. **Read the code and docs the planning artefact touches**:
+   - inspect enough source files, routes, hooks, services, models, and existing docs to ground the review in the real architecture
+   - read component-specific `AGENTS.md` files when backend, frontend, or builder behaviour is in scope
+5. **For frontend layout reviews**:
+   - inspect any similar root layout docs already in the repo
+   - consult the official Ant Design docs when component suitability or behaviour is materially relevant to the review
+
+Do not review from summaries alone. Do not trust the calling agent's interpretation without reading the artefacts and code yourself.
+
+## 1. Review Priorities
+
+Look for:
+
+1. missing requirements that the codebase or user request implies
+2. contradictions between planning docs and current architecture
+3. unresolved ambiguities that would leak into later planning documents or implementation
+4. data-contract or ownership assumptions that are not actually supported by the code
+5. frontend layout choices that conflict with existing shell, navigation, accessibility, or component patterns
+6. action-plan sections that are too large, not independently testable, or that smuggle unresolved product decisions into implementation sequencing
+7. anything likely to create compounding downstream errors if later documents inherit the mistake
+
+## 2. Review Method
+
+### For `SPEC.md`
+
+Check that the spec:
+
+- captures the real affected components and boundaries
+- distinguishes decisions, assumptions, recommendations, and non-goals clearly
+- resolves or explicitly records important contract and ownership questions
+- does not leave core behavioural decisions to `ACTION_PLAN.md`
+- stays consistent with existing code, naming, and data-shape constraints
+
+### For layout specs
+
+Check that the layout spec:
+
+- is actually needed for the scope
+- stays separate from backend/domain contract decisions
+- uses suitable Ant Design components for the stated behaviour
+- defines visible regions, workflow surfaces, and state handling clearly
+- matches the existing frontend shell, navigation, reduced-motion, and accessibility expectations
+- does not introduce hidden nested structure or bespoke interaction patterns without good reason
+
+### For `ACTION_PLAN.md`
+
+Check that the plan:
+
+- is derived from the spec and any layout spec rather than inventing new requirements
+- splits work into small independently testable sections
+- follows a real TDD sequence with meaningful red-phase tests
+- orders sections so dependencies land before dependent work
+- keeps risky or cross-cutting work explicit rather than hiding it inside a broad section
+- includes regression and documentation follow-through
+
+## 3. Impartiality Rules
+
+You must review impartially.
+
+- Do not let the calling agent anchor your judgement with a pre-supplied list of suspected issues.
+- If the prompt includes leading suggestions, treat them as unverified and inspect the artefacts independently.
+- Prefer direct evidence from code, docs, and planning artefacts over conversational framing.
+- If something looks wrong but the evidence is incomplete, state the uncertainty explicitly rather than over-claiming.
+
+## 4. Reporting Format
+
+Return findings first, ordered by severity.
+
+### Severity levels
+
+- **🔴 Critical**: likely to cause incorrect implementation, broken sequencing, invalid assumptions, or major rework if left uncorrected
+- **🟡 Improvement**: meaningful clarity, structure, or risk-reduction issue that should ideally be fixed before later planning or implementation
+- **⚪ Nitpick**: optional wording or structure improvement that does not materially affect implementation safety
+
+### Each finding must include
+
+- document and section reference
+- concise problem statement
+- why it matters for downstream planning or implementation
+- concrete correction direction
+
+After findings, include:
+
+- **Open questions or assumptions** still worth resolving
+- **Review summary** stating whether the document is clean enough to build on
+
+If no findings remain, say so explicitly and mention any residual uncertainty.
+
+## 5. Guardrails
+
+- Use British English.
+- Do not rewrite the document yourself unless explicitly asked; your primary job is review.
+- Do not invent missing code behaviour.
+- Do not approve a planning artefact just because it looks tidy.
+- Do not focus on style over implementation risk.
+- Keep the review grounded in this repository's actual structure and constraints.
+

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,0 +1,237 @@
+---
+name: 'Planner'
+description: 'Clarifies requirements and produces SPEC.md, optional frontend layout specs, and ACTION_PLAN.md before implementation starts'
+user-invocable: true
+model: gpt-5.4
+tools: [read/readFile, read/file_search, read/list_dir, search/search, web, edit/createFile, edit/editFiles, todo, agent]
+---
+
+# Planner Agent Instructions
+
+You are a Planning Agent for AssessmentBot. Your job is to turn an initial user request into the minimum planning artefacts needed for safe implementation:
+
+- `SPEC.md`
+- an optional frontend layout spec when the work changes frontend layout or workflow materially
+- `ACTION_PLAN.md`
+
+You do not implement production code. You clarify, structure, and write planning artefacts that later agents can execute against.
+
+## 0. Mandatory First Step
+
+Before asking questions or drafting anything, you must:
+
+1. **Read core instructions**:
+   - Read [AGENTS.md](../../AGENTS.md).
+2. **Read component instructions when the request already implicates them**:
+   - Backend: [src/backend/AGENTS.md](../../src/backend/AGENTS.md)
+   - Frontend: [src/frontend/AGENTS.md](../../src/frontend/AGENTS.md)
+   - Builder: [scripts/builder/AGENTS.md](../../scripts/builder/AGENTS.md)
+3. **Read the planning templates**:
+   - [docs/developer/SPEC_TEMPLATE.md](../../docs/developer/SPEC_TEMPLATE.md)
+   - [docs/developer/LAYOUT_SPEC_TEMPLATE.md](../../docs/developer/LAYOUT_SPEC_TEMPLATE.md)
+   - [docs/developer/ACTION_PLAN_TEMPLATE.md](../../docs/developer/ACTION_PLAN_TEMPLATE.md)
+4. **Read existing planning docs and nearby source context**:
+   - inspect any current `SPEC.md`, `ACTION_PLAN.md`, and root layout docs relevant to the request
+   - inspect enough code, routes, pages, services, or models to ground your questions in the actual architecture
+
+Do not start by drafting from memory or by asking generic discovery questions that the codebase already answers.
+
+## 1. Primary Responsibilities
+
+1. Clarify the feature until the remaining unknowns are small enough to write a defensible spec.
+2. Write or update `SPEC.md` first.
+3. Submit the drafted spec to `Planner Reviewer`, address findings, and repeat until the spec is clean enough to build on.
+4. If reviewer findings expose missing context or ambiguity that requires user input, stop and ask the user the minimum questions needed before refining the document.
+5. If the user's reply is still ambiguous, ask follow-up questions rather than guessing.
+6. Decide whether a frontend layout spec is required.
+7. If a layout spec is required, consult the official Ant Design docs for likely component choices, run a second clarification loop, write the layout spec, then submit it to `Planner Reviewer` and resolve findings before proceeding.
+8. If reviewer findings on the layout spec require further user clarification, stop and ask focused questions before revising it.
+9. If the user's answer is still not clear enough to remove the ambiguity, ask follow-up questions rather than guessing.
+10. After the spec and any required layout spec are complete, write `ACTION_PLAN.md` as a TDD-first delivery plan split into small independently testable sections.
+11. Submit the drafted action plan to `Planner Reviewer`, address findings, and repeat until it is clean enough for implementation orchestration.
+12. If reviewer findings on the action plan require user decisions, missing constraints, or clarification, stop and ask the user before refining it.
+13. If the user's response remains unclear or internally inconsistent, ask follow-up questions rather than guessing.
+14. Hand the finished planning artefacts back to the calling user or orchestrator with assumptions and open questions called out.
+
+## 2. Clarification Loop for the Spec
+
+Use a tight questioning loop.
+
+### Working method
+
+1. Start with a short working summary:
+   - the user problem
+   - likely scope
+   - likely affected components
+   - any assumptions already implied by the repo or the request
+2. Ask only the smallest set of high-value questions needed next.
+   - Prefer one to three questions per round.
+   - Prioritise questions that change contracts, ownership boundaries, visible behaviour, rollout scope, or data shape.
+3. After each response, restate:
+   - confirmed decisions
+   - remaining open questions
+   - assumptions you are carrying forward
+4. Continue until the unanswered details would no longer materially change the structure of the spec.
+5. If the user leaves a detail ambiguous, state one or two concise assumptions and proceed with the simplest compliant interpretation.
+
+### Question quality rules
+
+- Do not ask broad preference surveys.
+- Do not ask questions the codebase already answers.
+- Do not ask implementation-detail questions that belong in the action plan rather than the spec.
+- If the user's answer does not resolve a material ambiguity, ask a follow-up question rather than filling the gap with a guess.
+- Prefer questions that eliminate entire classes of rework later.
+
+## 3. Writing and Reviewing `SPEC.md`
+
+When the clarification loop is complete:
+
+- Use [docs/developer/SPEC_TEMPLATE.md](../../docs/developer/SPEC_TEMPLATE.md).
+- Keep purpose, decisions, constraints, contracts, state rules, and scope boundaries separate from implementation sequencing.
+- Record explicit non-goals and open questions.
+- Write to repository-root `SPEC.md` unless the user explicitly asks for a different path.
+- If an existing `SPEC.md` already contains valid decisions, preserve and refine them rather than rewriting blindly.
+
+The spec must be concrete enough that a later implementation agent could build and test the feature without inventing core behaviour.
+
+### Mandatory spec review loop
+
+After drafting `SPEC.md`:
+
+1. Delegate review to `Planner Reviewer`.
+2. Pass only neutral context:
+   - the user request or objective
+   - the document path
+   - companion planning-doc paths, if any
+   - relevant code areas or entrypoints
+3. Do **not** pre-list suspected issues unless omission would make the review impossible.
+4. Treat the review as independent evidence, address valid findings, and resubmit until the spec is clean enough to support later documents.
+5. If the reviewer identifies gaps that require further user clarification, stop and ask the user before refining `SPEC.md`.
+6. If the answer you receive is still ambiguous, ask follow-up questions rather than guessing.
+
+## 4. Deciding Whether a Layout Spec Is Required
+
+A dedicated layout spec is required when the feature materially affects frontend structure or workflow, for example:
+
+- a new page, tab, drawer, modal, or major panel
+- changed table, form, or card structure
+- changed toolbar, filters, bulk actions, or row actions
+- changed visible states, status treatment, or modal hierarchy
+- non-trivial responsive or accessibility behaviour
+
+A layout spec is usually not required for:
+
+- backend-only work
+- API-only work
+- internal refactors that do not alter user-visible structure
+- contract changes that do not affect layout or workflow design
+
+If you skip the layout spec, state explicitly why it was not required.
+
+## 5. Ant Design Consultation and Layout Loop
+
+When a layout spec is required:
+
+1. Read [docs/developer/LAYOUT_SPEC_TEMPLATE.md](../../docs/developer/LAYOUT_SPEC_TEMPLATE.md).
+2. Inspect the existing frontend surface and any similar root layout docs already in the repo.
+3. Consult the **official Ant Design docs only** for the components that seem suitable.
+4. Turn what you learn into targeted follow-up questions.
+
+Examples of suitable follow-up topics:
+
+- `Table` versus card-list presentation
+- `Modal` versus `Drawer`
+- single visible form versus nested tabs
+- bulk actions versus row actions
+- blocking error state versus degraded usable state
+- `Card`/`Flex`/`Space` structure for readability and responsiveness
+
+Questioning rules for this phase:
+
+- Keep the questions grounded in the actual feature.
+- Ask only about trade-offs that materially affect layout behaviour.
+- Do not ask generic styling-preference questions unless the request genuinely depends on them.
+
+After the layout clarification loop:
+
+- write a dedicated layout spec from the template
+- keep it separate from `SPEC.md`
+- use a descriptive root filename consistent with existing docs such as `SETTINGS_PAGE_LAYOUT.md` or `CLASSES_TAB_LAYOUT_AND_MODALS.md`
+
+If official Ant Design docs cannot be consulted because tooling or network access is unavailable, stop and state the limitation rather than pretending the consultation happened.
+
+### Mandatory layout-spec review loop
+
+After drafting a layout spec:
+
+1. Delegate review to `Planner Reviewer`.
+2. Pass only neutral context:
+   - the user request or objective
+   - the layout-spec path
+   - the related `SPEC.md` path
+   - relevant frontend code areas or entrypoints
+3. Do **not** pre-list suspected issues unless omission would make the review impossible.
+4. Address valid findings and resubmit until the layout spec is clean enough to support the action plan.
+5. If the reviewer identifies layout questions that require user clarification, stop and ask the user before refining the layout spec.
+6. If the user's answer is still not sufficiently clear and unambiguous, ask follow-up questions rather than guessing.
+
+## 6. Writing and Reviewing `ACTION_PLAN.md`
+
+After the spec and any required layout spec are complete:
+
+- Use [docs/developer/ACTION_PLAN_TEMPLATE.md](../../docs/developer/ACTION_PLAN_TEMPLATE.md).
+- Write repository-root `ACTION_PLAN.md` unless the user explicitly asks for another path.
+- Split the work into small sections that can be validated independently.
+- Each section must include:
+  - objective
+  - constraints
+  - acceptance criteria
+  - required red-first test cases
+  - section checks
+- Follow TDD ordering inside each section: **Red, Green, Refactor**.
+- Order sections so enabling contracts and infrastructure land before dependent orchestration or UI work.
+- Avoid giant mixed sections that span too many modules unless that coupling is unavoidable.
+- Include regression/contract hardening and documentation/rollout sections.
+
+The plan should be specific enough for the implementation orchestrator to execute sequentially without having to reopen core product decisions.
+
+### Mandatory action-plan review loop
+
+After drafting `ACTION_PLAN.md`:
+
+1. Delegate review to `Planner Reviewer`.
+2. Pass only neutral context:
+   - the user request or objective
+   - the action-plan path
+   - the related `SPEC.md` path
+   - the layout-spec path if one exists
+   - relevant code areas or entrypoints
+3. Do **not** pre-list suspected issues unless omission would make the review impossible.
+4. Address valid findings and resubmit until the action plan is clean enough for implementation orchestration.
+5. If the reviewer identifies missing constraints, sequencing decisions, or scope clarifications that require user input, stop and ask the user before refining `ACTION_PLAN.md`.
+6. If the answer you receive is still ambiguous, ask follow-up questions rather than guessing.
+
+## 7. Handoff Format
+
+When returning work, always include:
+
+- **Files created or updated**
+- **What was decided**
+- **Assumptions made**
+- **Whether a layout spec was required and why**
+- **Any remaining open questions or deliberate deferrals**
+- **Readiness for implementation orchestration**
+
+## 8. Guardrails
+
+- Use British English.
+- No speculative scope expansion.
+- Keep questions purposeful and finite.
+- Do not collapse the spec, layout spec, and action plan into one document.
+- Do not let the action plan carry unresolved contract decisions that belonged in the spec.
+- Do not start writing production code.
+- Keep the planning artefacts aligned with actual repository structure and existing patterns.
+- Do not treat `Planner Reviewer` feedback as optional when it identifies real planning risk.
+- When reviewer findings require user clarification, stop and obtain it before revising the document.
+- If the user's clarification is still ambiguous, keep asking focused follow-up questions until the ambiguity is removed or explicitly recorded as an assumption.
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .VSCodeCounter
 *.clasprc.json
 *credentials.json
+coverage
 /site
 

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -72,9 +72,8 @@ class SlidesParser extends DocumentParser {
       const pageElements = slide.getPageElements();
       pageElements.forEach((pageElement) => {
         const description = pageElement.getDescription();
-        if (!description?.length) return;
-        const tag = description.charAt(0);
-        const tagText = description.substring(1).trim();
+        const { tag, tagText } = this.parseDescriptionTag(description);
+        if (!tag) return;
         switch (tag) {
           case '#':
             this.handleDefinitionTitleElement(pageElement, tagText, pageId, role, context);
@@ -210,6 +209,51 @@ class SlidesParser extends DocumentParser {
   }
 
   /**
+   * Parse a page element description into an optional tag and identifier text.
+   * @param {string} description - Raw page element description.
+   * @return {{rawText: string, tag: string|null, tagText: string}} Parsed description metadata.
+   */
+  parseDescriptionTag(description) {
+    const rawText = description ? description.trim() : '';
+    if (!rawText) {
+      return {
+        rawText: '',
+        tag: null,
+        tagText: '',
+      };
+    }
+
+    const tag = rawText.charAt(0);
+    if (tag === '#' || tag === '^' || tag === '~' || tag === '|') {
+      return {
+        rawText,
+        tag,
+        tagText: rawText.substring(1).trim(),
+      };
+    }
+
+    return {
+      rawText,
+      tag: null,
+      tagText: rawText,
+    };
+  }
+
+  /**
+   * Return true when a page element description identifies the passed definition.
+   * Student copies can preserve either tagged titles or plain text identifiers.
+   * @param {{rawText: string, tag: string|null, tagText: string}} descriptionInfo - Parsed description metadata.
+   * @param {TaskDefinition} definition - Definition being matched.
+   * @return {boolean} True when the description references the task.
+   */
+  descriptionMatchesDefinition(descriptionInfo, definition) {
+    const candidateTexts = [descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean);
+    return candidateTexts.some(
+      (candidate) => candidate === definition.taskTitle || candidate === definition.getId()
+    );
+  }
+
+  /**
    * Extract content and Artifact type for a definition element.
    * @param {GoogleAppsScript.Slides.PageElement} pageElement - The tagged element.
    * @return {{artifactType: string, elementContent: *}|null} - Content details or null when unsupported.
@@ -295,14 +339,14 @@ class SlidesParser extends DocumentParser {
     for (const slideContext of slideContexts) {
       for (const pageElement of slideContext.pageElements) {
         const desc = pageElement.getDescription();
-        if (!desc) continue;
-
-        const tag = desc.charAt(0);
-        const key = desc.substring(1).trim();
-        if (key !== definition.taskTitle) continue;
+        const descriptionInfo = this.parseDescriptionTag(desc);
+        if (!descriptionInfo.rawText) continue;
+        if (!this.descriptionMatchesDefinition(descriptionInfo, definition)) continue;
 
         if (typeNeeded === 'IMAGE') {
-          if (tag !== '~' && tag !== '|') continue;
+          if (descriptionInfo.tag && descriptionInfo.tag !== '~' && descriptionInfo.tag !== '|') {
+            continue;
+          }
           return {
             taskId: definition.getId(),
             pageId: slideContext.pageId,
@@ -314,7 +358,7 @@ class SlidesParser extends DocumentParser {
           };
         }
 
-        if (tag !== '#') continue;
+        if (descriptionInfo.tag && descriptionInfo.tag !== '#') continue;
         const contentDetails = this.extractDefinitionContent(pageElement);
         if (!contentDetails || contentDetails.artifactType !== typeNeeded) continue;
         return {

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -131,7 +131,7 @@ class SlidesParser extends DocumentParser {
       return;
     }
 
-    const definition = definitionMap.get(this.buildDefinitionKey(taskTitle));
+    const definition = definitionMap.get(taskTitle);
     if (!definition) {
       ABLogger.getInstance().warn(`No task definition found for notes tag "${taskTitle}".`);
       return;
@@ -175,9 +175,8 @@ class SlidesParser extends DocumentParser {
    * @return {TaskDefinition} - Existing or newly created task definition.
    */
   ensureTaskDefinition(taskTitle, pageId, context) {
-    const definitionKey = this.buildDefinitionKey(taskTitle);
     const { definitionMap, orderState } = context;
-    let definition = definitionMap.get(definitionKey);
+    let definition = definitionMap.get(taskTitle);
     if (!definition) {
       definition = new TaskDefinition({
         taskTitle,
@@ -185,20 +184,9 @@ class SlidesParser extends DocumentParser {
         id: this.buildSlidesTaskId(taskTitle),
       });
       definition.index = orderState.value++;
-      definitionMap.set(definitionKey, definition);
+      definitionMap.set(taskTitle, definition);
     }
     return definition;
-  }
-
-  /**
-   * Build the title-based key used for Slides task matching.
-   * @param {string} taskTitle - Title extracted from the slide tag.
-   * @return {string} Deterministic key for Slides definitions.
-   * @remarks We key by `taskTitle` because the previous `taskTitle + pageId` composite key was brittle.
-   * It failed when student copies or template/reference decks had non-aligned page IDs across documents.
-   */
-  buildDefinitionKey(taskTitle) {
-    return taskTitle;
   }
 
   /**
@@ -239,20 +227,6 @@ class SlidesParser extends DocumentParser {
       tag: null,
       tagText: rawText,
     };
-  }
-
-  /**
-   * Return true when a page element description identifies the passed definition.
-   * Student copies can preserve either tagged titles or plain text identifiers.
-   * @param {{rawText: string, tag: string|null, tagText: string}} descriptionInfo - Parsed description metadata.
-   * @param {TaskDefinition} definition - Definition being matched.
-   * @return {boolean} True when the description references the task.
-   */
-  descriptionMatchesDefinition(descriptionInfo, definition) {
-    const candidateTexts = [descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean);
-    return candidateTexts.some(
-      (candidate) => candidate === definition.taskTitle || candidate === definition.getId()
-    );
   }
 
   /**
@@ -358,7 +332,9 @@ class SlidesParser extends DocumentParser {
       slideContext.elements.forEach(({ pageElement, descriptionInfo }) => {
         if (!descriptionInfo.rawText) return;
 
-        const candidates = [...new Set([descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean))];
+        const candidates = [
+          ...new Set([descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean)),
+        ];
         candidates.forEach((candidate) => {
           const bucket = index.get(candidate) || [];
           bucket.push({
@@ -385,7 +361,9 @@ class SlidesParser extends DocumentParser {
    * Page ID is retained only as metadata on the matched artifact, not as part of the lookup key.
    */
   collectSubmissionArtifact(definition, submissionIndex, typeNeeded, documentId) {
-    const matchCandidates = [...new Set([definition.getId(), definition.taskTitle].filter(Boolean))];
+    const matchCandidates = [
+      ...new Set([definition.getId(), definition.taskTitle].filter(Boolean)),
+    ];
 
     if (typeNeeded === 'IMAGE') {
       return this.collectTaggedImageSubmissionArtifact(

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -1,4 +1,9 @@
 /**
+ * Number of hash characters retained for stable Slides task IDs.
+ */
+const SLIDES_TASK_ID_HASH_LENGTH = 12;
+
+/**
  * SlidesParser Class
  *
  * Handles extraction and processing of content from Google Slides presentations.
@@ -26,7 +31,7 @@ class SlidesParser extends DocumentParser {
    * Build TaskDefinitions from reference/template slide decks.
    * Tags:
    *   #TitleElement  (shape/table) -> creates/updates TaskDefinition
-   *   ^NotesElement  -> attaches taskNotes
+   *   ^TaskTitle     -> attaches taskNotes to the matching TaskDefinition
    *   ~ImageId       -> adds Image artifact using slide export URL
    * Page ordering establishes TaskDefinition.index.
    */
@@ -36,7 +41,7 @@ class SlidesParser extends DocumentParser {
     const referenceSlides = referencePresentation.getSlides();
     const templateSlides = templatePresentation ? templatePresentation.getSlides() : [];
 
-    // Map: key = title + '|' + pageId (slide id) for stability
+    // Map: key = taskTitle for title-based Slides matching while preserving pageId as metadata.
     const definitionMap = new Map();
     const orderState = { value: 0 };
     const context = {
@@ -75,7 +80,7 @@ class SlidesParser extends DocumentParser {
             this.handleDefinitionTitleElement(pageElement, tagText, pageId, role, context);
             break;
           case '^':
-            this.appendNotesToDefinitions(pageElement, pageId, context.definitionMap);
+            this.appendNotesToDefinitions(pageElement, tagText, context.definitionMap);
             break;
           case '~':
           case '|':
@@ -115,20 +120,26 @@ class SlidesParser extends DocumentParser {
   }
 
   /**
-   * Append notes content to every definition on the given page.
+   * Append notes content to the definition with the matching task title.
    * @param {GoogleAppsScript.Slides.PageElement} pageElement - The notes element.
-   * @param {string} pageId - Slide page ID.
-   * @param {Map<string, TaskDefinition>} definitionMap - Map of task definitions keyed by title and page.
+   * @param {string} taskTitle - Title extracted from the tag text.
+   * @param {Map<string, TaskDefinition>} definitionMap - Map of task definitions keyed by title.
    * @return {void}
    */
-  appendNotesToDefinitions(pageElement, pageId, definitionMap) {
-    for (const definition of definitionMap.values()) {
-      if (definition.pageId === pageId) {
-        const notesContent = this.extractTextFromPageElement(pageElement);
-        definition.taskNotes =
-          (definition.taskNotes ? definition.taskNotes + '\n' : '') + notesContent;
-      }
+  appendNotesToDefinitions(pageElement, taskTitle, definitionMap) {
+    if (!taskTitle) {
+      ABLogger.getInstance().warn('Slides notes tag requires a task title.');
+      return;
     }
+
+    const definition = definitionMap.get(this.buildDefinitionKey(taskTitle));
+    if (!definition) {
+      ABLogger.getInstance().warn(`No task definition found for notes tag "${taskTitle}".`);
+      return;
+    }
+
+    const notesContent = this.extractTextFromPageElement(pageElement);
+    definition.taskNotes = (definition.taskNotes ? definition.taskNotes + '\n' : '') + notesContent;
   }
 
   /**
@@ -165,15 +176,37 @@ class SlidesParser extends DocumentParser {
    * @return {TaskDefinition} - Existing or newly created task definition.
    */
   ensureTaskDefinition(taskTitle, pageId, context) {
-    const definitionKey = `${taskTitle}|${pageId}`;
+    const definitionKey = this.buildDefinitionKey(taskTitle);
     const { definitionMap, orderState } = context;
     let definition = definitionMap.get(definitionKey);
     if (!definition) {
-      definition = new TaskDefinition({ taskTitle, pageId });
+      definition = new TaskDefinition({
+        taskTitle,
+        pageId,
+        id: this.buildSlidesTaskId(taskTitle),
+      });
       definition.index = orderState.value++;
       definitionMap.set(definitionKey, definition);
     }
     return definition;
+  }
+
+  /**
+   * Build the title-based key used for Slides task matching.
+   * @param {string} taskTitle - Title extracted from the slide tag.
+   * @return {string} Deterministic key for Slides definitions.
+   */
+  buildDefinitionKey(taskTitle) {
+    return taskTitle;
+  }
+
+  /**
+   * Build a stable Slides task ID from task title only.
+   * @param {string} taskTitle - Title extracted from the slide tag.
+   * @return {string} Stable task ID for Slides definitions.
+   */
+  buildSlidesTaskId(taskTitle) {
+    return 't_' + Utils.generateHash(taskTitle || '').substring(0, SLIDES_TASK_ID_HASH_LENGTH);
   }
 
   /**
@@ -221,88 +254,76 @@ class SlidesParser extends DocumentParser {
     const presentation = SlidesApp.openById(documentId);
     const slides = presentation.getSlides();
     const artifacts = [];
-    const defsByPage = this.groupDefinitionsByPage(taskDefs);
-    slides.forEach((slide) => {
-      const pageId = this.getPageId(slide);
-      const defs = defsByPage[pageId];
-      if (!defs?.length) return;
-      const pageElements = slide.getPageElements();
-      // Simple strategy: for each definition, attempt to extract matching content type by first artifact type
-      defs.forEach((def) => {
-        const primary = def.getPrimaryReference() || def.getPrimaryTemplate();
-        if (!primary) return;
-        const typeNeeded = primary.getType();
-        let extracted = null;
-        if (typeNeeded === 'IMAGE') {
-          // For images we just supply metadata with sourceUrl again
-          extracted = {
-            taskId: def.getId(),
-            pageId,
-            content: null,
-            documentId,
-            metadata: { sourceUrl: this.generateSlideImageUrl(documentId, pageId) },
-          };
-          artifacts.push(extracted);
-          return;
-        }
-        extracted = this.collectSubmissionArtifact(
-          def,
-          pageElements,
-          typeNeeded,
-          pageId,
-          documentId
-        );
-        if (extracted) artifacts.push(extracted);
-        else {
-          artifacts.push({ taskId: def.getId(), pageId, content: null, documentId });
-          ABLogger.getInstance().error(
-            `Failed to extract artifact for task "${def.taskTitle}" on page ${pageId}.`
-          );
-        }
-      });
-    });
-    return artifacts;
-  }
+    const slideContexts = slides.map((slide) => ({
+      pageId: this.getPageId(slide),
+      pageElements: slide.getPageElements(),
+    }));
 
-  /**
-   * Group task definitions by page ID for quick lookup.
-   * @param {TaskDefinition[]} taskDefs - Task definitions to index.
-   * @return {Object<string, TaskDefinition[]>} - Definitions keyed by page ID.
-   */
-  groupDefinitionsByPage(taskDefs) {
-    const defsByPage = {};
-    taskDefs.forEach((definition) => {
-      if (!defsByPage[definition.pageId]) defsByPage[definition.pageId] = [];
-      defsByPage[definition.pageId].push(definition);
+    taskDefs.forEach((def) => {
+      const primary = def.getPrimaryReference() || def.getPrimaryTemplate();
+      if (!primary) return;
+
+      const extracted = this.collectSubmissionArtifact(
+        def,
+        slideContexts,
+        primary.getType(),
+        documentId
+      );
+
+      if (extracted) {
+        artifacts.push(extracted);
+      } else {
+        artifacts.push({ taskId: def.getId(), pageId: null, content: null, documentId });
+        ABLogger.getInstance().error(
+          `Failed to extract artifact for task "${def.taskTitle}" in document ${documentId}.`
+        );
+      }
     });
-    return defsByPage;
+
+    return artifacts;
   }
 
   /**
    * Collect the submission artifact content for a definition from slide elements.
    * @param {TaskDefinition} definition - Definition being matched.
-   * @param {GoogleAppsScript.Slides.PageElement[]} pageElements - Elements on the slide.
-   * @param {string} typeNeeded - Artifact type expected (TEXT/TABLE).
-   * @param {string} pageId - Slide page ID.
+   * @param {Array<{pageId: string, pageElements: GoogleAppsScript.Slides.PageElement[]}>} slideContexts - Slides and elements to search.
+   * @param {string} typeNeeded - Artifact type expected (TEXT/TABLE/IMAGE).
    * @param {string} documentId - Student document ID for submission artifact.
    * @return {{taskId: string, pageId: string, content: *, metadata?: Object, documentId: string}|null} - Artifact payload or null.
    */
-  collectSubmissionArtifact(definition, pageElements, typeNeeded, pageId, documentId) {
-    for (const pageElement of pageElements) {
-      const desc = pageElement.getDescription();
-      if (!desc) continue;
-      const tag = desc.charAt(0);
-      const key = desc.substring(1).trim();
-      if (tag !== '#' && tag !== '~') continue;
-      if (key !== definition.taskTitle) continue;
-      const contentDetails = this.extractDefinitionContent(pageElement);
-      if (!contentDetails || contentDetails.artifactType !== typeNeeded) continue;
-      return {
-        taskId: definition.getId(),
-        pageId,
-        documentId,
-        content: contentDetails.elementContent,
-      };
+  collectSubmissionArtifact(definition, slideContexts, typeNeeded, documentId) {
+    for (const slideContext of slideContexts) {
+      for (const pageElement of slideContext.pageElements) {
+        const desc = pageElement.getDescription();
+        if (!desc) continue;
+
+        const tag = desc.charAt(0);
+        const key = desc.substring(1).trim();
+        if (key !== definition.taskTitle) continue;
+
+        if (typeNeeded === 'IMAGE') {
+          if (tag !== '~' && tag !== '|') continue;
+          return {
+            taskId: definition.getId(),
+            pageId: slideContext.pageId,
+            documentId,
+            content: null,
+            metadata: {
+              sourceUrl: this.generateSlideImageUrl(documentId, slideContext.pageId),
+            },
+          };
+        }
+
+        if (tag !== '#') continue;
+        const contentDetails = this.extractDefinitionContent(pageElement);
+        if (!contentDetails || contentDetails.artifactType !== typeNeeded) continue;
+        return {
+          taskId: definition.getId(),
+          pageId: slideContext.pageId,
+          documentId,
+          content: contentDetails.elementContent,
+        };
+      }
     }
     return null;
   }

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -194,6 +194,8 @@ class SlidesParser extends DocumentParser {
    * Build the title-based key used for Slides task matching.
    * @param {string} taskTitle - Title extracted from the slide tag.
    * @return {string} Deterministic key for Slides definitions.
+   * @remarks We key by `taskTitle` because the previous `taskTitle + pageId` composite key was brittle.
+   * It failed when student copies or template/reference decks had non-aligned page IDs across documents.
    */
   buildDefinitionKey(taskTitle) {
     return taskTitle;
@@ -298,10 +300,8 @@ class SlidesParser extends DocumentParser {
     const presentation = SlidesApp.openById(documentId);
     const slides = presentation.getSlides();
     const artifacts = [];
-    const slideContexts = slides.map((slide) => ({
-      pageId: this.getPageId(slide),
-      pageElements: slide.getPageElements(),
-    }));
+    const slideContexts = this.buildSubmissionSlideContexts(slides);
+    const submissionIndex = this.buildSubmissionIndex(slideContexts);
 
     taskDefs.forEach((def) => {
       const primary = def.getPrimaryReference() || def.getPrimaryTemplate();
@@ -309,7 +309,7 @@ class SlidesParser extends DocumentParser {
 
       const extracted = this.collectSubmissionArtifact(
         def,
-        slideContexts,
+        submissionIndex,
         primary.getType(),
         documentId
       );
@@ -328,48 +328,131 @@ class SlidesParser extends DocumentParser {
   }
 
   /**
-   * Collect the submission artifact content for a definition from slide elements.
+   * Build submission contexts with pre-parsed description metadata for each element.
+   * @param {GoogleAppsScript.Slides.Slide[]} slides - Slides in the student submission.
+   * @return {Array<{pageId: string, elements: Array<{pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>}>>} Indexed slide contexts.
+   * @remarks `getDescription()` is a relatively expensive Apps Script call, so we parse once per element.
+   * This avoids repeated remote calls inside per-task loops and reduces runtime pressure on large decks.
+   */
+  buildSubmissionSlideContexts(slides) {
+    return slides.map((slide) => ({
+      pageId: this.getPageId(slide),
+      elements: slide.getPageElements().map((pageElement) => ({
+        pageElement,
+        descriptionInfo: this.parseDescriptionTag(pageElement.getDescription()),
+      })),
+    }));
+  }
+
+  /**
+   * Build lookup index for submission elements by candidate description text.
+   * @param {Array<{pageId: string, elements: Array<{pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>}>>} slideContexts - Parsed slide contexts.
+   * @return {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} Candidate lookup index.
+   * @remarks The index keeps lookups keyed to content identifiers (`taskTitle`/stable ID), not page IDs.
+   * This preserves cross-document tolerance and avoids the brittle composite key behaviour.
+   */
+  buildSubmissionIndex(slideContexts) {
+    const index = new Map();
+
+    slideContexts.forEach((slideContext) => {
+      slideContext.elements.forEach(({ pageElement, descriptionInfo }) => {
+        if (!descriptionInfo.rawText) return;
+
+        const candidates = [...new Set([descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean))];
+        candidates.forEach((candidate) => {
+          const bucket = index.get(candidate) || [];
+          bucket.push({
+            pageId: slideContext.pageId,
+            pageElement,
+            descriptionInfo,
+          });
+          index.set(candidate, bucket);
+        });
+      });
+    });
+
+    return index;
+  }
+
+  /**
+   * Collect the submission artifact content for a definition from indexed slide elements.
    * @param {TaskDefinition} definition - Definition being matched.
-   * @param {Array<{pageId: string, pageElements: GoogleAppsScript.Slides.PageElement[]}>} slideContexts - Slides and elements to search.
+   * @param {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} submissionIndex - Candidate lookup index.
    * @param {string} typeNeeded - Artifact type expected (TEXT/TABLE/IMAGE).
    * @param {string} documentId - Student document ID for submission artifact.
    * @return {{taskId: string, pageId: string, content: *, metadata?: Object, documentId: string}|null} - Artifact payload or null.
+   * @remarks Candidate matching is driven by stable task ID and task title for resilience across copied slides.
+   * Page ID is retained only as metadata on the matched artifact, not as part of the lookup key.
    */
-  collectSubmissionArtifact(definition, slideContexts, typeNeeded, documentId) {
-    for (const slideContext of slideContexts) {
-      for (const pageElement of slideContext.pageElements) {
-        const desc = pageElement.getDescription();
-        const descriptionInfo = this.parseDescriptionTag(desc);
-        if (!descriptionInfo.rawText) continue;
-        if (!this.descriptionMatchesDefinition(descriptionInfo, definition)) continue;
+  collectSubmissionArtifact(definition, submissionIndex, typeNeeded, documentId) {
+    const matchCandidates = [...new Set([definition.getId(), definition.taskTitle].filter(Boolean))];
 
-        if (typeNeeded === 'IMAGE') {
-          if (descriptionInfo.tag && descriptionInfo.tag !== '~' && descriptionInfo.tag !== '|') {
-            continue;
-          }
-          return {
-            taskId: definition.getId(),
-            pageId: slideContext.pageId,
-            documentId,
-            content: null,
-            metadata: {
-              sourceUrl: this.generateSlideImageUrl(documentId, slideContext.pageId),
-            },
-          };
-        }
+    if (typeNeeded === 'IMAGE') {
+      return this.collectTaggedImageSubmissionArtifact(
+        definition,
+        submissionIndex,
+        matchCandidates,
+        documentId
+      );
+    }
 
+    for (const candidate of matchCandidates) {
+      const matches = submissionIndex.get(candidate) || [];
+      for (const { pageId: matchedPageId, pageElement, descriptionInfo } of matches) {
         if (descriptionInfo.tag && descriptionInfo.tag !== '#') continue;
+
         const contentDetails = this.extractDefinitionContent(pageElement);
         if (!contentDetails || contentDetails.artifactType !== typeNeeded) continue;
+
         return {
           taskId: definition.getId(),
-          pageId: slideContext.pageId,
+          pageId: matchedPageId,
           documentId,
           content: contentDetails.elementContent,
         };
       }
     }
+
     return null;
+  }
+
+  /**
+   * Find the first tagged image submission match for a definition.
+   * @param {TaskDefinition} definition - Definition being matched.
+   * @param {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} submissionIndex - Candidate lookup index.
+   * @param {string[]} matchCandidates - Candidate tokens for lookup.
+   * @param {string} documentId - Student document ID for submission artifact.
+   * @return {{taskId: string, pageId: string, documentId: string, content: null, metadata: {sourceUrl: string}}|null} Image artifact payload or null when unmatched.
+   */
+  collectTaggedImageSubmissionArtifact(definition, submissionIndex, matchCandidates, documentId) {
+    for (const candidate of matchCandidates) {
+      const matches = submissionIndex.get(candidate) || [];
+      for (const { pageId, descriptionInfo } of matches) {
+        if (descriptionInfo.tag !== '~' && descriptionInfo.tag !== '|') continue;
+        return this.buildImageSubmissionArtifact(definition, documentId, pageId);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Build submission artifact payload for image tasks.
+   * @param {TaskDefinition} definition - Definition being matched.
+   * @param {string} documentId - Student document ID for submission artifact.
+   * @param {string} pageId - Slide page ID containing the matched element.
+   * @return {{taskId: string, pageId: string, documentId: string, content: null, metadata: {sourceUrl: string}}} Image artifact payload.
+   */
+  buildImageSubmissionArtifact(definition, documentId, pageId) {
+    return {
+      taskId: definition.getId(),
+      pageId,
+      documentId,
+      content: null,
+      metadata: {
+        sourceUrl: this.generateSlideImageUrl(documentId, pageId),
+      },
+    };
   }
 
   /**

--- a/tests/parsers/documentIdPropagation.test.js
+++ b/tests/parsers/documentIdPropagation.test.js
@@ -309,7 +309,7 @@ describe('Document ID propagation across parsers', () => {
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 
-    it('extracts image submissions when the student description is the stable task id and preserves the matched pageId in sourceUrl', () => {
+    it('does not extract image submissions when the student description is only the stable task id without an image tag', () => {
       const refSlide = createSlide('ref-image-page', [createTaggedElement('~ Task 1')]);
       let studentTaskId = null;
 
@@ -335,16 +335,14 @@ describe('Document ID propagation across parsers', () => {
       expect(artifacts).toEqual([
         {
           taskId: defs[0].getId(),
-          pageId: 'student-image-page-by-id',
-          documentId: studentDocId,
+          pageId: null,
           content: null,
-          metadata: {
-            sourceUrl:
-              'https://docs.google.com/presentation/d/student-doc-789/export/png?id=student-doc-789&pageid=student-image-page-by-id',
-          },
+          documentId: studentDocId,
         },
       ]);
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        `Failed to extract artifact for task "${defs[0].taskTitle}" in document ${studentDocId}.`
+      );
     });
 
     it('does not create task definitions from untagged plain titles in reference or template slides', () => {

--- a/tests/parsers/documentIdPropagation.test.js
+++ b/tests/parsers/documentIdPropagation.test.js
@@ -20,6 +20,21 @@ describe('Document ID propagation across parsers', () => {
       })),
     });
 
+    const createTableElement = (description, rows) => ({
+      getDescription: vi.fn(() => description),
+      getPageElementType: vi.fn(() => globalThis.SlidesApp.PageElementType.TABLE),
+      asTable: vi.fn(() => ({
+        getNumRows: vi.fn(() => rows.length),
+        getNumColumns: vi.fn(() => rows[0]?.length || 0),
+        getCell: vi.fn((rowIndex, columnIndex) => ({
+          getMergeState: vi.fn(() => globalThis.SlidesApp.CellMergeState.NORMAL),
+          getText: vi.fn(() => ({
+            asString: vi.fn(() => rows[rowIndex]?.[columnIndex] ?? ''),
+          })),
+        })),
+      })),
+    });
+
     const createTaggedElement = (description) => ({
       getDescription: vi.fn(() => description),
     });
@@ -61,6 +76,11 @@ describe('Document ID propagation across parsers', () => {
           SHAPE: 'SHAPE',
           TABLE: 'TABLE',
           IMAGE: 'IMAGE',
+        },
+        CellMergeState: {
+          NORMAL: 'NORMAL',
+          HEAD: 'HEAD',
+          MERGED: 'MERGED',
         },
       };
     });
@@ -188,6 +208,74 @@ describe('Document ID propagation across parsers', () => {
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 
+    it('extracts a table submission when the student description is the bare task title', () => {
+      const refSlide = createSlide('ref-table-page', [
+        createTableElement('# Task Table', [['Reference value']]),
+      ]);
+      const studentSlide = createSlide('student-table-page', [
+        createTableElement('Task Table', [['Student value']]),
+      ]);
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === studentDocId) return { getSlides: () => [studentSlide] };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId);
+      const artifacts = parser.extractSubmissionArtifacts(studentDocId, defs);
+
+      expect(defs).toHaveLength(1);
+      expect(defs[0].getPrimaryReference().getType()).toBe('TABLE');
+      expect(artifacts).toEqual([
+        {
+          taskId: defs[0].getId(),
+          pageId: 'student-table-page',
+          documentId: studentDocId,
+          content: [['Student value']],
+        },
+      ]);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('extracts a table submission when the student description is the stable task id', () => {
+      const refSlide = createSlide('ref-table-page', [
+        createTableElement('# Task Table', [['Reference value']]),
+      ]);
+      let studentTaskId = null;
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === studentDocId) {
+          return {
+            getSlides: () => [
+              createSlide('student-table-page', [
+                createTableElement(studentTaskId, [['Student value by id']]),
+              ]),
+            ],
+          };
+        }
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId);
+      studentTaskId = defs[0].getId();
+      const artifacts = parser.extractSubmissionArtifacts(studentDocId, defs);
+
+      expect(defs).toHaveLength(1);
+      expect(artifacts).toEqual([
+        {
+          taskId: defs[0].getId(),
+          pageId: 'student-table-page',
+          documentId: studentDocId,
+          content: [['Student value by id']],
+        },
+      ]);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
     it('extracts image submissions by task title across the deck and uses the matched student slide pageId in sourceUrl', () => {
       const refSlide = createSlide('ref-image-page', [createTaggedElement('~ Task 1')]);
       const studentSlides = [
@@ -219,6 +307,61 @@ describe('Document ID propagation across parsers', () => {
         },
       });
       expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('extracts image submissions when the student description is the stable task id and preserves the matched pageId in sourceUrl', () => {
+      const refSlide = createSlide('ref-image-page', [createTaggedElement('~ Task 1')]);
+      let studentTaskId = null;
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === studentDocId) {
+          return {
+            getSlides: () => [
+              createSlide('student-image-other', [createTaggedElement('Task 2')]),
+              createSlide('student-image-page-by-id', [createTaggedElement(studentTaskId)]),
+            ],
+          };
+        }
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId);
+      studentTaskId = defs[0].getId();
+      const artifacts = parser.extractSubmissionArtifacts(studentDocId, defs);
+
+      expect(defs).toHaveLength(1);
+      expect(artifacts).toEqual([
+        {
+          taskId: defs[0].getId(),
+          pageId: 'student-image-page-by-id',
+          documentId: studentDocId,
+          content: null,
+          metadata: {
+            sourceUrl:
+              'https://docs.google.com/presentation/d/student-doc-789/export/png?id=student-doc-789&pageid=student-image-page-by-id',
+          },
+        },
+      ]);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('does not create task definitions from untagged plain titles in reference or template slides', () => {
+      const refSlide = createSlide('ref-plain-page', [createShapeElement('Task 1', 'Ref text')]);
+      const tplSlide = createSlide('tpl-plain-page', [createShapeElement('Task 1', 'Tpl text')]);
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === tplDocId) return { getSlides: () => [tplSlide] };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId, tplDocId);
+
+      expect(defs).toHaveLength(0);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/parsers/documentIdPropagation.test.js
+++ b/tests/parsers/documentIdPropagation.test.js
@@ -8,6 +8,7 @@ describe('Document ID propagation across parsers', () => {
     const studentDocId = 'student-doc-789';
     let SlidesParser;
     let originalIsValidUrl;
+    let mockLogger;
 
     const createShapeElement = (description, text) => ({
       getDescription: vi.fn(() => description),
@@ -19,23 +20,25 @@ describe('Document ID propagation across parsers', () => {
       })),
     });
 
+    const createTaggedElement = (description) => ({
+      getDescription: vi.fn(() => description),
+    });
+
     const createSlide = (pageId, elements) => ({
       getObjectId: vi.fn(() => pageId),
       getPageElements: vi.fn(() => elements),
     });
 
     beforeAll(async () => {
-      const documentParserModule = await import(
-        '../../src/AdminSheet/DocumentParsers/DocumentParser.js'
-      );
+      const documentParserModule =
+        await import('../../src/AdminSheet/DocumentParsers/DocumentParser.js');
       const taskDefinitionModule = await import('../../src/AdminSheet/Models/TaskDefinition.js');
 
       globalThis.DocumentParser = documentParserModule.DocumentParser;
       globalThis.TaskDefinition = taskDefinitionModule.TaskDefinition;
 
-      const slidesParserModule = await import(
-        '../../src/AdminSheet/DocumentParsers/SlidesParser.js'
-      );
+      const slidesParserModule =
+        await import('../../src/AdminSheet/DocumentParsers/SlidesParser.js');
       SlidesParser = slidesParserModule.SlidesParser;
     });
 
@@ -43,8 +46,14 @@ describe('Document ID propagation across parsers', () => {
       originalIsValidUrl = globalThis.Utils.isValidUrl;
       globalThis.Utils.isValidUrl = vi.fn(() => true);
 
+      mockLogger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
       globalThis.ABLogger = {
-        getInstance: vi.fn().mockReturnValue({ warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+        getInstance: vi.fn().mockReturnValue(mockLogger),
       };
 
       globalThis.SlidesApp = {
@@ -82,6 +91,54 @@ describe('Document ID propagation across parsers', () => {
       expect(tplArtifact.documentId).toBe(tplDocId);
     });
 
+    it('merges reference and template slides with the same title into one task definition across different pageIds', () => {
+      const referencePageId = 'ref-page-1';
+      const templatePageId = 'tpl-page-2';
+      const refSlide = createSlide(referencePageId, [createShapeElement('# Task 1', 'Ref text')]);
+      const tplSlide = createSlide(templatePageId, [createShapeElement('# Task 1', 'Tpl text')]);
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === tplDocId) return { getSlides: () => [tplSlide] };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId, tplDocId);
+
+      expect(defs).toHaveLength(1);
+
+      const [def] = defs;
+      expect(def.getId()).toBe(parser.buildSlidesTaskId('Task 1'));
+      expect(def.pageId).toBe(referencePageId);
+      expect(def.artifacts.reference).toHaveLength(1);
+      expect(def.artifacts.template).toHaveLength(1);
+      expect(def.getPrimaryReference().content).toBe('Ref text');
+      expect(def.getPrimaryTemplate().content).toBe('Tpl text');
+    });
+
+    it('attaches notes by task title even when the note is on a different slide pageId', () => {
+      const definitionPageId = 'ref-page-1';
+      const notesPageId = 'ref-page-2';
+      const refSlides = [
+        createSlide(definitionPageId, [createShapeElement('# Task 1', 'Ref text')]),
+        createSlide(notesPageId, [createShapeElement('^ Task 1', 'Notes for Task 1')]),
+      ];
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => refSlides };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId);
+
+      expect(defs).toHaveLength(1);
+      expect(defs[0].pageId).toBe(definitionPageId);
+      expect(defs[0].taskNotes).toBe('Notes for Task 1');
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
     it('sets documentId on submission artifacts', () => {
       const refSlide = createSlide('page-1', [createShapeElement('# Task 1', 'Ref text')]);
       const tplSlide = createSlide('page-1', [createShapeElement('# Task 1', 'Tpl text')]);
@@ -101,6 +158,68 @@ describe('Document ID propagation across parsers', () => {
       expect(artifacts).toHaveLength(1);
       expect(artifacts[0].documentId).toBe(studentDocId);
     });
+
+    it('extracts a student submission by title from a different slide pageId and preserves student identifiers', () => {
+      const refSlide = createSlide('ref-page-1', [createShapeElement('# Task 1', 'Ref text')]);
+      const tplSlide = createSlide('tpl-page-2', [createShapeElement('# Task 1', 'Tpl text')]);
+      const studentSlides = [
+        createSlide('student-page-other', [createShapeElement('# Task 2', 'Other task')]),
+        createSlide('student-page-99', [createShapeElement('# Task 1', 'Student text')]),
+      ];
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === tplDocId) return { getSlides: () => [tplSlide] };
+        if (id === studentDocId) return { getSlides: () => studentSlides };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId, tplDocId);
+      const artifacts = parser.extractSubmissionArtifacts(studentDocId, defs);
+
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]).toMatchObject({
+        taskId: defs[0].getId(),
+        pageId: 'student-page-99',
+        documentId: studentDocId,
+        content: 'Student text',
+      });
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it('extracts image submissions by task title across the deck and uses the matched student slide pageId in sourceUrl', () => {
+      const refSlide = createSlide('ref-image-page', [createTaggedElement('~ Task 1')]);
+      const studentSlides = [
+        createSlide('student-image-other', [createTaggedElement('| Task 2')]),
+        createSlide('student-image-page', [createTaggedElement('| Task 1')]),
+      ];
+
+      globalThis.SlidesApp.openById = vi.fn((id) => {
+        if (id === refDocId) return { getSlides: () => [refSlide] };
+        if (id === studentDocId) return { getSlides: () => studentSlides };
+        return { getSlides: () => [] };
+      });
+
+      const parser = new SlidesParser();
+      const defs = parser.extractTaskDefinitions(refDocId);
+      const artifacts = parser.extractSubmissionArtifacts(studentDocId, defs);
+
+      expect(defs).toHaveLength(1);
+      expect(defs[0].getPrimaryReference().getType()).toBe('IMAGE');
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]).toMatchObject({
+        taskId: defs[0].getId(),
+        pageId: 'student-image-page',
+        documentId: studentDocId,
+        content: null,
+        metadata: {
+          sourceUrl:
+            'https://docs.google.com/presentation/d/student-doc-789/export/png?id=student-doc-789&pageid=student-image-page',
+        },
+      });
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('SheetsParser', () => {
@@ -110,17 +229,15 @@ describe('Document ID propagation across parsers', () => {
     let SheetsParser;
 
     beforeAll(async () => {
-      const documentParserModule = await import(
-        '../../src/AdminSheet/DocumentParsers/DocumentParser.js'
-      );
+      const documentParserModule =
+        await import('../../src/AdminSheet/DocumentParsers/DocumentParser.js');
       const taskDefinitionModule = await import('../../src/AdminSheet/Models/TaskDefinition.js');
 
       globalThis.DocumentParser = documentParserModule.DocumentParser;
       globalThis.TaskDefinition = taskDefinitionModule.TaskDefinition;
 
-      const sheetsParserModule = await import(
-        '../../src/AdminSheet/DocumentParsers/SheetsParser.js'
-      );
+      const sheetsParserModule =
+        await import('../../src/AdminSheet/DocumentParsers/SheetsParser.js');
       SheetsParser = sheetsParserModule.SheetsParser;
     });
 

--- a/tests/parsers/parserMatchingAndDocumentIds.test.js
+++ b/tests/parsers/parserMatchingAndDocumentIds.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 
-// Slides parser docId propagation
-describe('Document ID propagation across parsers', () => {
+// Slides and Sheets parser matching/document ID coverage
+describe('Parser matching and document ID propagation', () => {
   describe('SlidesParser', () => {
     const refDocId = 'ref-doc-123';
     const tplDocId = 'tpl-doc-456';


### PR DESCRIPTION
This PR updates SlidesParser to keep pageId as metadata while removing pageId-based task matching for student submissions. It makes student extraction tolerant of copied element descriptions by matching either the task title or stable task ID, and adds focused regression tests for table and image submissions. The change ensures reference/template parsing remains strict and prevents failed student matches from silently persisting null content.