### PR TITLE
SlidesParser: use stable title keys and indexed submission parsing; require explicit image tags

### DIFF
--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -385,7 +385,7 @@ class SlidesParser extends DocumentParser {
    * Page ID is retained only as metadata on the matched artifact, not as part of the lookup key.
    */
   collectSubmissionArtifact(definition, submissionIndex, typeNeeded, documentId) {
-    const matchCandidates = [definition.getId(), definition.taskTitle].filter(Boolean);
+    const matchCandidates = [...new Set([definition.getId(), definition.taskTitle].filter(Boolean))];
 
     if (typeNeeded === 'IMAGE') {
       return this.collectTaggedImageSubmissionArtifact(

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -194,6 +194,8 @@ class SlidesParser extends DocumentParser {
    * Build the title-based key used for Slides task matching.
    * @param {string} taskTitle - Title extracted from the slide tag.
    * @return {string} Deterministic key for Slides definitions.
+   * @remarks We key by `taskTitle` because the previous `taskTitle + pageId` composite key was brittle.
+   * It failed when student copies or template/reference decks had non-aligned page IDs across documents.
    */
   buildDefinitionKey(taskTitle) {
     return taskTitle;
@@ -298,10 +300,8 @@ class SlidesParser extends DocumentParser {
     const presentation = SlidesApp.openById(documentId);
     const slides = presentation.getSlides();
     const artifacts = [];
-    const slideContexts = slides.map((slide) => ({
-      pageId: this.getPageId(slide),
-      pageElements: slide.getPageElements(),
-    }));
+    const slideContexts = this.buildSubmissionSlideContexts(slides);
+    const submissionIndex = this.buildSubmissionIndex(slideContexts);
 
     taskDefs.forEach((def) => {
       const primary = def.getPrimaryReference() || def.getPrimaryTemplate();
@@ -309,7 +309,7 @@ class SlidesParser extends DocumentParser {
 
       const extracted = this.collectSubmissionArtifact(
         def,
-        slideContexts,
+        submissionIndex,
         primary.getType(),
         documentId
       );
@@ -328,48 +328,131 @@ class SlidesParser extends DocumentParser {
   }
 
   /**
-   * Collect the submission artifact content for a definition from slide elements.
+   * Build submission contexts with pre-parsed description metadata for each element.
+   * @param {GoogleAppsScript.Slides.Slide[]} slides - Slides in the student submission.
+   * @return {Array<{pageId: string, elements: Array<{pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>}>>} Indexed slide contexts.
+   * @remarks `getDescription()` is a relatively expensive Apps Script call, so we parse once per element.
+   * This avoids repeated remote calls inside per-task loops and reduces runtime pressure on large decks.
+   */
+  buildSubmissionSlideContexts(slides) {
+    return slides.map((slide) => ({
+      pageId: this.getPageId(slide),
+      elements: slide.getPageElements().map((pageElement) => ({
+        pageElement,
+        descriptionInfo: this.parseDescriptionTag(pageElement.getDescription()),
+      })),
+    }));
+  }
+
+  /**
+   * Build lookup index for submission elements by candidate description text.
+   * @param {Array<{pageId: string, elements: Array<{pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>}>>} slideContexts - Parsed slide contexts.
+   * @return {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} Candidate lookup index.
+   * @remarks The index keeps lookups keyed to content identifiers (`taskTitle`/stable ID), not page IDs.
+   * This preserves cross-document tolerance and avoids the brittle composite key behaviour.
+   */
+  buildSubmissionIndex(slideContexts) {
+    const index = new Map();
+
+    slideContexts.forEach((slideContext) => {
+      slideContext.elements.forEach(({ pageElement, descriptionInfo }) => {
+        if (!descriptionInfo.rawText) return;
+
+        const candidates = [descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean);
+        candidates.forEach((candidate) => {
+          const bucket = index.get(candidate) || [];
+          bucket.push({
+            pageId: slideContext.pageId,
+            pageElement,
+            descriptionInfo,
+          });
+          index.set(candidate, bucket);
+        });
+      });
+    });
+
+    return index;
+  }
+
+  /**
+   * Collect the submission artifact content for a definition from indexed slide elements.
    * @param {TaskDefinition} definition - Definition being matched.
-   * @param {Array<{pageId: string, pageElements: GoogleAppsScript.Slides.PageElement[]}>} slideContexts - Slides and elements to search.
+   * @param {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} submissionIndex - Candidate lookup index.
    * @param {string} typeNeeded - Artifact type expected (TEXT/TABLE/IMAGE).
    * @param {string} documentId - Student document ID for submission artifact.
    * @return {{taskId: string, pageId: string, content: *, metadata?: Object, documentId: string}|null} - Artifact payload or null.
+   * @remarks Candidate matching is driven by stable task ID and task title for resilience across copied slides.
+   * Page ID is retained only as metadata on the matched artifact, not as part of the lookup key.
    */
-  collectSubmissionArtifact(definition, slideContexts, typeNeeded, documentId) {
-    for (const slideContext of slideContexts) {
-      for (const pageElement of slideContext.pageElements) {
-        const desc = pageElement.getDescription();
-        const descriptionInfo = this.parseDescriptionTag(desc);
-        if (!descriptionInfo.rawText) continue;
-        if (!this.descriptionMatchesDefinition(descriptionInfo, definition)) continue;
+  collectSubmissionArtifact(definition, submissionIndex, typeNeeded, documentId) {
+    const matchCandidates = [definition.getId(), definition.taskTitle].filter(Boolean);
 
-        if (typeNeeded === 'IMAGE') {
-          if (descriptionInfo.tag && descriptionInfo.tag !== '~' && descriptionInfo.tag !== '|') {
-            continue;
-          }
-          return {
-            taskId: definition.getId(),
-            pageId: slideContext.pageId,
-            documentId,
-            content: null,
-            metadata: {
-              sourceUrl: this.generateSlideImageUrl(documentId, slideContext.pageId),
-            },
-          };
-        }
+    if (typeNeeded === 'IMAGE') {
+      return this.collectTaggedImageSubmissionArtifact(
+        definition,
+        submissionIndex,
+        matchCandidates,
+        documentId
+      );
+    }
 
+    for (const candidate of matchCandidates) {
+      const matches = submissionIndex.get(candidate) || [];
+      for (const { pageId: matchedPageId, pageElement, descriptionInfo } of matches) {
         if (descriptionInfo.tag && descriptionInfo.tag !== '#') continue;
+
         const contentDetails = this.extractDefinitionContent(pageElement);
         if (!contentDetails || contentDetails.artifactType !== typeNeeded) continue;
+
         return {
           taskId: definition.getId(),
-          pageId: slideContext.pageId,
+          pageId: matchedPageId,
           documentId,
           content: contentDetails.elementContent,
         };
       }
     }
+
     return null;
+  }
+
+  /**
+   * Find the first tagged image submission match for a definition.
+   * @param {TaskDefinition} definition - Definition being matched.
+   * @param {Map<string, Array<{pageId: string, pageElement: GoogleAppsScript.Slides.PageElement, descriptionInfo: {rawText: string, tag: string|null, tagText: string}}>>} submissionIndex - Candidate lookup index.
+   * @param {string[]} matchCandidates - Candidate tokens for lookup.
+   * @param {string} documentId - Student document ID for submission artifact.
+   * @return {{taskId: string, pageId: string, documentId: string, content: null, metadata: {sourceUrl: string}}|null} Image artifact payload or null when unmatched.
+   */
+  collectTaggedImageSubmissionArtifact(definition, submissionIndex, matchCandidates, documentId) {
+    for (const candidate of matchCandidates) {
+      const matches = submissionIndex.get(candidate) || [];
+      for (const { pageId, descriptionInfo } of matches) {
+        if (descriptionInfo.tag !== '~' && descriptionInfo.tag !== '|') continue;
+        return this.buildImageSubmissionArtifact(definition, documentId, pageId);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Build submission artifact payload for image tasks.
+   * @param {TaskDefinition} definition - Definition being matched.
+   * @param {string} documentId - Student document ID for submission artifact.
+   * @param {string} pageId - Slide page ID containing the matched element.
+   * @return {{taskId: string, pageId: string, documentId: string, content: null, metadata: {sourceUrl: string}}} Image artifact payload.
+   */
+  buildImageSubmissionArtifact(definition, documentId, pageId) {
+    return {
+      taskId: definition.getId(),
+      pageId,
+      documentId,
+      content: null,
+      metadata: {
+        sourceUrl: this.generateSlideImageUrl(documentId, pageId),
+      },
+    };
   }
 
   /**

--- a/src/AdminSheet/DocumentParsers/SlidesParser.js
+++ b/src/AdminSheet/DocumentParsers/SlidesParser.js
@@ -358,7 +358,7 @@ class SlidesParser extends DocumentParser {
       slideContext.elements.forEach(({ pageElement, descriptionInfo }) => {
         if (!descriptionInfo.rawText) return;
 
-        const candidates = [descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean);
+        const candidates = [...new Set([descriptionInfo.rawText, descriptionInfo.tagText].filter(Boolean))];
         candidates.forEach((candidate) => {
           const bucket = index.get(candidate) || [];
           bucket.push({

--- a/tests/parsers/documentIdPropagation.test.js
+++ b/tests/parsers/documentIdPropagation.test.js
@@ -309,7 +309,7 @@ describe('Document ID propagation across parsers', () => {
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
 
-    it('extracts image submissions when the student description is the stable task id and preserves the matched pageId in sourceUrl', () => {
+    it('does not extract image submissions when the student description is only the stable task id without an image tag', () => {
       const refSlide = createSlide('ref-image-page', [createTaggedElement('~ Task 1')]);
       let studentTaskId = null;
 
@@ -335,16 +335,14 @@ describe('Document ID propagation across parsers', () => {
       expect(artifacts).toEqual([
         {
           taskId: defs[0].getId(),
-          pageId: 'student-image-page-by-id',
-          documentId: studentDocId,
+          pageId: null,
           content: null,
-          metadata: {
-            sourceUrl:
-              'https://docs.google.com/presentation/d/student-doc-789/export/png?id=student-doc-789&pageid=student-image-page-by-id',
-          },
+          documentId: studentDocId,
         },
       ]);
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        `Failed to extract artifact for task "${defs[0].taskTitle}" in document ${studentDocId}.`
+      );
     });
 
     it('does not create task definitions from untagged plain titles in reference or template slides', () => {


### PR DESCRIPTION
### Motivation

- Avoid brittle composite keys tied to slide page IDs so task matching survives copied or templated decks. 
- Reduce Apps Script RPC calls and runtime overhead by parsing element descriptions once per slide element instead of repeatedly during per-task matching. 
- Prevent accidental image extraction when a submission only contains the stable task id without an explicit image tag. 

### Description

- Use a title-only definition key via `buildDefinitionKey(taskTitle)` and generate stable slide task IDs with `buildSlidesTaskId(taskTitle)` using a hash. 
- Prebuild per-slide `slideContexts` with parsed description metadata via `buildSubmissionSlideContexts(slides)` and create a lookup `submissionIndex` via `buildSubmissionIndex(slideContexts)` to speed matching. 
- Replace inline description parsing in `collectSubmissionArtifact` with indexed lookups and split image handling into `collectTaggedImageSubmissionArtifact` and `buildImageSubmissionArtifact` so images are only matched when the student element has an explicit image tag (`~` or `|`). 
- Preserve matched `pageId` as metadata on artifacts while avoiding pageId-driven lookup keys. 

### Testing

- Ran the parser unit tests including `tests/parsers/documentIdPropagation.test.js`, which was updated to reflect the new image-tag requirement and now verifies that a student element containing only the stable task id does not produce an image artifact; the test suite passed. 
- Executed the full parser test suite locally and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de12270aa08329b8e39ca7caa78d69)