### PR TITLE
fix: hide assignment dropdown on assessment success (issue #260)

### DIFF
--- a/.opencode/plugins/no-eslint-silence.ts
+++ b/.opencode/plugins/no-eslint-silence.ts
@@ -1,0 +1,45 @@
+import type { Plugin } from '@opencode-ai/plugin';
+
+const SILENCE_PATTERNS = [
+  /eslint-disable(?:-next-line|-line)?/i,
+  /@ts-ignore/i,
+  /@ts-nocheck/i,
+  /@ts-expect-error/i,
+  /noqa/i,
+  /type:\s*ignore/i,
+];
+
+function hasSilencingRule(text: string): string | null {
+  for (const pattern of SILENCE_PATTERNS) {
+    if (pattern.test(text)) return pattern.source;
+  }
+  return null;
+}
+
+export default (async () => {
+  return {
+    'tool.execute.before': async (input, output) => {
+      if (input.tool === 'edit') {
+        const match = hasSilencingRule(output.args.newString);
+        if (match) {
+          throw new Error(
+            `Blocked edit: new text contains a lint/ts silencing rule (${match}). ` +
+              `Fix the underlying issue instead of suppressing the warning. ` +
+              `If you truly believe there is no good way around the eslint rule, stop and hand back to the user for permission before proceeding.`
+          );
+        }
+      }
+
+      if (input.tool === 'write') {
+        const match = hasSilencingRule(output.args.content);
+        if (match) {
+          throw new Error(
+            `Blocked write: content contains a lint/ts silencing rule (${match}). ` +
+              `Fix the underlying issue instead of suppressing the warning. ` +
+              `If you truly believe there is no good way around the eslint rule, stop and hand back to the user for permission before proceeding.`
+          );
+        }
+      }
+    },
+  };
+}) satisfies Plugin;

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
@@ -1448,3 +1448,74 @@ describe('No-match resolution — linking state and link flow', () => {
     expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: Issue #260 – dropdown should not appear after successful assessment
+// ---------------------------------------------------------------------------
+
+describe('Issue #260 regression — dropdown hidden on success', () => {
+  it('wizard create success: assignment dropdown is not visible after successful trigger', async () => {
+    const { dialog } = await setupWizardTest({
+      startRunResult: null,
+      startRunType: 'resolve',
+    });
+
+    await clickCreateNewDefinition(dialog);
+    const properties = await getWizardProperties();
+    properties.onCreateSuccess('new-def-key');
+
+    // Wait for success state
+    const alert = await within(dialog).findByRole('alert');
+    expect(alert).toHaveTextContent(/assessment started for/i);
+
+    // Dropdown should NOT be visible
+    expect(within(dialog).queryByRole('combobox')).toBeNull();
+    // "Select assignment" label should NOT be visible
+    expect(within(dialog).queryByText('Select assignment')).toBeNull();
+  });
+
+  it('matched flow success: assignment dropdown is not visible after successful trigger', async () => {
+    const matchedDefinition = createDefinitionPartial();
+    const { dialog } = renderWithCache({
+      classPartials: [
+        createFixtureClassPartial({ classId: MOCK_CLASS_ID, yearGroupKey: 'year-10' }),
+      ],
+      definitionPartials: [matchedDefinition],
+      findMatchResult: { kind: 'matched', definition: matchedDefinition },
+      startRunResult: null,
+      startRunType: 'resolve',
+    });
+
+    await selectAssignment(dialog);
+    clickStartAssessment(dialog);
+
+    // Wait for success state
+    const alert = await within(dialog).findByRole('alert');
+    expect(alert).toHaveTextContent(/assessment started for/i);
+
+    // Dropdown should NOT be visible
+    expect(within(dialog).queryByRole('combobox')).toBeNull();
+    // "Select assignment" label should NOT be visible
+    expect(within(dialog).queryByText('Select assignment')).toBeNull();
+  });
+
+  it('link flow success: assignment dropdown is not visible after successful trigger', async () => {
+    const { dialog } = renderWithNoMatchCache({
+      upsertResult: DEFAULT_UPSERT_RESULT,
+      upsertType: 'resolve',
+      startRunResult: null,
+      startRunType: 'resolve',
+    });
+
+    await performLinkFlow(dialog);
+
+    // Wait for success state
+    const alert = await within(dialog).findByRole('alert');
+    expect(alert).toHaveTextContent(/assessment started for/i);
+
+    // Dropdown should NOT be visible
+    expect(within(dialog).queryByRole('combobox')).toBeNull();
+    // "Select assignment" label should NOT be visible
+    expect(within(dialog).queryByText('Select assignment')).toBeNull();
+  });
+});

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
@@ -596,15 +596,23 @@ export function AssessTaskModal(properties: Readonly<AssessTaskModalProperties>)
    * @returns {React.ReactNode} The rendered assignments selection content.
    */
   function renderAssignmentsContent(): React.ReactNode {
-    const selectOptions = assignments.map((assignment) => ({
-      value: assignment.assignmentId,
-      label: assignment.title,
-    }));
-
     const assessmentAlert =
       assessmentState === 'success' || (assessmentState === 'error' && assessmentError) ? (
         <Alert type={assessmentAlertType} showIcon title={assessmentError} style={{ marginBottom: 16 }} />
       ) : null;
+
+    if (assessmentState === 'success') {
+      return (
+        <Space vertical style={{ width: '100%' }}>
+          {assessmentAlert}
+        </Space>
+      );
+    }
+
+    const selectOptions = assignments.map((assignment) => ({
+      value: assignment.assignmentId,
+      label: assignment.title,
+    }));
 
     return (
       <Space vertical style={{ width: '100%' }}>
@@ -684,6 +692,8 @@ export function AssessTaskModal(properties: Readonly<AssessTaskModalProperties>)
       );
     }
 
+    // On success, only show the Alert — no picker. Mirrors the renderAssignmentsContent()
+    // early-return for the matched/wizard success paths (see Issue #260).
     if (assessmentState === 'success') {
       return <Alert type="success" showIcon title={assessmentError} style={{ marginBottom: 16 }} />;
     }


### PR DESCRIPTION
Fix for issue #260: Success message from AssessTask modal shows dropdown where it shouldn't.

When an assessment task is successfully triggered via the Assess Task modal (particularly through the wizard create flow), the UI was showing BOTH the success message/close button AND the assignment dropdown, when it should ONLY show the success message/close button.

## Changes

### Bug Fix
- Modified `renderAssignmentsContent()` in `AssessTaskModal.tsx` to return only the success alert when `assessmentState === 'success'` (hiding the dropdown and "Select assignment" label)

### Regression Tests
- Added 3 regression tests in `AssessTaskModal.spec.tsx` covering:
  - Wizard create success flow
  - Matched definition success flow  
  - Link flow success

### Code Review Improvement
- Added comment in `renderLinkingBody()` referencing Issue #260 for consistency

## Verification
- All 58 AssessTaskModal tests pass
- All 1114 frontend tests pass
- Frontend lint: Clean
- TypeScript compilation: Clean

## Impact
This fix ensures that when an assessment task has been successfully triggered, only the success message and close button are shown, not the assignment dropdown.

Co-authored-by: openhands <openhands@all-hands.dev>
