### PR TITLE
Fix frontend test noise: eliminate act() warnings, No queryFn warnings, and key prop spread warnings

### DIFF
--- a/docs/developer/frontend/frontend-react-query-and-prefetch.md
+++ b/docs/developer/frontend/frontend-react-query-and-prefetch.md
@@ -191,3 +191,29 @@ interface AssignmentDefinitionPartial {
 
 Frontend cache persistence is intentionally disabled.
 Cached data remains in memory only for the current session because the app handles sensitive student-related data and should not persist shared query payloads in browser storage by default.
+
+### Disabled query pattern: use `skipToken`
+
+When a `useQuery` call is intentionally disabled (for example `enabled: false`) and the query
+should never execute, use `skipToken` from `@tanstack/react-query` as the `queryFn` value
+instead of providing a dummy async function that returns an empty value.
+
+```typescript
+import { skipToken, useQuery } from '@tanstack/react-query';
+
+// ✅ Correct — idiomatic, intent is clear, never executes
+const { data } = useQuery({
+  queryKey: queryKeys.assignmentDefinitionPartials(),
+  queryFn: skipToken,
+});
+
+// ❌ Wrong — dummy queryFn is unnecessary and misleading
+const { data } = useQuery({
+  queryKey: queryKeys.assignmentDefinitionPartials(),
+  queryFn: () => Promise.resolve([]),
+  enabled: false,
+});
+```
+
+`skipToken` makes the disabled intent explicit and eliminates the need for `enabled: false`
+(the query is implicitly skipped when `queryFn` is `skipToken`).

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -362,6 +362,27 @@ afterEach(() => {
 
 **Rationale:** `vi.resetAllMocks()` ensures complete isolation between tests by resetting both the call history and any mock implementations. This prevents test pollution where one test's mock setup affects subsequent tests.
 
+### userEvent.setup() Isolation
+
+Create a fresh `userEvent` instance per test by initialising in `beforeEach` rather than at
+the module level. The `userEvent` instance maintains internal state (keyboard sequences,
+timer references) that can leak between tests if shared across the module.
+
+```typescript
+// ✅ Correct — fresh instance per test
+let user: ReturnType<typeof userEvent.setup>;
+
+beforeEach(() => {
+  user = userEvent.setup();
+});
+
+// ❌ Wrong — module-level instance leaks state between tests
+const user = userEvent.setup();
+```
+
+This rule applies to spec files (**`*.spec.tsx`**). Shared test helper functions that call
+`userEvent.setup()` locally within each function are not affected.
+
 ## React Query Testing Patterns
 
 When testing components that use `@tanstack/react-query`'s `useMutation`, be aware that the mutation function receives **additional arguments** beyond the request data. The `mutateAsync` method passes mutation context as a second argument:

--- a/docs/developer/frontend/frontend-testing.md
+++ b/docs/developer/frontend/frontend-testing.md
@@ -786,6 +786,47 @@ indicate bugs in application code, but they clutter output and obscure real fail
    `userEvent.selectOptions(...)` instead, which handle the full gesture and wait for
    motion to settle.
 
+7. **Wrap direct mock callback calls in `act()`.**
+   When tests invoke callbacks obtained from mock components (for example
+   `properties.onClose()` or `properties.onCreateSuccess(...)` on a wizard mock),
+   those calls trigger synchronous React state transitions inside component state
+   reducers that aren't wrapped by any user interaction. Enclose them in
+   `await act(async () => { ... })`:
+
+   ```typescript
+   await act(async () => {
+     properties.onClose();
+   });
+
+   await act(async () => {
+     properties.onCreateSuccess('new-def-key');
+   });
+   ```
+
+   If the callback triggers async work (e.g. a `useMutation`), the `act()` wrapper
+   prevents the associated state updates from escaping the current test step.
+
+8. **Wrap `rerender()` calls in `act()` when they change component props that
+   trigger async initialisation.**
+   `rerender(...)` from Testing Library is synchronous and does not wrap the
+   component's re-mount / effect re-run inside `act()`. If the re-render changes
+   props that trigger data fetching, state transitions, or animation mounts, wrap
+   the call in `await act(async () => { ... })`:
+
+   ```typescript
+   await act(async () => {
+     rerender(
+       <QueryClientProvider client={queryClient}>
+         <AssessTaskModal {...defaultProperties({ open: false })} />
+       </QueryClientProvider>
+     );
+   });
+   ```
+
+   This applies specifically to prop changes that cause the component to mount
+   fresh effects (for example toggling `open` on a modal, or changing a `classId`
+   that triggers a `useEffect` fetch).
+
 ## Notes
 
 - Frontend unit/component tests run in the frontend package (`src/frontend`) through root scripts.

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssessTaskModal } from './AssessTaskModal';
@@ -93,6 +94,8 @@ vi.mock('../../assignmentWizard/AssignmentDefinitionWizardModal', () => ({
   }),
 }));
 
+const user = userEvent.setup();
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -171,12 +174,10 @@ describe('Ready state (selection made)', () => {
     // Wait for the Select to appear
     await within(dialog).findByRole('combobox');
 
-    // Open the Select dropdown
-    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
-
-    // Select the assignment option by its label
+    // Open the Select dropdown and select the assignment option
+    await user.click(within(dialog).getByRole('combobox'));
     const option = await screen.findByText('Essay');
-    fireEvent.click(option);
+    await user.click(option);
 
     // After selection, Start Assessment should be enabled
     await waitFor(() => {
@@ -235,7 +236,7 @@ describe('Error state', () => {
 describe('Cancel and close', () => {
   it('calls onClose when Cancel button is clicked', async () => {
     const mockedGetAssignments = vi.mocked(getGoogleClassroomAssignments);
-    mockedGetAssignments.mockResolvedValue(MOCK_ASSIGNMENTS);
+    mockedGetAssignments.mockImplementation(() => Promise.resolve(MOCK_ASSIGNMENTS));
     const onClose = vi.fn();
 
     renderWithFrontendProviders(<AssessTaskModal {...defaultProperties({ onClose })} />);
@@ -243,7 +244,7 @@ describe('Cancel and close', () => {
     const dialog = screen.getByRole('dialog', { name: MODAL_TITLE });
     await within(dialog).findByRole('combobox'); // wait for ready state
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -254,7 +255,7 @@ describe('Cancel and close', () => {
   // system in JSDOM, we use native dispatchEvent to ensure the handlers fire.
   it('calls onClose when modal backdrop is clicked', async () => {
     const mockedGetAssignments = vi.mocked(getGoogleClassroomAssignments);
-    mockedGetAssignments.mockResolvedValue(MOCK_ASSIGNMENTS);
+    mockedGetAssignments.mockImplementation(() => Promise.resolve(MOCK_ASSIGNMENTS));
     const onClose = vi.fn();
 
     renderWithFrontendProviders(<AssessTaskModal {...defaultProperties({ onClose })} />);
@@ -298,7 +299,7 @@ describe('Fetch on open', () => {
 describe('Reopen resets state', () => {
   it('triggers fresh fetch with new classId when modal reopens for a different class', async () => {
     const mockedGetAssignments = vi.mocked(getGoogleClassroomAssignments);
-    mockedGetAssignments.mockResolvedValue(MOCK_ASSIGNMENTS);
+    mockedGetAssignments.mockImplementation(() => Promise.resolve(MOCK_ASSIGNMENTS));
 
     const queryClient = createAppQueryClient();
     const { rerender } = render(
@@ -312,19 +313,23 @@ describe('Reopen resets state', () => {
     expect(mockedGetAssignments).toHaveBeenCalledTimes(1);
 
     // Close the modal
-    rerender(
-      <QueryClientProvider client={queryClient}>
-        <AssessTaskModal {...defaultProperties({ open: false })} />
-      </QueryClientProvider>
-    );
+    await act(async () => {
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <AssessTaskModal {...defaultProperties({ open: false })} />
+        </QueryClientProvider>
+      );
+    });
 
     // Reopen with a different classId
     const newClassId = 'class-456';
-    rerender(
-      <QueryClientProvider client={queryClient}>
-        <AssessTaskModal {...defaultProperties({ open: true, classId: newClassId })} />
-      </QueryClientProvider>
-    );
+    await act(async () => {
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <AssessTaskModal {...defaultProperties({ open: true, classId: newClassId })} />
+        </QueryClientProvider>
+      );
+    });
 
     // Should trigger a fresh fetch with the new classId
     const expectedFetchCountAfterReopen = 2;
@@ -422,7 +427,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     expect(await within(dialog).findByRole('alert')).toBeInTheDocument();
   });
@@ -437,7 +442,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const alert = await within(dialog).findByRole('alert');
     expect(alert).toHaveTextContent('Class not found in cached data');
@@ -453,7 +458,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     expect(await within(dialog).findByRole('alert')).toBeInTheDocument();
   });
@@ -474,7 +479,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const alert = await within(dialog).findByRole('alert');
     expect(alert).toBeInTheDocument();
@@ -489,7 +494,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const alert = await within(dialog).findByRole('alert');
     expect(alert).toHaveTextContent('Cannot determine year group for this class');
@@ -512,7 +517,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const alert = await within(dialog).findByRole('alert');
     expect(alert).toBeInTheDocument();
@@ -535,7 +540,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Success alert should appear
     const alert = await within(dialog).findByRole('alert');
@@ -569,7 +574,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     await expect(within(dialog).findByRole('alert')).resolves.toBeInTheDocument();
   });
@@ -598,7 +603,7 @@ describe('Assessment run interaction', () => {
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // FUTURE BEHAVIOUR: Should transition to wizard stale-recovery
     // Currently this FAILS because handleApiError only shows a warning alert
@@ -631,7 +636,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Error alert should appear (existing behaviour)
     await expect(within(dialog).findByRole('alert')).resolves.toBeInTheDocument();
@@ -661,7 +666,7 @@ describe('Assessment run interaction', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // During API call, button should show loading state.
     // Ant Design appends "loading" to the accessible name when loading.
@@ -703,7 +708,7 @@ async function setupReopenInPlace() {
 
   const dialog = screen.getByRole('dialog', { name: MODAL_TITLE });
   await selectAssignment(dialog);
-  clickStartAssessment(dialog);
+  await clickStartAssessment(dialog);
 
   // Close the modal
   rerender(
@@ -731,7 +736,7 @@ describe('No-match resolution — choice state', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // An info Alert should explain the no-match situation
     const alert = await within(dialog).findByRole('alert');
@@ -750,7 +755,7 @@ describe('No-match resolution — choice state', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Assignment Select should NOT be visible
     expect(within(dialog).queryByRole('combobox')).toBeNull();
@@ -764,10 +769,10 @@ describe('No-match resolution — choice state', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Click "Create New Definition" — this should transition to 'creating'
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Create New Definition' }));
+    await clickCreateNewDefinition(dialog);
 
     // Once in creating state, the choice buttons should be gone
     await waitFor(() => {
@@ -785,7 +790,7 @@ describe('No-match resolution — choice state', () => {
     const { dialog } = renderWithNoMatchCache({ definitionPartials: [] });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const linkButton = within(dialog).getByRole('button', { name: 'Link to Existing Definition' });
     expect(linkButton).toBeDisabled();
@@ -829,7 +834,7 @@ describe('No-match resolution — choice state', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // The choice prompt must NOT appear — confirming noMatchResolution starts as 'idle'.
     // If noMatchResolution were 'choice', the choice prompt would render instead of
@@ -855,13 +860,13 @@ describe('Success state close', () => {
     const matchedDefinition = createDefinitionPartial();
     const onClose = vi.fn();
 
-    vi.mocked(getGoogleClassroomAssignments).mockResolvedValue(MOCK_ASSIGNMENTS);
+    vi.mocked(getGoogleClassroomAssignments).mockImplementation(() => Promise.resolve(MOCK_ASSIGNMENTS));
 
     vi.mocked(findMatchingDefinition).mockReturnValue({
       kind: 'matched',
       definition: matchedDefinition,
     });
-    vi.mocked(startAssessmentRun).mockResolvedValue(null);
+    vi.mocked(startAssessmentRun).mockImplementation(() => Promise.resolve(null));
 
     const queryClient = createAppQueryClient();
     queryClient.setQueryData(queryKeys.classPartials(), [
@@ -875,14 +880,14 @@ describe('Success state close', () => {
 
     const dialog = screen.getByRole('dialog', { name: MODAL_TITLE });
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Wait for success state — find the Close button in the footer
     const footer = dialog.querySelector('.ant-modal-footer') as HTMLElement | null;
     expect(footer).not.toBeNull();
     const closeButton = await within(footer!).findByRole('button', { name: 'Close' });
 
-    fireEvent.click(closeButton);
+    await user.click(closeButton);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
@@ -915,7 +920,7 @@ describe('Footer buttons across states', () => {
     cleanup();
 
     // Test empty state — separate render
-    mockedGetAssignments.mockResolvedValue(MOCK_EMPTY_ASSIGNMENTS);
+    mockedGetAssignments.mockImplementation(() => Promise.resolve(MOCK_EMPTY_ASSIGNMENTS));
     renderWithFrontendProviders(<AssessTaskModal {...defaultProperties()} key="empty" />);
     dialog = await screen.findByRole('dialog', { name: MODAL_TITLE });
     await within(dialog).findByText('No assignments found for this class');
@@ -925,7 +930,7 @@ describe('Footer buttons across states', () => {
     cleanup();
 
     // Test ready state (no selection) — separate render
-    mockedGetAssignments.mockResolvedValue(MOCK_ASSIGNMENTS);
+    mockedGetAssignments.mockImplementation(() => Promise.resolve(MOCK_ASSIGNMENTS));
     renderWithFrontendProviders(<AssessTaskModal {...defaultProperties()} key="ready-no-sel" />);
     dialog = await screen.findByRole('dialog', { name: MODAL_TITLE });
     await within(dialog).findByRole('combobox');
@@ -933,9 +938,9 @@ describe('Footer buttons across states', () => {
     expect(within(dialog).getByRole('button', { name: 'Start Assessment' })).toBeInTheDocument();
 
     // Test ready state (selection made) — same render, just interact
-    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+    await user.click(within(dialog).getByRole('combobox'));
     const option = await screen.findByText('Essay');
-    fireEvent.click(option);
+    await user.click(option);
     await waitFor(() => {
       expect(within(dialog).getByRole('button', { name: 'Start Assessment' })).toBeEnabled();
     });
@@ -956,7 +961,7 @@ async function setupWizardTest(options: Partial<RenderWithCacheOptions> = {}) {
   const { dialog, queryClient } = renderWithNoMatchCache(options);
 
   await selectAssignment(dialog);
-  clickStartAssessment(dialog);
+  await clickStartAssessment(dialog);
 
   return { dialog, queryClient };
 }
@@ -1047,7 +1052,9 @@ describe('No-match resolution — creating state and wizard integration', () => 
 
     await clickCreateNewDefinition(dialog);
     const properties = await getWizardProperties();
-    properties.onCreateSuccess('new-def-key');
+    await act(async () => {
+      properties.onCreateSuccess('new-def-key');
+    });
 
     // startAssessmentRun should have been called with the new definition key
     await waitFor(() => {
@@ -1078,7 +1085,9 @@ describe('No-match resolution — creating state and wizard integration', () => 
 
     await clickCreateNewDefinition(dialog);
     const properties = await getWizardProperties();
-    properties.onCreateSuccess('new-def-key');
+    await act(async () => {
+      properties.onCreateSuccess('new-def-key');
+    });
 
     // Error alert should appear
     const alert = await within(dialog).findByRole('alert');
@@ -1093,7 +1102,9 @@ describe('No-match resolution — creating state and wizard integration', () => 
     const properties = await getWizardProperties();
 
     // Simulate wizard cancel (onClose fires without onCreateSuccess having been called)
-    properties.onClose();
+    await act(async () => {
+      properties.onClose();
+    });
 
     // Should return to choice state — choice buttons appear again
     await waitFor(() => {
@@ -1113,7 +1124,7 @@ describe('No-match resolution — creating state and wizard integration', () => 
     await clickCreateNewDefinition(dialog);
 
     // Now in creating state — click Cancel in the AssessTaskModal footer
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -1129,7 +1140,9 @@ describe('No-match resolution — creating state and wizard integration', () => 
 
     await clickCreateNewDefinition(dialog);
     const properties = await getWizardProperties();
-    properties.onCreateSuccess('new-def-key');
+    await act(async () => {
+      properties.onCreateSuccess('new-def-key');
+    });
 
     // During loading: the wizard mock should be unmounted
     expect(screen.queryByTestId('wizard-mock')).toBeNull();
@@ -1170,13 +1183,15 @@ describe('No-match resolution — creating state and wizard integration', () => 
 
     await clickCreateNewDefinition(dialog);
     const properties = await getWizardProperties();
-    properties.onCreateSuccess('test-key');
+    await act(async () => {
+      properties.onCreateSuccess('test-key');
+    });
 
     // During auto-assessment loading, Cancel should be in the footer
     expect(within(dialog).getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
 
     // Click Cancel — the outer modal's Cancel during creating+loading calls onClose
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
@@ -1190,7 +1205,7 @@ describe('No-match resolution — linking state and link flow', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const linkButton = await within(dialog).findByRole('button', { name: 'Link to Existing Definition' });
     expect(linkButton).toBeEnabled();
@@ -1202,7 +1217,7 @@ describe('No-match resolution — linking state and link flow', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     const linkButton = await within(dialog).findByRole('button', { name: 'Link to Existing Definition' });
     expect(linkButton).toBeDisabled();
@@ -1220,7 +1235,7 @@ describe('No-match resolution — linking state and link flow', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     await clickLinkToExisting(dialog);
 
@@ -1239,11 +1254,11 @@ describe('No-match resolution — linking state and link flow', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
     await clickLinkToExisting(dialog);
 
     // Click Cancel in the picker footer
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     // Choice buttons should reappear
     await waitFor(() => {
@@ -1260,7 +1275,7 @@ describe('No-match resolution — linking state and link flow', () => {
     const { dialog } = renderWithNoMatchCache();
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
     await clickLinkToExisting(dialog);
 
     expectLinkButtonDisabled(dialog);
@@ -1471,7 +1486,7 @@ describe('No-match resolution — linking state and link flow', () => {
   it('state reset on modal reopen', async () => {
     const onClose = vi.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(upsertAssignmentDefinition).mockResolvedValue(DEFAULT_UPSERT_RESULT as any);
+    vi.mocked(upsertAssignmentDefinition).mockImplementation(() => Promise.resolve(DEFAULT_UPSERT_RESULT as any));
 
     const { queryClient } = renderWithNoMatchCache({ onClose });
     cleanup();
@@ -1484,7 +1499,7 @@ describe('No-match resolution — linking state and link flow', () => {
 
     const dialog = screen.getByRole('dialog', { name: MODAL_TITLE });
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // Try to reach linking state
     await clickLinkToExisting(dialog);
@@ -1516,11 +1531,11 @@ describe('No-match resolution — linking state and link flow', () => {
     const { dialog } = renderWithNoMatchCache({ onClose });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
     await clickLinkToExisting(dialog);
 
     // Click Cancel in the picker footer — should return to choice, not close modal
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     // noMatchResolution returns to 'choice' — choice buttons reappear
     await waitFor(() => {
@@ -1545,7 +1560,7 @@ describe('No-match resolution — linking state and link flow', () => {
     await performLinkFlow(dialog);
 
     // During loading, click Cancel — should close the modal
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -1574,7 +1589,7 @@ describe('No-match resolution — linking state and link flow', () => {
     });
 
     await selectAssignment(dialog);
-    clickStartAssessment(dialog);
+    await clickStartAssessment(dialog);
 
     // The choice prompt should be visible and the Link button disabled because
     // linkableDefinitions is empty (no definitions for year-10 in the cache)
@@ -1614,34 +1629,34 @@ describe('Inline event handler stability', () => {
     // Handler 1: Assignment Select onChange — selects an assignment
     // Side effect: selectedAssignmentId is set, enabling Start Assessment
     await within(dialog).findByRole('combobox');
-    fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+    await user.click(within(dialog).getByRole('combobox'));
     const essayOption = await screen.findByText('Essay');
-    fireEvent.click(essayOption);
+    await user.click(essayOption);
     await waitFor(() => {
       expect(within(dialog).getByRole('button', { name: 'Start Assessment' })).toBeEnabled();
     });
 
     // Handler 2: Start Assessment button onClick — triggers the no-match flow
     // Side effect: assessment state transitions to no-match and choice prompt appears
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Start Assessment' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Start Assessment' }));
     await within(dialog).findByRole('button', { name: 'Link to Existing Definition' });
 
     // Navigate to the linking state
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Link to Existing Definition' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Link to Existing Definition' }));
 
     // Handler 3: Linkable definition Select onSelect — selects a definition row
     // Side effect: selectedDefinitionForLink is set, enabling the Link button
     const linkableSelect = within(dialog).getByRole('combobox');
-    fireEvent.mouseDown(linkableSelect);
+    await user.click(linkableSelect);
     const definitionOption = await screen.findByText('Essay');
-    fireEvent.click(definitionOption);
+    await user.click(definitionOption);
     await waitFor(() => {
       expect(within(dialog).getByRole('button', { name: 'Link' })).toBeEnabled();
     });
 
     // Handler 4: Link button onClick — triggers the link-upsert and assessment run
     // Side effect: upsertAssignmentDefinition and startAssessmentRun are called
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Link' }));
+    await user.click(within(dialog).getByRole('button', { name: 'Link' }));
     await waitFor(() => {
       expect(vi.mocked(upsertAssignmentDefinition)).toHaveBeenCalledTimes(1);
     });

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx
@@ -94,9 +94,10 @@ vi.mock('../../assignmentWizard/AssignmentDefinitionWizardModal', () => ({
   }),
 }));
 
-const user = userEvent.setup();
+let user: ReturnType<typeof userEvent.setup>;
 
 beforeEach(() => {
+  user = userEvent.setup();
   vi.clearAllMocks();
 });
 

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
@@ -166,6 +166,7 @@ export function AssessTaskModal(properties: Readonly<AssessTaskModalProperties>)
    */
   const { data: definitionPartialsFromCache } = useQuery<AssignmentDefinitionPartial[]>({
     queryKey: queryKeys.assignmentDefinitionPartials(),
+    queryFn: () => Promise.resolve([] as AssignmentDefinitionPartial[]),
     enabled: false,
   });
 

--- a/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
+++ b/src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Empty, Modal, Select, Space, Spin, Tooltip, Typography } from 'antd';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { getGoogleClassroomAssignments } from '../../../services/googleClassrooms/googleClassroomAssignmentsService';
@@ -166,8 +166,7 @@ export function AssessTaskModal(properties: Readonly<AssessTaskModalProperties>)
    */
   const { data: definitionPartialsFromCache } = useQuery<AssignmentDefinitionPartial[]>({
     queryKey: queryKeys.assignmentDefinitionPartials(),
-    queryFn: () => Promise.resolve([] as AssignmentDefinitionPartial[]),
-    enabled: false,
+    queryFn: skipToken,
   });
 
   const linkableDefinitions = useMemo<LinkableDefinition[]>(() => {

--- a/src/frontend/src/features/classes/ClassesManagementPanel.bulkMetadataFailure.spec.tsx
+++ b/src/frontend/src/features/classes/ClassesManagementPanel.bulkMetadataFailure.spec.tsx
@@ -259,7 +259,7 @@ const selectedMetadataYearGroups = yearGroupOptions.filter(
   ({ key }) => key === 'year-7' || key === 'year-8',
 );
 
-const user = userEvent.setup();
+let user: ReturnType<typeof userEvent.setup>;
 
 /**
  * Renders the panel with a mocked classes-management state and query client.
@@ -356,6 +356,10 @@ async function expectAllFailureState(
 }
 
 describe('ClassesManagementPanel bulk metadata failure handling', () => {
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });

--- a/src/frontend/src/features/classes/ClassesManagementPanel.bulkMetadataFailure.spec.tsx
+++ b/src/frontend/src/features/classes/ClassesManagementPanel.bulkMetadataFailure.spec.tsx
@@ -9,7 +9,8 @@
 
 import * as React from 'react';
 import type { ReactElement } from 'react';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { queryKeys } from '../../query/queryKeys';
 import { renderWithFrontendProviders } from '../../test/renderWithFrontendProviders';
@@ -258,6 +259,8 @@ const selectedMetadataYearGroups = yearGroupOptions.filter(
   ({ key }) => key === 'year-7' || key === 'year-8',
 );
 
+const user = userEvent.setup();
+
 /**
  * Renders the panel with a mocked classes-management state and query client.
  *
@@ -301,9 +304,9 @@ async function loadPanel() {
  * @returns {Promise<void>} Completion signal.
  */
 async function submitSelectModal(buttonName: 'Set cohort' | 'Set year group') {
-  fireEvent.click(screen.getByRole('button', { name: buttonName }));
+  await user.click(screen.getByRole('button', { name: buttonName }));
   const dialog = await screen.findByRole('dialog', { name: buttonName });
-  fireEvent.click(within(dialog).getByRole('button', { name: 'OK' }));
+  await user.click(within(dialog).getByRole('button', { name: 'OK' }));
 }
 
 /**
@@ -312,9 +315,9 @@ async function submitSelectModal(buttonName: 'Set cohort' | 'Set year group') {
  * @returns {Promise<void>} Completion signal.
  */
 async function submitCourseLengthModal() {
-  fireEvent.click(screen.getByRole('button', { name: 'Set course length' }));
+  await user.click(screen.getByRole('button', { name: 'Set course length' }));
   const dialog = await screen.findByRole('dialog', { name: 'Set course length' });
-  fireEvent.click(within(dialog).getByRole('button', { name: 'OK' }));
+  await user.click(within(dialog).getByRole('button', { name: 'OK' }));
 }
 
 /**
@@ -359,10 +362,10 @@ describe('ClassesManagementPanel bulk metadata failure handling', () => {
 
   it('shows a panel-level alert and closes the modal after a full cohort failure', async () => {
     const { ClassesManagementPanel } = await loadPanel();
-    bulkSetCohortMock.mockResolvedValue([
+    bulkSetCohortMock.mockImplementation(() => Promise.resolve([
       { status: 'rejected', row: rows[0], error: new Error('Update failed.') },
       { status: 'rejected', row: rows[1], error: new Error('Update failed.') },
-    ]);
+    ]));
     const { onSelectedRowKeysChange, invalidateQueriesSpy } = renderPanel(<ClassesManagementPanel />);
 
     await submitSelectModal('Set cohort');
@@ -379,10 +382,10 @@ describe('ClassesManagementPanel bulk metadata failure handling', () => {
 
   it('shows a panel-level alert and closes the modal after a full year-group failure', async () => {
     const { ClassesManagementPanel } = await loadPanel();
-    bulkSetYearGroupMock.mockResolvedValue([
+    bulkSetYearGroupMock.mockImplementation(() => Promise.resolve([
       { status: 'rejected', row: rows[0], error: new Error('Update failed.') },
       { status: 'rejected', row: rows[1], error: new Error('Update failed.') },
-    ]);
+    ]));
     const { onSelectedRowKeysChange, invalidateQueriesSpy } = renderPanel(<ClassesManagementPanel />);
 
     await submitSelectModal('Set year group');
@@ -399,10 +402,10 @@ describe('ClassesManagementPanel bulk metadata failure handling', () => {
 
   it('closes the metadata modal and promotes warning feedback to panel scope on partial failure', async () => {
     const { ClassesManagementPanel } = await loadPanel();
-    bulkSetCohortMock.mockResolvedValue([
+    bulkSetCohortMock.mockImplementation(() => Promise.resolve([
       { status: 'fulfilled', row: rows[0], data: { ok: true } },
       { status: 'rejected', row: rows[1], error: new Error('Update failed.') },
-    ]);
+    ]));
     const { onSelectedRowKeysChange, invalidateQueriesSpy } = renderPanel(<ClassesManagementPanel />);
 
     await submitSelectModal('Set cohort');
@@ -423,10 +426,10 @@ describe('ClassesManagementPanel bulk metadata failure handling', () => {
 
   it('shows a panel-level alert and closes the modal after a full course-length failure', async () => {
     const { ClassesManagementPanel } = await loadPanel();
-    bulkSetCourseLengthMock.mockResolvedValue([
+    bulkSetCourseLengthMock.mockImplementation(() => Promise.resolve([
       { status: 'rejected', row: rows[0], error: new Error('Update failed.') },
       { status: 'rejected', row: rows[1], error: new Error('Update failed.') },
-    ]);
+    ]));
     const { onSelectedRowKeysChange, invalidateQueriesSpy } = renderPanel(<ClassesManagementPanel />);
 
     await submitCourseLengthModal();

--- a/src/frontend/src/test/classes/AssessTaskModal.link-flow-helpers.tsx
+++ b/src/frontend/src/test/classes/AssessTaskModal.link-flow-helpers.tsx
@@ -55,7 +55,7 @@ export function renderWithNoMatchCache(
  */
 export async function performLinkFlow(dialog: HTMLElement): Promise<void> {
   await selectAssignment(dialog);
-  clickStartAssessment(dialog);
+  await clickStartAssessment(dialog);
   await clickLinkToExisting(dialog);
   await pickLinkableDefinition(dialog);
   await clickLink(dialog);

--- a/src/frontend/src/test/classes/AssessTaskModal.test-utilities.tsx
+++ b/src/frontend/src/test/classes/AssessTaskModal.test-utilities.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { AssessTaskModal } from '../../features/classes/AssessTaskModal/AssessTaskModal';
 import { getGoogleClassroomAssignments } from '../../services/googleClassrooms/googleClassroomAssignmentsService';
@@ -214,10 +215,11 @@ export function renderWithCache(options: RenderWithCacheOptions = {}): {
  * @returns {Promise<void>} Resolves when the button is enabled.
  */
 export async function selectAssignment(dialog: HTMLElement): Promise<void> {
+  const user = userEvent.setup();
   await within(dialog).findByRole('combobox');
-  fireEvent.mouseDown(within(dialog).getByRole('combobox'));
+  await user.click(within(dialog).getByRole('combobox'));
   const option = await screen.findByText('Essay');
-  fireEvent.click(option);
+  await user.click(option);
   await waitFor(() => {
     expect(within(dialog).getByRole('button', { name: 'Start Assessment' })).toBeEnabled();
   });
@@ -227,9 +229,11 @@ export async function selectAssignment(dialog: HTMLElement): Promise<void> {
  * Clicks the Start Assessment button.
  *
  * @param {HTMLElement} dialog The modal dialog element.
+ * @returns {Promise<void>} Resolves when the click action completes.
  */
-export function clickStartAssessment(dialog: HTMLElement): void {
-  fireEvent.click(within(dialog).getByRole('button', { name: 'Start Assessment' }));
+export async function clickStartAssessment(dialog: HTMLElement): Promise<void> {
+  const user = userEvent.setup();
+  await user.click(within(dialog).getByRole('button', { name: 'Start Assessment' }));
 }
 
 /**
@@ -238,8 +242,9 @@ export function clickStartAssessment(dialog: HTMLElement): void {
  * @param {HTMLElement} dialog The modal dialog element.
  */
 export async function clickCreateNewDefinition(dialog: HTMLElement): Promise<void> {
-  await within(dialog).findByRole('button', { name: 'Create New Definition' });
-  fireEvent.click(within(dialog).getByRole('button', { name: 'Create New Definition' }));
+  const user = userEvent.setup();
+  const button = await within(dialog).findByRole('button', { name: 'Create New Definition' });
+  await user.click(button);
 }
 
 /**
@@ -293,8 +298,9 @@ export function expectCancelButtonPresent(dialog: HTMLElement): void {
  * @returns {Promise<void>} Resolves when the button has been clicked.
  */
 export async function clickLinkToExisting(dialog: HTMLElement): Promise<void> {
+  const user = userEvent.setup();
   const button = await within(dialog).findByRole('button', { name: 'Link to Existing Definition' });
-  fireEvent.click(button);
+  await user.click(button);
 }
 
 /**
@@ -312,8 +318,9 @@ export async function clickLinkToExisting(dialog: HTMLElement): Promise<void> {
  * @returns {Promise<void>} Resolves when the button has been clicked.
  */
 export async function clickLink(dialog: HTMLElement): Promise<void> {
+  const user = userEvent.setup();
   const button = await within(dialog).findByRole('button', { name: 'Link' });
-  fireEvent.click(button);
+  await user.click(button);
 }
 
 /**
@@ -336,6 +343,8 @@ export async function pickLinkableDefinition(
   dialog: HTMLElement,
   index: number = 0
 ): Promise<void> {
+  const user = userEvent.setup();
+
   // In the linking state the assignment Select is hidden, so only the
   // linkable-definition Select combobox is visible in the dialog.
   const comboboxes = within(dialog).getAllByRole('combobox');
@@ -345,7 +354,7 @@ export async function pickLinkableDefinition(
     );
   }
   const linkableCombobox = comboboxes[0];
-  fireEvent.mouseDown(linkableCombobox);
+  await user.click(linkableCombobox);
   const options = await screen.findAllByRole('option');
   if (index >= options.length || index < 0) {
     throw new Error(
@@ -358,7 +367,7 @@ export async function pickLinkableDefinition(
       `pickLinkableDefinition: option at index ${index} is undefined (found ${options.length} options)`
     );
   }
-  fireEvent.click(option);
+  await user.click(option);
 }
 
 /**

--- a/src/frontend/src/test/classes/modalTestHelpers.tsx
+++ b/src/frontend/src/test/classes/modalTestHelpers.tsx
@@ -204,13 +204,13 @@ export function CreateModalResetHarness<TProperties extends object>({ modalCompo
   const handleReopen = () => setOpen(true);
   const handleCancel = () => setOpen(false);
 
-  // Create a new element with updated props, preserving type safety
+  // Create a new element with updated props, preserving type safety.
+  // React forbids spreading `key` into JSX, so we pass `key` directly on the JSX element.
   const ModalComponent = modalComponent.type;
   const updatedProperties = {
     ...modalComponent.props,
     open: open as TProperties extends { open: infer TOpen } ? TOpen : boolean,
     onCancel: handleCancel as TProperties extends { onCancel: infer TOnCancel } ? TOnCancel : (() => void),
-    key: 'test-harness-modal',
   };
 
   return (
@@ -218,7 +218,7 @@ export function CreateModalResetHarness<TProperties extends object>({ modalCompo
       <button type="button" onClick={handleReopen} aria-label="Reopen modal">
         Reopen
       </button>
-      <ModalComponent {...updatedProperties} />
+      <ModalComponent key="test-harness-modal" {...updatedProperties} />
     </>
   );
 }

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -1,5 +1,11 @@
 import { vi } from 'vitest';
 
+// Set React 19 act environment flag to suppress "not configured to support act" warnings.
+// React Testing Library sets this dynamically during operations, but happy-dom can trigger
+// state updates between act() boundaries. Setting it globally suppresses the false-positive
+// variant of the act() warning that occurs between wrapped operations.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 // Import jest-dom extensions for vitest
 import '@testing-library/jest-dom/vitest';
 

--- a/src/frontend/src/test/setup.ts
+++ b/src/frontend/src/test/setup.ts
@@ -4,7 +4,11 @@ import { vi } from 'vitest';
 // React Testing Library sets this dynamically during operations, but happy-dom can trigger
 // state updates between act() boundaries. Setting it globally suppresses the false-positive
 // variant of the act() warning that occurs between wrapped operations.
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  value: true,
+  writable: true,
+});
 
 // Import jest-dom extensions for vitest
 import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary

Eliminates test noise across the frontend suite — 61 act() warnings → 2 (antd internal, expected), 306 No queryFn warnings → 0, 2 key prop spread warnings → 0. All 1194 tests still pass.

## Changes

| File | Change |
|---|---|
| `src/frontend/src/test/setup.ts` | Added `globalThis.IS_REACT_ACT_ENVIRONMENT = true` |
| `src/frontend/src/test/classes/modalTestHelpers.tsx` | Moved `key` from spread to JSX element |
| `src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.tsx` | Added `queryFn` to cache-only `useQuery` (React Query v5 requirement) |
| `src/frontend/src/test/classes/AssessTaskModal.test-utilities.tsx` | Replaced `fireEvent` with `userEvent` in all 6 helpers; made `clickStartAssessment` async |
| `src/frontend/src/test/classes/AssessTaskModal.link-flow-helpers.tsx` | Added `await` before `clickStartAssessment` |
| `src/frontend/src/features/classes/AssessTaskModal/AssessTaskModal.spec.tsx` | Converted ~27 `clickStartAssessment` calls to async; replaced ~12 inline `fireEvent.click` with `await user.click`; replaced ~4 `fireEvent.mouseDown+click` with `await user.click`; replaced ~8 `mockResolvedValue` with `mockImplementation(() => Promise.resolve(...))`; wrapped 5 wizard callback calls and 2 rerender blocks in `act()` |
| `src/frontend/src/features/classes/ClassesManagementPanel.bulkMetadataFailure.spec.tsx` | Replaced `fireEvent` with `userEvent`; replaced 4 `mockResolvedValue` with `mockImplementation` |

## Validation
- `npm run lint:frontend` — ✅ zero errors, zero warnings
- `npm run test:frontend` — ✅ 104 test files, 1194 tests, all passing
- Act warnings: 61 → **2** (both antd internal animation timers, expected/tolerated per testing docs)
- No queryFn warnings: 306 → **0**
- Key prop spread warnings: 2 → **0**